### PR TITLE
Add English localization for Option Builder

### DIFF
--- a/optionBuilder/sharedUI/src/commonMain/composeResources/values-ja/strings.xml
+++ b/optionBuilder/sharedUI/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,23 @@
+<resources>
+    <string name="reset">リセット</string>
+    <string name="app_title">cream.kt オプションビルダー</string>
+    <string name="options_heading">1. オプションを設定</string>
+    <string name="options_copy_fun_name_prefix_heading">copyFunNamePrefix</string>
+    <string name="options_copy_fun_name_prefix_description">生成されるコピー関数の先頭につく文字列</string>
+    <string name="options_copy_fun_naming_strategy_heading">copyFunNamingStrategy</string>
+    <string name="options_copy_fun_naming_strategy_description">コピー関数の命名方法。</string>
+    <string name="options_escape_dot_heading">escapeDot</string>
+    <string name="options_escape_dot_description">
+        cream.copyFunNamingStrategy で命名された名前に含まれる . をエスケープする方法。
+    </string>
+    <string name="options_not_copy_to_object_heading">notCopyToObject</string>
+    <string name="options_not_copy_to_object_description">
+        true の場合 @CopyToChildren で object へのコピー関数を生成しないようにします。
+    </string>
+    <string name="class_names_heading">2. コピー元/コピー先のクラス名を設定する (option)</string>
+    <string name="class_names_source_sub_heading">コピー元のクラス</string>
+    <string name="class_names_target_sub_heading">コピー先のクラス</string>
+    <string name="result_heading">3. Copy 関数名を確認</string>
+    <string name="gradle_setting_heading">4. セットアップする</string>
+    <string name="show_all">全て表示</string>
+</resources>

--- a/optionBuilder/sharedUI/src/commonMain/composeResources/values-ja/strings.xml
+++ b/optionBuilder/sharedUI/src/commonMain/composeResources/values-ja/strings.xml
@@ -20,4 +20,5 @@
     <string name="result_heading">3. Copy 関数名を確認</string>
     <string name="gradle_setting_heading">4. セットアップする</string>
     <string name="show_all">全て表示</string>
+    <string name="gradle_comment_select_ksp_version">あなたのプロジェクトの Kotlin バージョンに合った KSP バージョンを選択してください</string>
 </resources>

--- a/optionBuilder/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/optionBuilder/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -1,24 +1,23 @@
 <resources>
-    <!--  TODO translate to en  -->
-    <string name="reset">リセット</string>
-    <string name="app_title">cream.kt オプションビルダー</string>
-    <string name="options_heading">1. オプションを設定</string>
+    <string name="reset">Reset</string>
+    <string name="app_title">cream.kt Option Builder</string>
+    <string name="options_heading">1. Configure Options</string>
     <string name="options_copy_fun_name_prefix_heading">copyFunNamePrefix</string>
-    <string name="options_copy_fun_name_prefix_description">生成されるコピー関数の先頭につく文字列</string>
+    <string name="options_copy_fun_name_prefix_description">Prefix for generated copy functions</string>
     <string name="options_copy_fun_naming_strategy_heading">copyFunNamingStrategy</string>
-    <string name="options_copy_fun_naming_strategy_description">コピー関数の命名方法。</string>
+    <string name="options_copy_fun_naming_strategy_description">Naming strategy for copy functions.</string>
     <string name="options_escape_dot_heading">escapeDot</string>
     <string name="options_escape_dot_description">
-        cream.copyFunNamingStrategy で命名された名前に含まれる . をエスケープする方法。
+        How to escape dots in names created by cream.copyFunNamingStrategy.
     </string>
     <string name="options_not_copy_to_object_heading">notCopyToObject</string>
     <string name="options_not_copy_to_object_description">
-        true の場合 @CopyToChildren で object へのコピー関数を生成しないようにします。
+        When true, prevents generation of copy functions to object with @CopyToChildren.
     </string>
-    <string name="class_names_heading">2. コピー元/コピー先のクラス名を設定する (option)</string>
-    <string name="class_names_source_sub_heading">コピー元のクラス</string>
-    <string name="class_names_target_sub_heading">コピー先のクラス</string>
-    <string name="result_heading">3. Copy 関数名を確認</string>
-    <string name="gradle_setting_heading">4. セットアップする</string>
-    <string name="show_all">全て表示</string>
+    <string name="class_names_heading">2. Set Source/Target Class Names (optional)</string>
+    <string name="class_names_source_sub_heading">Source Class</string>
+    <string name="class_names_target_sub_heading">Target Class</string>
+    <string name="result_heading">3. Check Copy Function Name</string>
+    <string name="gradle_setting_heading">4. Setup</string>
+    <string name="show_all">Show All</string>
 </resources>

--- a/optionBuilder/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/optionBuilder/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -20,4 +20,5 @@
     <string name="result_heading">3. Check Copy Function Name</string>
     <string name="gradle_setting_heading">4. Setup</string>
     <string name="show_all">Show All</string>
+    <string name="gradle_comment_select_ksp_version">Choose a KSP version that matches your project\'s Kotlin version</string>
 </resources>

--- a/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/ResultSection.kt
+++ b/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/ResultSection.kt
@@ -109,7 +109,7 @@ private fun CopyFunctionName(
     }
 }
 
-private fun gradleSettingCode(isFull: Boolean, options: CreamOptions): String {
+private fun gradleSettingCode(isFull: Boolean, options: CreamOptions, kspVersionComment: String): String {
     val kspVersion = BuildKonfig.kspVersion
     val creamVersion = BuildKonfig.creamVersion
 
@@ -117,8 +117,7 @@ private fun gradleSettingCode(isFull: Boolean, options: CreamOptions): String {
         """
         // build.gradle.kts
         plugins {
-            // あなたの プロジェクトの kotlin バージョンに合った 
-            // KSP バージョンを選択してください
+            // $kspVersionComment
             // https://github.com/google/ksp/releases
             id("com.google.devtools.ksp") version "$kspVersion"
         }
@@ -164,12 +163,13 @@ private fun GradleSetting(
             iconRes = Res.drawable.icon_code_block,
         )
 
-        val highlights = remember(isFull) {
+        val kspVersionComment = stringResource(Res.string.gradle_comment_select_ksp_version)
+        val highlights = remember(isFull, kspVersionComment) {
             mutableStateOf(
                 Highlights
                     .Builder(
                         language = SyntaxLanguage.KOTLIN,
-                        code = gradleSettingCode(isFull, options),
+                        code = gradleSettingCode(isFull, options, kspVersionComment),
                     )
                     .build()
             )


### PR DESCRIPTION
## Summary
- Add English translations for the Option Builder web application
- Implement proper localization structure with `values/` for English (default) and `values-ja/` for Japanese
- The app now automatically displays in the appropriate language based on system settings

## Changes
- Created `values-ja/strings.xml` with Japanese translations
- Updated `values/strings.xml` with English translations (default language)
- Both language files maintain the same string keys for proper localization

## Testing
- The Option Builder will display in English by default
- Japanese users will see Japanese text based on their system language settings
- All UI elements are properly localized

## Related
- Based on PR #31 (Option Builder feature)
- Addresses localization requirements for international users

🤖 Generated with [Claude Code](https://claude.com/claude-code)