### PR TITLE
docs: Include 'Declarative data copy' phrase in README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@
 日本語 |
 <a href="https://deepwiki.com/TBSten/cream">DeepWiki</a>
 
-cream.kt は **クラスを跨いだ copy** をしやすくする KSP Plugin です。
+cream.kt は **宣言的データコピー（Declarative data copy）** を可能にし、**クラスを跨いだ copy** をしやすくする KSP Plugin です。
 
 あるオブジェクトをほぼ同じクラスの別インスタンスへコピーする Mapper を自動生成します。
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ English |
 <a href="https://github.com/TBSten/cream/blob/main/README.ja.md">日本語</a> |
 <a href="https://deepwiki.com/TBSten/cream">DeepWiki</a>
 
-cream.kt is a KSP Plugin that makes it easy to **copy across classes**.
+cream.kt is a KSP Plugin that enables **declarative data copy** and makes it easy to **copy across classes**.
 
 Automatically generates a Mapper that copies an object to another instance of approximately the same
 class.


### PR DESCRIPTION
## Summary

This PR includes the phrase 'Declarative data copy' in both README files as requested in issue #13.

## Changes

- **README.md**: Added 'declarative data copy' phrase to the introduction section
- **README.ja.md**: Added '宣言的データコピー（Declarative data copy）' phrase to the introduction section

## Resolves

- Closes #13

## Testing

- ✅ Verified that both README files contain the required phrase
- ✅ Confirmed the changes are correctly applied