### PR TITLE
Fix generic type to object

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Object.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Object.kt
@@ -21,9 +21,20 @@ internal fun BufferedWriter.appendCopyToObjectFunction(
             options,
         )
     appendCopyToObjectKDoc(source, targetObject, generateSourceAnnotation, funName.toString())
-    appendLine(
-        "${targetObject.visibilityStr} fun ${source.fullName}.$funName() = ${targetObject.fullName}",
-    )
+    append("${targetObject.visibilityStr} fun ")
+    append(source.fullName)
+
+    if (source.typeParameters.isNotEmpty()) {
+        append("<")
+        append(
+            source.typeParameters
+                .joinToString(", ") { "*" },
+        )
+        append(">")
+    }
+
+    append(".$funName() = ${targetObject.fullName}")
+    appendLine()
 }
 
 internal fun BufferedWriter.appendCombineToObjectFunction(
@@ -72,15 +83,19 @@ private fun BufferedWriter.appendCombineToObjectKDoc(
         val exampleLines =
             buildString {
                 appendLine(
-                    "val ${primarySource.underPackageName.replaceFirstChar {
-                        it.lowercase()
-                    }} = ${primarySource.simpleName.asString()}(...)",
+                    "val ${
+                        primarySource.underPackageName.replaceFirstChar {
+                            it.lowercase()
+                        }
+                    } = ${primarySource.simpleName.asString()}(...)",
                 )
                 sources.drop(1).forEach { otherSource ->
                     appendLine(
-                        "val ${otherSource.underPackageName.replaceFirstChar {
-                            it.lowercase()
-                        }} = ${otherSource.simpleName.asString()}(...)",
+                        "val ${
+                            otherSource.underPackageName.replaceFirstChar {
+                                it.lowercase()
+                            }
+                        } = ${otherSource.simpleName.asString()}(...)",
                     )
                 }
                 append("val target = ${primarySource.underPackageName.replaceFirstChar { it.lowercase() }}.$funName($otherSourceParams)")

--- a/test/src/commonMain/kotlin/me/tbsten/cream/test/generic/GenericClasses.kt
+++ b/test/src/commonMain/kotlin/me/tbsten/cream/test/generic/GenericClasses.kt
@@ -12,7 +12,7 @@ data class GenericSourceWithTwoTypeArg<
     @CopyFrom.Map("Bbb")
     @CopyTo.Map("Bbb")
     B,
->(
+    >(
     val a: A?,
     val b: List<B>,
     val d: Int,
@@ -25,7 +25,7 @@ data class GenericTargetWithThreeTypeArg<Aaa, Bbb, Ccc>(
     val d: Int,
 ) where Aaa : Comparable<String>, Aaa : CharSequence
 
-@CopyTo(GenericTargetWithTwoTypeArg::class)
+@CopyTo(GenericTargetWithTwoTypeArg::class, GenericTargetObject::class)
 @CopyFrom(GenericTargetWithTwoTypeArg::class)
 data class GenericSourceWithThreeTypeArg<
     @CopyFrom.Map("Aaa")
@@ -33,7 +33,7 @@ data class GenericSourceWithThreeTypeArg<
     @CopyFrom.Map("Bbb")
     B,
     C,
->(
+    >(
     val a: A?,
     val b: List<B>,
     val c: C,
@@ -43,3 +43,5 @@ data class GenericTargetWithTwoTypeArg<Aaa, Bbb>(
     val a: Aaa?,
     val b: List<Bbb>,
 ) where Aaa : Comparable<String>, Aaa : CharSequence
+
+data object GenericTargetObject

--- a/test/src/commonMain/kotlin/me/tbsten/cream/test/generic/GenericClasses.kt
+++ b/test/src/commonMain/kotlin/me/tbsten/cream/test/generic/GenericClasses.kt
@@ -12,7 +12,7 @@ data class GenericSourceWithTwoTypeArg<
     @CopyFrom.Map("Bbb")
     @CopyTo.Map("Bbb")
     B,
-    >(
+>(
     val a: A?,
     val b: List<B>,
     val d: Int,
@@ -33,7 +33,7 @@ data class GenericSourceWithThreeTypeArg<
     @CopyFrom.Map("Bbb")
     B,
     C,
-    >(
+>(
     val a: A?,
     val b: List<B>,
     val c: C,

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/generic/GenericClassTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/generic/GenericClassTest.kt
@@ -75,4 +75,20 @@ class GenericClassTest {
             assertEquals(actual, expected)
         }
     }
+
+    @Test
+    fun threeArgToObject() {
+        val source =
+            GenericSourceWithThreeTypeArg(
+                a = "test",
+                b = listOf("a", "b"),
+                c = "c",
+            )
+
+        mapOf(
+            source.copyToGenericTargetObject() to GenericTargetObject,
+        ).forEach { (actual, expected) ->
+            assertEquals(actual, expected)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add support for generating copy functions from generic classes to objects
- Fix generated object extension functions to correctly handle source type parameters using star projections (`<*, *>`)
- Improve string interpolation formatting in KDoc generation

## Background

When using `@CopyTo` to copy from a class with generic type parameters (e.g., `GenericSourceWithThreeTypeArg<A, B, C>`) to an `object`, the generated extension function did not include the receiver's type parameters, resulting in a compile error.

## Changes

- `Object.kt`: Add star projections (`<*, *>`) to the receiver type when the source class has type parameters
- `GenericClasses.kt`: Add `@CopyTo(GenericTargetObject::class)` to `GenericSourceWithThreeTypeArg` and define `GenericTargetObject` for testing
- `GenericClassTest.kt`: Add `threeArgToObject()` test to verify copying from a generic class to an object

## Test plan

- [x] `GenericClassTest.threeArgToObject()` verifies that copying from a generic class to an object works correctly
- [x] Existing generic class tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)