### PR TITLE
Add kctfork-based KSP compilation tests for cream-ksp

### DIFF
--- a/.claude/rules/ksp-test.md
+++ b/.claude/rules/ksp-test.md
@@ -31,23 +31,9 @@ paths:
 
 ### Snapshot file format
 
-golden ファイルは `*.md` (Markdown)。最小形は単一の fenced code block:
-
-````md
-```kt
-// snapshot 対象のテキスト
-```
-````
-
-`assertMatchesSnapshot(name, actual, lang)` の `lang` でフェンス言語を指定する
-(default `kt`)。コンパイラ出力など非 Kotlin テキストは `lang = "text"` を渡す。
-
-#### Facets (multi-section)
-
-`assertMatchesSnapshot` に block を渡すと、main 部分が `## [mainTitle]` 配下に置かれ、
-block 内で宣言した facet が `## <facet 名>` セクションとして追加される。
-SSoT (test code と snapshot で input を二重管理しない) を保つため、input source は test
-code 側で local val として抽出し、`compileWithCream(...)` と facet の両方に渡す:
+golden ファイルは `*.md` (Markdown)。すべての captured 値は **facet** として宣言する
+(「最初が main」のような特別扱いはない)。各 facet は宣言順に `## <facet 名>` セクション
+として書き出される:
 
 ```kt
 val source = """
@@ -56,23 +42,38 @@ val source = """
 """.trimIndent()
 val result = compileWithCream(source)
 
-assertMatchesSnapshot("name", result.generatedSourceText()) {
-    "Input" facetOf source                              // default lang = "kt"
-    facet("KSP options", optionsText, lang = "properties")
+assertMatchesSnapshot("MyTest.scenario") {
+    "Generated" facetOf result.generatedSourceText()            // default lang = "kt"
+    "Input" facetOf source                                      // default lang = "kt"
+    facet("Compiler messages", result.messages, lang = "text")  // 明示で別言語
 }
 ```
 
-infix `facetOf` は default `lang = "kt"`。違う言語を使う facet は `facet(name, content, lang)`
-を使う。facet は宣言順に書き出される。
+infix `facetOf` は default `lang = "kt"`。違う言語が必要な facet は
+`facet(name, content, lang)` を使う。block 内で最低 1 つの facet が必要。
 
-diagnostic 系では main が compiler output なので `mainTitle = "Compiler output"` を渡す。
-それ以外 (snapshot 系) は default の `"Generated"` のまま。
+#### SSoT を保つ
+
+test code と snapshot で input を二重管理しないために、input source は test code 側で
+`val source = """...""".trimIndent()` として抽出し、`compileWithCream(source)` と
+`"Input" facetOf source` の両方に同じ値を渡す。
+
+#### Facet 名の規約
+
+呼び出し側が自由に付けられる。主用途での慣習:
+
+- snapshot 系 (生成された Kotlin source を見る): `"Generated"` + `"Input"`
+- diagnostic 系 (コンパイラ出力を見る): `facet("Compiler output", ..., lang = "text")` + `"Input"`
+
+順序は test 著者が決める。慣習は「主要な観測値が先、コンテキストが後」 (= `Generated` →
+`Input` / `Compiler output` → `Input`)。
 
 #### Backtick collision
 
 snapshot 本文に backtick run (例: cream が出す KDoc の ` ```kt ... ``` ` 例) が含まれる
 場合、各セクションのフェンスは独立に「内部の最長 backtick run + 1」の長さで拡張される
-(最小 3)。比較は fenced block 全体 (フェンス含む) で行うので、フェンスを直接書き換えると壊れる。
+(最小 3)。比較は file 全体 (見出し + フェンス含む) で行うので、フェンスを直接書き換えると
+壊れる。
 
 ### `normalizedCompilerOutput()`
 

--- a/.claude/rules/ksp-test.md
+++ b/.claude/rules/ksp-test.md
@@ -1,0 +1,78 @@
+---
+paths:
+  - cream-ksp/src/test/**
+  - cream-ksp/src/test/resources/snapshots/**
+---
+
+# KSP Compilation Tests (kctfork)
+
+`cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/` には [kctfork](https://github.com/zacsweers/kotlin-compile-testing)
+(`dev.zacsweers.kctfork:core` / `:ksp`) を使った JVM 専用の end-to-end テストを置いている。
+マルチプラットフォームの `test/` モジュールでは表現しにくいシナリオを補完する。
+
+## レイアウト
+
+- `testing/` — テスト基盤
+  - `CreamCompilation.kt` — `compileWithCream(...)` ヘルパー。`KotlinCompilation` + `useKsp2()` を組み合わせ
+    cream のプロセッサを inline ソース文字列に対して走らせる
+  - `CreamCompilationResult.kt` — 結果ラッパー (`exitCode`, `messages`, `compilerOutput`, ジェネレートされた
+    ソースへのアクセサ)
+  - `CreamCompilationResultUtils.kt` — `generatedSourceText()` などのユーティリティ
+  - `SnapshotAssertion.kt` — golden 比較ヘルパー
+- `diagnostic/` — 不正な annotation 使用や不正な KSP option 値に対して、`InvalidCreamUsageException` /
+  `InvalidCreamOptionException` がコンパイル失敗としてメッセージに乗ることを assert する。
+  exit code を `assertNotEquals(OK, ...)` で確認したうえで、`normalizedCompilerOutput()` を
+  `*.output.md` の golden と突き合わせて error message 全文を固定化する
+- `options/` — `cream.copyFunNamePrefix` / `cream.copyFunNamingStrategy` / `cream.escapeDot`
+  / `cream.notCopyToObject` のあらゆる値を end-to-end で走らせ、生成された関数名を検証
+- `snapshot/` — 代表的な成功シナリオ (basic `@CopyTo`, sealed `@CopyToChildren`, generic `@CopyFrom`,
+  object-target `@CombineTo`) について、生成 Kotlin ソース全文を golden ファイルと比較。
+  Golden は `cream-ksp/src/test/resources/snapshots/` に格納
+
+### Snapshot file format
+
+golden ファイルは `*.md` (Markdown) で、中身は単一の fenced code block:
+
+````md
+```kt
+// snapshot 対象のテキスト
+```
+````
+
+`assertMatchesSnapshot(name, actual, lang)` の `lang` パラメータがフェンス言語を決める
+(default は `kt`)。生成 Kotlin source なら `kt` (default のまま)、コンパイラ出力など
+非 Kotlin テキストは `lang = "text"` を指定する。GitHub diff viewer で syntax highlight が
+効くのが主な狙い。
+
+snapshot 本文に backtick run (例: cream が出す KDoc の ` ```kt ... ``` ` 例) が含まれる
+場合は、外側フェンスは「内部の最長 backtick run + 1」の長さで自動的に拡張される。
+比較は fenced block 全体 (フェンス含む) で行うので、フェンスを直接書き換えると壊れる。
+
+### `normalizedCompilerOutput()`
+
+以下を置換/集約してから返す:
+
+- `java.io.tmpdir` → `<TMPDIR>`
+- `Kotlin-CompilationNNN` → `Kotlin-Compilation<N>`
+- 連続する `\tat ...` および `\t... NN more` (stack-trace フレーム) → 1 行の `\t<stack trace omitted>`
+
+stack frame は Gradle / JUnit / KSP / cream 自身の line 変更や `... NN more` の depth count
+で簡単にずれるため、diagnostic snapshot で固定化しているのは「error message 本文」だけ。
+特定 frame の存在を assert したいなら、snapshot とは別に `messages.contains(...)` を併用する。
+
+## 運用
+
+### スナップショット更新
+
+```bash
+./gradlew :cream-ksp:test -Dcream.snapshot.update=true
+```
+
+`-D` フラグは `cream-ksp/build.gradle.kts` の `tasks.named<Test>("test")` 設定で systemProperty として
+転送される。
+
+### 新しいテストを足すとき
+
+- 既存パターンに合うなら該当ディレクトリ (`diagnostic/` / `options/` / `snapshot/`) に追加
+- 新しいカテゴリが必要なら同じレベルにディレクトリを切る
+- 共有ヘルパーが必要になったら `testing/` に追加し、本ドキュメントの「レイアウト」 を更新

--- a/.claude/rules/ksp-test.md
+++ b/.claude/rules/ksp-test.md
@@ -31,7 +31,7 @@ paths:
 
 ### Snapshot file format
 
-golden ファイルは `*.md` (Markdown) で、中身は単一の fenced code block:
+golden ファイルは `*.md` (Markdown)。最小形は単一の fenced code block:
 
 ````md
 ```kt
@@ -39,14 +39,40 @@ golden ファイルは `*.md` (Markdown) で、中身は単一の fenced code bl
 ```
 ````
 
-`assertMatchesSnapshot(name, actual, lang)` の `lang` パラメータがフェンス言語を決める
-(default は `kt`)。生成 Kotlin source なら `kt` (default のまま)、コンパイラ出力など
-非 Kotlin テキストは `lang = "text"` を指定する。GitHub diff viewer で syntax highlight が
-効くのが主な狙い。
+`assertMatchesSnapshot(name, actual, lang)` の `lang` でフェンス言語を指定する
+(default `kt`)。コンパイラ出力など非 Kotlin テキストは `lang = "text"` を渡す。
+
+#### Facets (multi-section)
+
+`assertMatchesSnapshot` に block を渡すと、main 部分が `## [mainTitle]` 配下に置かれ、
+block 内で宣言した facet が `## <facet 名>` セクションとして追加される。
+SSoT (test code と snapshot で input を二重管理しない) を保つため、input source は test
+code 側で local val として抽出し、`compileWithCream(...)` と facet の両方に渡す:
+
+```kt
+val source = """
+    @CopyTo(Target::class)
+    data class Source(...)
+""".trimIndent()
+val result = compileWithCream(source)
+
+assertMatchesSnapshot("name", result.generatedSourceText()) {
+    "Input" facetOf source                              // default lang = "kt"
+    facet("KSP options", optionsText, lang = "properties")
+}
+```
+
+infix `facetOf` は default `lang = "kt"`。違う言語を使う facet は `facet(name, content, lang)`
+を使う。facet は宣言順に書き出される。
+
+diagnostic 系では main が compiler output なので `mainTitle = "Compiler output"` を渡す。
+それ以外 (snapshot 系) は default の `"Generated"` のまま。
+
+#### Backtick collision
 
 snapshot 本文に backtick run (例: cream が出す KDoc の ` ```kt ... ``` ` 例) が含まれる
-場合は、外側フェンスは「内部の最長 backtick run + 1」の長さで自動的に拡張される。
-比較は fenced block 全体 (フェンス含む) で行うので、フェンスを直接書き換えると壊れる。
+場合、各セクションのフェンスは独立に「内部の最長 backtick run + 1」の長さで拡張される
+(最小 3)。比較は fenced block 全体 (フェンス含む) で行うので、フェンスを直接書き換えると壊れる。
 
 ### `normalizedCompilerOutput()`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,14 @@ Unit tests for processor logic (naming strategies, property matching, etc.):
 ./gradlew :cream-ksp:test
 ```
 
+### KSP Compilation Tests (`cream-ksp/src/test/` with kctfork)
+
+JVM-only end-to-end tests built on kctfork live under
+`cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/`. See
+[.claude/rules/ksp-test.md](.claude/rules/ksp-test.md) for the layout
+(`testing/` / `diagnostic/` / `options/` / `snapshot/`), the snapshot
+regeneration command, and how to add new tests.
+
 ## Multiplatform Considerations
 
 **KSP Limitation:** KSP doesn't support intermediate source sets (e.g., `commonMain`) directly. The `test/` module uses a workaround:

--- a/cream-ksp/build.gradle.kts
+++ b/cream-ksp/build.gradle.kts
@@ -9,6 +9,9 @@ kotlin {
         "com.google.devtools.ksp.KspExperimental",
         "me.tbsten.cream.InternalCreamApi",
     )
+    sourceSets.named("test") {
+        languageSettings.optIn("org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")
+    }
 }
 
 dependencies {
@@ -18,6 +21,15 @@ dependencies {
     implementation(kotlin("reflect"))
     testImplementation(libs.kotlinTest)
     testImplementation(libs.mockk)
+    testImplementation(libs.kctforkCore)
+    testImplementation(libs.kctforkKsp)
+}
+
+tasks.named<Test>("test") {
+    // Allow snapshot regeneration via `-Dcream.snapshot.update=true` on the gradle command line.
+    System.getProperty("cream.snapshot.update")?.let {
+        systemProperty("cream.snapshot.update", it)
+    }
 }
 
 mavenPublishing {

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToChildrenDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToChildrenDiagnosticTest.kt
@@ -27,12 +27,8 @@ internal class CopyToChildrenDiagnosticTest {
             result.exitCode,
             "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
         )
-        assertMatchesSnapshot(
-            "CopyToChildrenDiagnosticTest.nonSealedClass.output",
-            result.normalizedCompilerOutput(),
-            lang = "text",
-            mainTitle = "Compiler output",
-        ) {
+        assertMatchesSnapshot("CopyToChildrenDiagnosticTest.nonSealedClass.output") {
+            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
             "Input" facetOf source
         }
     }
@@ -55,12 +51,8 @@ internal class CopyToChildrenDiagnosticTest {
             result.exitCode,
             "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
         )
-        assertMatchesSnapshot(
-            "CopyToChildrenDiagnosticTest.dataClass.output",
-            result.normalizedCompilerOutput(),
-            lang = "text",
-            mainTitle = "Compiler output",
-        ) {
+        assertMatchesSnapshot("CopyToChildrenDiagnosticTest.dataClass.output") {
+            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
             "Input" facetOf source
         }
     }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToChildrenDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToChildrenDiagnosticTest.kt
@@ -1,0 +1,89 @@
+package me.tbsten.cream.ksp.diagnostic
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+internal class CopyToChildrenDiagnosticTest {
+    @Test
+    fun `non-sealed class with @CopyToChildren fails compilation`() {
+        val result =
+            compileWithCream(
+                """
+                package diag
+
+                import me.tbsten.cream.CopyToChildren
+
+                @CopyToChildren
+                class NotSealed(val prop: String)
+                """.trimIndent(),
+            )
+
+        assertNotEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
+        )
+        assertMatchesSnapshot(
+            "CopyToChildrenDiagnosticTest.nonSealedClass.output",
+            result.normalizedCompilerOutput(),
+            lang = "text",
+        )
+    }
+
+    @Test
+    fun `data class with @CopyToChildren fails compilation`() {
+        val result =
+            compileWithCream(
+                """
+                package diag
+
+                import me.tbsten.cream.CopyToChildren
+
+                @CopyToChildren
+                data class JustData(val prop: String)
+                """.trimIndent(),
+            )
+
+        assertNotEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
+        )
+        assertMatchesSnapshot(
+            "CopyToChildrenDiagnosticTest.dataClass.output",
+            result.normalizedCompilerOutput(),
+            lang = "text",
+        )
+    }
+
+    @Test
+    fun `sealed interface with @CopyToChildren compiles successfully`() {
+        val result =
+            compileWithCream(
+                """
+                package diag
+
+                import me.tbsten.cream.CopyToChildren
+
+                @CopyToChildren
+                sealed interface State {
+                    val id: String
+
+                    data class Loading(override val id: String) : State
+                    data class Loaded(override val id: String, val value: Int) : State
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}",
+        )
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToChildrenDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToChildrenDiagnosticTest.kt
@@ -11,17 +11,16 @@ import kotlin.test.assertNotEquals
 internal class CopyToChildrenDiagnosticTest {
     @Test
     fun `non-sealed class with @CopyToChildren fails compilation`() {
-        val result =
-            compileWithCream(
-                """
-                package diag
+        val source =
+            """
+            package diag
 
-                import me.tbsten.cream.CopyToChildren
+            import me.tbsten.cream.CopyToChildren
 
-                @CopyToChildren
-                class NotSealed(val prop: String)
-                """.trimIndent(),
-            )
+            @CopyToChildren
+            class NotSealed(val prop: String)
+            """.trimIndent()
+        val result = compileWithCream(source)
 
         assertNotEquals(
             KotlinCompilation.ExitCode.OK,
@@ -32,22 +31,24 @@ internal class CopyToChildrenDiagnosticTest {
             "CopyToChildrenDiagnosticTest.nonSealedClass.output",
             result.normalizedCompilerOutput(),
             lang = "text",
-        )
+            mainTitle = "Compiler output",
+        ) {
+            "Input" facetOf source
+        }
     }
 
     @Test
     fun `data class with @CopyToChildren fails compilation`() {
-        val result =
-            compileWithCream(
-                """
-                package diag
+        val source =
+            """
+            package diag
 
-                import me.tbsten.cream.CopyToChildren
+            import me.tbsten.cream.CopyToChildren
 
-                @CopyToChildren
-                data class JustData(val prop: String)
-                """.trimIndent(),
-            )
+            @CopyToChildren
+            data class JustData(val prop: String)
+            """.trimIndent()
+        val result = compileWithCream(source)
 
         assertNotEquals(
             KotlinCompilation.ExitCode.OK,
@@ -58,7 +59,10 @@ internal class CopyToChildrenDiagnosticTest {
             "CopyToChildrenDiagnosticTest.dataClass.output",
             result.normalizedCompilerOutput(),
             lang = "text",
-        )
+            mainTitle = "Compiler output",
+        ) {
+            "Input" facetOf source
+        }
     }
 
     @Test

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToDiagnosticTest.kt
@@ -28,12 +28,8 @@ internal class CopyToDiagnosticTest {
             result.exitCode,
             "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
         )
-        assertMatchesSnapshot(
-            "CopyToDiagnosticTest.enumTarget.output",
-            result.normalizedCompilerOutput(),
-            lang = "text",
-            mainTitle = "Compiler output",
-        ) {
+        assertMatchesSnapshot("CopyToDiagnosticTest.enumTarget.output") {
+            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
             "Input" facetOf source
         }
     }
@@ -60,12 +56,8 @@ internal class CopyToDiagnosticTest {
             result.exitCode,
             "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
         )
-        assertMatchesSnapshot(
-            "CopyToDiagnosticTest.nonSealedInterface.output",
-            result.normalizedCompilerOutput(),
-            lang = "text",
-            mainTitle = "Compiler output",
-        ) {
+        assertMatchesSnapshot("CopyToDiagnosticTest.nonSealedInterface.output") {
+            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
             "Input" facetOf source
         }
     }
@@ -90,12 +82,8 @@ internal class CopyToDiagnosticTest {
             result.exitCode,
             "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
         )
-        assertMatchesSnapshot(
-            "CopyToDiagnosticTest.annotationTarget.output",
-            result.normalizedCompilerOutput(),
-            lang = "text",
-            mainTitle = "Compiler output",
-        ) {
+        assertMatchesSnapshot("CopyToDiagnosticTest.annotationTarget.output") {
+            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
             "Input" facetOf source
         }
     }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToDiagnosticTest.kt
@@ -10,19 +10,18 @@ import kotlin.test.assertNotEquals
 internal class CopyToDiagnosticTest {
     @Test
     fun `@CopyTo targeting an enum class fails compilation`() {
-        val result =
-            compileWithCream(
-                """
-                package diag
+        val source =
+            """
+            package diag
 
-                import me.tbsten.cream.CopyTo
+            import me.tbsten.cream.CopyTo
 
-                enum class Color { RED, BLUE }
+            enum class Color { RED, BLUE }
 
-                @CopyTo(Color::class)
-                data class Source(val name: String)
-                """.trimIndent(),
-            )
+            @CopyTo(Color::class)
+            data class Source(val name: String)
+            """.trimIndent()
+        val result = compileWithCream(source)
 
         assertNotEquals(
             KotlinCompilation.ExitCode.OK,
@@ -33,26 +32,28 @@ internal class CopyToDiagnosticTest {
             "CopyToDiagnosticTest.enumTarget.output",
             result.normalizedCompilerOutput(),
             lang = "text",
-        )
+            mainTitle = "Compiler output",
+        ) {
+            "Input" facetOf source
+        }
     }
 
     @Test
     fun `@CopyTo targeting a non-sealed interface fails compilation`() {
-        val result =
-            compileWithCream(
-                """
-                package diag
+        val source =
+            """
+            package diag
 
-                import me.tbsten.cream.CopyTo
+            import me.tbsten.cream.CopyTo
 
-                interface Plain {
-                    val id: String
-                }
+            interface Plain {
+                val id: String
+            }
 
-                @CopyTo(Plain::class)
-                data class Source(val id: String)
-                """.trimIndent(),
-            )
+            @CopyTo(Plain::class)
+            data class Source(val id: String)
+            """.trimIndent()
+        val result = compileWithCream(source)
 
         assertNotEquals(
             KotlinCompilation.ExitCode.OK,
@@ -63,24 +64,26 @@ internal class CopyToDiagnosticTest {
             "CopyToDiagnosticTest.nonSealedInterface.output",
             result.normalizedCompilerOutput(),
             lang = "text",
-        )
+            mainTitle = "Compiler output",
+        ) {
+            "Input" facetOf source
+        }
     }
 
     @Test
     fun `@CopyTo targeting an annotation class fails compilation`() {
-        val result =
-            compileWithCream(
-                """
-                package diag
+        val source =
+            """
+            package diag
 
-                import me.tbsten.cream.CopyTo
+            import me.tbsten.cream.CopyTo
 
-                annotation class Marker
+            annotation class Marker
 
-                @CopyTo(Marker::class)
-                data class Source(val name: String)
-                """.trimIndent(),
-            )
+            @CopyTo(Marker::class)
+            data class Source(val name: String)
+            """.trimIndent()
+        val result = compileWithCream(source)
 
         assertNotEquals(
             KotlinCompilation.ExitCode.OK,
@@ -91,6 +94,9 @@ internal class CopyToDiagnosticTest {
             "CopyToDiagnosticTest.annotationTarget.output",
             result.normalizedCompilerOutput(),
             lang = "text",
-        )
+            mainTitle = "Compiler output",
+        ) {
+            "Input" facetOf source
+        }
     }
 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToDiagnosticTest.kt
@@ -1,0 +1,96 @@
+package me.tbsten.cream.ksp.diagnostic
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+
+internal class CopyToDiagnosticTest {
+    @Test
+    fun `@CopyTo targeting an enum class fails compilation`() {
+        val result =
+            compileWithCream(
+                """
+                package diag
+
+                import me.tbsten.cream.CopyTo
+
+                enum class Color { RED, BLUE }
+
+                @CopyTo(Color::class)
+                data class Source(val name: String)
+                """.trimIndent(),
+            )
+
+        assertNotEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
+        )
+        assertMatchesSnapshot(
+            "CopyToDiagnosticTest.enumTarget.output",
+            result.normalizedCompilerOutput(),
+            lang = "text",
+        )
+    }
+
+    @Test
+    fun `@CopyTo targeting a non-sealed interface fails compilation`() {
+        val result =
+            compileWithCream(
+                """
+                package diag
+
+                import me.tbsten.cream.CopyTo
+
+                interface Plain {
+                    val id: String
+                }
+
+                @CopyTo(Plain::class)
+                data class Source(val id: String)
+                """.trimIndent(),
+            )
+
+        assertNotEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
+        )
+        assertMatchesSnapshot(
+            "CopyToDiagnosticTest.nonSealedInterface.output",
+            result.normalizedCompilerOutput(),
+            lang = "text",
+        )
+    }
+
+    @Test
+    fun `@CopyTo targeting an annotation class fails compilation`() {
+        val result =
+            compileWithCream(
+                """
+                package diag
+
+                import me.tbsten.cream.CopyTo
+
+                annotation class Marker
+
+                @CopyTo(Marker::class)
+                data class Source(val name: String)
+                """.trimIndent(),
+            )
+
+        assertNotEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
+        )
+        assertMatchesSnapshot(
+            "CopyToDiagnosticTest.annotationTarget.output",
+            result.normalizedCompilerOutput(),
+            lang = "text",
+        )
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/OptionsDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/OptionsDiagnosticTest.kt
@@ -38,7 +38,10 @@ internal class OptionsDiagnosticTest {
             "OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output",
             result.normalizedCompilerOutput(),
             lang = "text",
-        )
+            mainTitle = "Compiler output",
+        ) {
+            "Input" facetOf validSource
+        }
     }
 
     @Test
@@ -58,7 +61,10 @@ internal class OptionsDiagnosticTest {
             "OptionsDiagnosticTest.invalidEscapeDot.output",
             result.normalizedCompilerOutput(),
             lang = "text",
-        )
+            mainTitle = "Compiler output",
+        ) {
+            "Input" facetOf validSource
+        }
     }
 
     @Test

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/OptionsDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/OptionsDiagnosticTest.kt
@@ -1,0 +1,78 @@
+package me.tbsten.cream.ksp.diagnostic
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+internal class OptionsDiagnosticTest {
+    private val validSource: String =
+        """
+        package diag
+
+        import me.tbsten.cream.CopyTo
+
+        @CopyTo(Target::class)
+        data class Source(val prop: String)
+
+        data class Target(val prop: String)
+        """.trimIndent()
+
+    @Test
+    fun `invalid copyFunNamingStrategy fails compilation with helpful message`() {
+        val result =
+            compileWithCream(
+                validSource,
+                options = mapOf("cream.copyFunNamingStrategy" to "not-a-strategy"),
+            )
+
+        assertNotEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
+        )
+        assertMatchesSnapshot(
+            "OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output",
+            result.normalizedCompilerOutput(),
+            lang = "text",
+        )
+    }
+
+    @Test
+    fun `invalid escapeDot fails compilation with helpful message`() {
+        val result =
+            compileWithCream(
+                validSource,
+                options = mapOf("cream.escapeDot" to "not-an-escape"),
+            )
+
+        assertNotEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
+        )
+        assertMatchesSnapshot(
+            "OptionsDiagnosticTest.invalidEscapeDot.output",
+            result.normalizedCompilerOutput(),
+            lang = "text",
+        )
+    }
+
+    @Test
+    fun `valid copyFunNamingStrategy value compiles successfully`() {
+        val result =
+            compileWithCream(
+                validSource,
+                options = mapOf("cream.copyFunNamingStrategy" to "full-name"),
+            )
+
+        assertEquals(
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+            "Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}",
+        )
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/OptionsDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/OptionsDiagnosticTest.kt
@@ -34,12 +34,8 @@ internal class OptionsDiagnosticTest {
             result.exitCode,
             "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
         )
-        assertMatchesSnapshot(
-            "OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output",
-            result.normalizedCompilerOutput(),
-            lang = "text",
-            mainTitle = "Compiler output",
-        ) {
+        assertMatchesSnapshot("OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output") {
+            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
             "Input" facetOf validSource
         }
     }
@@ -57,12 +53,8 @@ internal class OptionsDiagnosticTest {
             result.exitCode,
             "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
         )
-        assertMatchesSnapshot(
-            "OptionsDiagnosticTest.invalidEscapeDot.output",
-            result.normalizedCompilerOutput(),
-            lang = "text",
-            mainTitle = "Compiler output",
-        ) {
+        assertMatchesSnapshot("OptionsDiagnosticTest.invalidEscapeDot.output") {
+            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
             "Input" facetOf validSource
         }
     }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/CopyFunNamePrefixOptionTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/CopyFunNamePrefixOptionTest.kt
@@ -1,0 +1,71 @@
+package me.tbsten.cream.ksp.options
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class CopyFunNamePrefixOptionTest {
+    private val sampleSource: String =
+        """
+        package opts.prefix
+
+        import me.tbsten.cream.CopyTo
+
+        @CopyTo(Target::class)
+        data class Source(val prop: String)
+
+        data class Target(val prop: String)
+        """.trimIndent()
+
+    @Test
+    fun `default prefix copyTo is used when option is not set`() {
+        val result = compileWithCream(sampleSource)
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val generated = result.generatedSourceText()
+        assertTrue(
+            generated.contains("copyToTarget"),
+            "Generated source should contain 'copyToTarget'. Actual:\n$generated",
+        )
+    }
+
+    @Test
+    fun `prefix transitionTo is used when configured`() {
+        val result =
+            compileWithCream(
+                sampleSource,
+                options = mapOf("cream.copyFunNamePrefix" to "transitionTo"),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val generated = result.generatedSourceText()
+        assertTrue(
+            generated.contains("transitionToTarget"),
+            "Generated source should contain 'transitionToTarget'. Actual:\n$generated",
+        )
+        assertFalse(
+            generated.contains("copyToTarget"),
+            "Default prefix should not appear when custom prefix is set. Actual:\n$generated",
+        )
+    }
+
+    @Test
+    fun `prefix ending with non-letter does not capitalize target name`() {
+        val result =
+            compileWithCream(
+                sampleSource,
+                options = mapOf("cream.copyFunNamePrefix" to "to_"),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val generated = result.generatedSourceText()
+        assertTrue(
+            generated.contains("to_target"),
+            "Generated source should contain 'to_target' (no capitalization rewrite for underscore-ending prefix). Actual:\n$generated",
+        )
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/CopyFunNamingStrategyOptionTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/CopyFunNamingStrategyOptionTest.kt
@@ -1,0 +1,106 @@
+package me.tbsten.cream.ksp.options
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class CopyFunNamingStrategyOptionTest {
+    private val sampleSource: String =
+        """
+        package opts.strategy
+
+        import me.tbsten.cream.CopyTo
+
+        @CopyTo(Target::class)
+        data class Source(val prop: String)
+
+        data class Target(val prop: String)
+        """.trimIndent()
+
+    private fun runWithStrategy(strategy: String) =
+        compileWithCream(
+            sampleSource,
+            options = mapOf("cream.copyFunNamingStrategy" to strategy),
+        )
+
+    @Test
+    fun `under-package strategy uses target name relative to package`() {
+        val result = runWithStrategy("under-package")
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        // under-package: "opts.strategy.Target" minus "opts.strategy." = "Target"
+        // escape lower-camel-case: "Target" -> "target"
+        // prefix "copyTo" capitalizes -> "copyToTarget"
+        assertTrue(
+            result.generatedSourceText().contains("copyToTarget"),
+            "Expected 'copyToTarget'. Actual:\n${result.generatedSourceText()}",
+        )
+    }
+
+    @Test
+    fun `simple-name strategy uses target simpleName`() {
+        val result = runWithStrategy("simple-name")
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertTrue(
+            result.generatedSourceText().contains("copyToTarget"),
+            "Expected 'copyToTarget'. Actual:\n${result.generatedSourceText()}",
+        )
+    }
+
+    @Test
+    fun `full-name strategy includes the package in the function name`() {
+        val result = runWithStrategy("full-name")
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        // full-name: "opts.strategy.Target"
+        // escape lower-camel-case: -> "optsStrategyTarget"
+        // prefix capitalizes -> "copyToOptsStrategyTarget"
+        assertTrue(
+            result.generatedSourceText().contains("copyToOptsStrategyTarget"),
+            "Expected 'copyToOptsStrategyTarget'. Actual:\n${result.generatedSourceText()}",
+        )
+    }
+
+    @Test
+    fun `diff strategy uses difference between source and target`() {
+        val result = runWithStrategy("diff")
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        // common prefix "opts.strategy." then S vs T differ -> diff = "Target"
+        // escape lower-camel-case "Target" -> "target"
+        // prefix capitalize -> "copyToTarget"
+        assertTrue(
+            result.generatedSourceText().contains("copyToTarget"),
+            "Expected 'copyToTarget'. Actual:\n${result.generatedSourceText()}",
+        )
+    }
+
+    @Test
+    fun `inner-name strategy drops the leading segment of underPackageName`() {
+        val result =
+            compileWithCream(
+                """
+                package opts.strategy
+
+                import me.tbsten.cream.CopyTo
+
+                data class Outer(val prop: String) {
+                    @CopyTo(Inner::class)
+                    data class Source(val prop: String)
+
+                    data class Inner(val prop: String)
+                }
+                """.trimIndent(),
+                options = mapOf("cream.copyFunNamingStrategy" to "inner-name"),
+            )
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        // inner-name for Outer.Inner: underPackageName "Outer.Inner".split(".") -> ["Outer","Inner"], size>1
+        // subList(1, 2) -> ["Inner"], joinToString(".") -> "Inner"
+        // escape lower-camel-case "Inner" -> "inner"
+        // prefix capitalize -> "copyToInner"
+        assertTrue(
+            result.generatedSourceText().contains("copyToInner"),
+            "Expected 'copyToInner'. Actual:\n${result.generatedSourceText()}",
+        )
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/EscapeDotOptionTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/EscapeDotOptionTest.kt
@@ -1,0 +1,85 @@
+package me.tbsten.cream.ksp.options
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class EscapeDotOptionTest {
+    // full-name strategy makes the dotted full FQN show up in the function name,
+    // which lets us observe how each EscapeDot variant rewrites it.
+    private val fullNameSource: String =
+        """
+        package opts.escape
+
+        import me.tbsten.cream.CopyTo
+
+        @CopyTo(Target::class)
+        data class Source(val prop: String)
+
+        data class Target(val prop: String)
+        """.trimIndent()
+
+    private fun runWithEscape(escape: String) =
+        compileWithCream(
+            fullNameSource,
+            options =
+                mapOf(
+                    "cream.copyFunNamingStrategy" to "full-name",
+                    "cream.escapeDot" to escape,
+                ),
+        )
+
+    @Test
+    fun `lower-camel-case removes dots and capitalizes each segment`() {
+        val result = runWithEscape("lower-camel-case")
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        // "opts.escape.Target" -> "optsEscapeTarget" -> first lower "optsEscapeTarget"
+        // prefix capitalizes -> "copyToOptsEscapeTarget"
+        assertTrue(
+            result.generatedSourceText().contains("copyToOptsEscapeTarget"),
+            "Expected 'copyToOptsEscapeTarget'. Actual:\n${result.generatedSourceText()}",
+        )
+    }
+
+    @Test
+    fun `replace-to-underscore prefixes underscore and substitutes dots`() {
+        val result = runWithEscape("replace-to-underscore")
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        // "opts.escape.Target" -> "_opts_escape_Target"
+        // prefix "copyTo" ends with letter; first char is '_' (non-letter) -> no further capitalization
+        // -> "copyTo_opts_escape_Target"
+        assertTrue(
+            result.generatedSourceText().contains("copyTo_opts_escape_Target"),
+            "Expected 'copyTo_opts_escape_Target'. Actual:\n${result.generatedSourceText()}",
+        )
+    }
+
+    @Test
+    fun `backquote wraps the target name in backticks in generated source`() {
+        // backquote produces the literal substring `copyTo\`Target\`` in the generated function
+        // name. Note that Kotlin currently cannot parse a function declaration whose name has
+        // a non-quoted prefix followed by a backquote-wrapped suffix, so downstream compilation
+        // would fail — this test only verifies the KSP code-generation behavior of the option.
+        val result =
+            compileWithCream(
+                fullNameSource,
+                options =
+                    mapOf(
+                        "cream.copyFunNamingStrategy" to "simple-name",
+                        "cream.escapeDot" to "backquote",
+                    ),
+            )
+        // simple-name -> "Target"
+        // backquote -> "`Target`"
+        // first char `\`` non-letter -> no capitalize change
+        // -> "copyTo`Target`" (matches CopyFunctionNameTest unit-test expectations)
+        val generated = result.generatedSourceText()
+        assertTrue(
+            generated.contains("copyTo`Target`"),
+            "Expected 'copyTo`Target`' in generated source. Actual:\n$generated",
+        )
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/NotCopyToObjectOptionTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/NotCopyToObjectOptionTest.kt
@@ -1,0 +1,54 @@
+package me.tbsten.cream.ksp.options
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class NotCopyToObjectOptionTest {
+    // @CombineTo is the path that actually consults options.notCopyToObject (Transform.kt:94),
+    // so we exercise it here. @CopyToChildren has its own annotation parameter for the same
+    // intent, which is covered by the existing test/ module.
+    private val combineToSource: String =
+        """
+        package opts.notobj
+
+        import me.tbsten.cream.CombineTo
+
+        @CombineTo(Singleton::class)
+        data class Source(val prop: String)
+
+        data object Singleton
+        """.trimIndent()
+
+    @Test
+    fun `default behavior generates combine function to object target`() {
+        val result = compileWithCream(combineToSource)
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val generated = result.generatedSourceText()
+        assertTrue(
+            generated.contains("copyToSingleton"),
+            "Default behavior should include 'copyToSingleton' for the data object target. Actual:\n$generated",
+        )
+    }
+
+    @Test
+    fun `cream notCopyToObject=true suppresses combine function to data object`() {
+        val result =
+            compileWithCream(
+                combineToSource,
+                options = mapOf("cream.notCopyToObject" to "true"),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val generated = result.generatedSourceText()
+        assertFalse(
+            generated.contains("copyToSingleton"),
+            "'copyToSingleton' should be suppressed when cream.notCopyToObject=true. Actual:\n$generated",
+        )
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/BasicSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/BasicSnapshotTest.kt
@@ -30,7 +30,8 @@ internal class BasicSnapshotTest {
         val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("BasicSnapshotTest.copyTo", result.generatedSourceText()) {
+        assertMatchesSnapshot("BasicSnapshotTest.copyTo") {
+            "Generated" facetOf result.generatedSourceText()
             "Input" facetOf source
         }
     }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/BasicSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/BasicSnapshotTest.kt
@@ -1,0 +1,36 @@
+package me.tbsten.cream.ksp.snapshot
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class BasicSnapshotTest {
+    @Test
+    fun `copyTo class generates expected source`() {
+        val result =
+            compileWithCream(
+                """
+                package snap.basic
+
+                import me.tbsten.cream.CopyTo
+
+                @CopyTo(Target::class)
+                data class Source(
+                    val shared: String,
+                    val onlyOnSource: Int,
+                )
+
+                data class Target(
+                    val shared: String,
+                    val onlyOnTarget: Boolean,
+                )
+                """.trimIndent(),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertMatchesSnapshot("BasicSnapshotTest.copyTo", result.generatedSourceText())
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/BasicSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/BasicSnapshotTest.kt
@@ -10,27 +10,28 @@ import kotlin.test.assertEquals
 internal class BasicSnapshotTest {
     @Test
     fun `copyTo class generates expected source`() {
-        val result =
-            compileWithCream(
-                """
-                package snap.basic
+        val source =
+            """
+            package snap.basic
 
-                import me.tbsten.cream.CopyTo
+            import me.tbsten.cream.CopyTo
 
-                @CopyTo(Target::class)
-                data class Source(
-                    val shared: String,
-                    val onlyOnSource: Int,
-                )
-
-                data class Target(
-                    val shared: String,
-                    val onlyOnTarget: Boolean,
-                )
-                """.trimIndent(),
+            @CopyTo(Target::class)
+            data class Source(
+                val shared: String,
+                val onlyOnSource: Int,
             )
 
+            data class Target(
+                val shared: String,
+                val onlyOnTarget: Boolean,
+            )
+            """.trimIndent()
+        val result = compileWithCream(source)
+
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("BasicSnapshotTest.copyTo", result.generatedSourceText())
+        assertMatchesSnapshot("BasicSnapshotTest.copyTo", result.generatedSourceText()) {
+            "Input" facetOf source
+        }
     }
 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/GenericSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/GenericSnapshotTest.kt
@@ -30,7 +30,8 @@ internal class GenericSnapshotTest {
         val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("GenericSnapshotTest.copyFromGeneric", result.generatedSourceText()) {
+        assertMatchesSnapshot("GenericSnapshotTest.copyFromGeneric") {
+            "Generated" facetOf result.generatedSourceText()
             "Input" facetOf source
         }
     }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/GenericSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/GenericSnapshotTest.kt
@@ -1,0 +1,36 @@
+package me.tbsten.cream.ksp.snapshot
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class GenericSnapshotTest {
+    @Test
+    fun `copyFrom with a single type parameter generates expected source`() {
+        val result =
+            compileWithCream(
+                """
+                package snap.generic
+
+                import me.tbsten.cream.CopyFrom
+
+                @CopyFrom(Source::class)
+                data class Target<T>(
+                    val value: T,
+                    val label: String,
+                )
+
+                data class Source<T>(
+                    val value: T,
+                    val label: String,
+                )
+                """.trimIndent(),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertMatchesSnapshot("GenericSnapshotTest.copyFromGeneric", result.generatedSourceText())
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/GenericSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/GenericSnapshotTest.kt
@@ -10,27 +10,28 @@ import kotlin.test.assertEquals
 internal class GenericSnapshotTest {
     @Test
     fun `copyFrom with a single type parameter generates expected source`() {
-        val result =
-            compileWithCream(
-                """
-                package snap.generic
+        val source =
+            """
+            package snap.generic
 
-                import me.tbsten.cream.CopyFrom
+            import me.tbsten.cream.CopyFrom
 
-                @CopyFrom(Source::class)
-                data class Target<T>(
-                    val value: T,
-                    val label: String,
-                )
-
-                data class Source<T>(
-                    val value: T,
-                    val label: String,
-                )
-                """.trimIndent(),
+            @CopyFrom(Source::class)
+            data class Target<T>(
+                val value: T,
+                val label: String,
             )
 
+            data class Source<T>(
+                val value: T,
+                val label: String,
+            )
+            """.trimIndent()
+        val result = compileWithCream(source)
+
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("GenericSnapshotTest.copyFromGeneric", result.generatedSourceText())
+        assertMatchesSnapshot("GenericSnapshotTest.copyFromGeneric", result.generatedSourceText()) {
+            "Input" facetOf source
+        }
     }
 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KindMatrixSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KindMatrixSnapshotTest.kt
@@ -14,110 +14,114 @@ import kotlin.test.assertEquals
 internal class KindMatrixSnapshotTest {
     @Test
     fun `copyTo from data class to data object generates expected source`() {
-        val result =
-            compileWithCream(
-                """
-                package snap.kind.classToObject
+        val source =
+            """
+            package snap.kind.classToObject
 
-                import me.tbsten.cream.CopyTo
+            import me.tbsten.cream.CopyTo
 
-                @CopyTo(Loaded::class)
-                data class Source(val id: String)
+            @CopyTo(Loaded::class)
+            data class Source(val id: String)
 
-                data object Loaded
-                """.trimIndent(),
-            )
+            data object Loaded
+            """.trimIndent()
+        val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
         assertMatchesSnapshot(
             "KindMatrixSnapshotTest.copyToDataObject",
             result.generatedSourceText(),
-        )
+        ) {
+            "Input" facetOf source
+        }
     }
 
     @Test
     fun `copyTo from data class to sealed interface expands across subclasses`() {
-        val result =
-            compileWithCream(
-                """
-                package snap.kind.classToSealed
+        val source =
+            """
+            package snap.kind.classToSealed
 
-                import me.tbsten.cream.CopyTo
+            import me.tbsten.cream.CopyTo
 
-                @CopyTo(State::class)
-                data class Source(val id: String)
+            @CopyTo(State::class)
+            data class Source(val id: String)
 
-                sealed interface State {
-                    val id: String
+            sealed interface State {
+                val id: String
 
-                    data class Loading(override val id: String) : State
-                    data class Loaded(override val id: String, val payload: Int) : State
-                }
-                """.trimIndent(),
-            )
+                data class Loading(override val id: String) : State
+                data class Loaded(override val id: String, val payload: Int) : State
+            }
+            """.trimIndent()
+        val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
         assertMatchesSnapshot(
             "KindMatrixSnapshotTest.copyToSealedInterface",
             result.generatedSourceText(),
-        )
+        ) {
+            "Input" facetOf source
+        }
     }
 
     @Test
     fun `copyFrom basic data class to data class generates expected source`() {
-        val result =
-            compileWithCream(
-                """
-                package snap.kind.copyFromBasic
+        val source =
+            """
+            package snap.kind.copyFromBasic
 
-                import me.tbsten.cream.CopyFrom
+            import me.tbsten.cream.CopyFrom
 
-                data class Source(
-                    val shared: String,
-                    val onlyOnSource: Int,
-                )
-
-                @CopyFrom(Source::class)
-                data class Target(
-                    val shared: String,
-                    val onlyOnTarget: Boolean,
-                )
-                """.trimIndent(),
+            data class Source(
+                val shared: String,
+                val onlyOnSource: Int,
             )
+
+            @CopyFrom(Source::class)
+            data class Target(
+                val shared: String,
+                val onlyOnTarget: Boolean,
+            )
+            """.trimIndent()
+        val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
         assertMatchesSnapshot(
             "KindMatrixSnapshotTest.copyFromBasic",
             result.generatedSourceText(),
-        )
+        ) {
+            "Input" facetOf source
+        }
     }
 
     @Test
     fun `copyToChildren with mixed data class and data object subclasses generates expected source`() {
-        val result =
-            compileWithCream(
-                """
-                package snap.kind.sealedMixed
+        val source =
+            """
+            package snap.kind.sealedMixed
 
-                import me.tbsten.cream.CopyToChildren
+            import me.tbsten.cream.CopyToChildren
 
-                @CopyToChildren
-                sealed interface State {
-                    val id: String
+            @CopyToChildren
+            sealed interface State {
+                val id: String
 
-                    data object Initial : State {
-                        override val id: String get() = "initial"
-                    }
-
-                    data class Loaded(override val id: String, val payload: Int) : State
+                data object Initial : State {
+                    override val id: String get() = "initial"
                 }
-                """.trimIndent(),
-            )
+
+                data class Loaded(override val id: String, val payload: Int) : State
+            }
+            """.trimIndent()
+        val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
         assertMatchesSnapshot(
             "KindMatrixSnapshotTest.copyToChildrenMixed",
             result.generatedSourceText(),
-        )
+        ) {
+            "Input" facetOf source
+        }
     }
 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KindMatrixSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KindMatrixSnapshotTest.kt
@@ -28,10 +28,8 @@ internal class KindMatrixSnapshotTest {
         val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot(
-            "KindMatrixSnapshotTest.copyToDataObject",
-            result.generatedSourceText(),
-        ) {
+        assertMatchesSnapshot("KindMatrixSnapshotTest.copyToDataObject") {
+            "Generated" facetOf result.generatedSourceText()
             "Input" facetOf source
         }
     }
@@ -57,10 +55,8 @@ internal class KindMatrixSnapshotTest {
         val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot(
-            "KindMatrixSnapshotTest.copyToSealedInterface",
-            result.generatedSourceText(),
-        ) {
+        assertMatchesSnapshot("KindMatrixSnapshotTest.copyToSealedInterface") {
+            "Generated" facetOf result.generatedSourceText()
             "Input" facetOf source
         }
     }
@@ -87,10 +83,8 @@ internal class KindMatrixSnapshotTest {
         val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot(
-            "KindMatrixSnapshotTest.copyFromBasic",
-            result.generatedSourceText(),
-        ) {
+        assertMatchesSnapshot("KindMatrixSnapshotTest.copyFromBasic") {
+            "Generated" facetOf result.generatedSourceText()
             "Input" facetOf source
         }
     }
@@ -117,10 +111,8 @@ internal class KindMatrixSnapshotTest {
         val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot(
-            "KindMatrixSnapshotTest.copyToChildrenMixed",
-            result.generatedSourceText(),
-        ) {
+        assertMatchesSnapshot("KindMatrixSnapshotTest.copyToChildrenMixed") {
+            "Generated" facetOf result.generatedSourceText()
             "Input" facetOf source
         }
     }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KindMatrixSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KindMatrixSnapshotTest.kt
@@ -1,0 +1,123 @@
+package me.tbsten.cream.ksp.snapshot
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Snapshot tests covering cross-kind source/target combinations that are not exercised by
+ * [BasicSnapshotTest] / [GenericSnapshotTest] / [SealedSnapshotTest] / [ObjectTargetSnapshotTest].
+ */
+internal class KindMatrixSnapshotTest {
+    @Test
+    fun `copyTo from data class to data object generates expected source`() {
+        val result =
+            compileWithCream(
+                """
+                package snap.kind.classToObject
+
+                import me.tbsten.cream.CopyTo
+
+                @CopyTo(Loaded::class)
+                data class Source(val id: String)
+
+                data object Loaded
+                """.trimIndent(),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertMatchesSnapshot(
+            "KindMatrixSnapshotTest.copyToDataObject",
+            result.generatedSourceText(),
+        )
+    }
+
+    @Test
+    fun `copyTo from data class to sealed interface expands across subclasses`() {
+        val result =
+            compileWithCream(
+                """
+                package snap.kind.classToSealed
+
+                import me.tbsten.cream.CopyTo
+
+                @CopyTo(State::class)
+                data class Source(val id: String)
+
+                sealed interface State {
+                    val id: String
+
+                    data class Loading(override val id: String) : State
+                    data class Loaded(override val id: String, val payload: Int) : State
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertMatchesSnapshot(
+            "KindMatrixSnapshotTest.copyToSealedInterface",
+            result.generatedSourceText(),
+        )
+    }
+
+    @Test
+    fun `copyFrom basic data class to data class generates expected source`() {
+        val result =
+            compileWithCream(
+                """
+                package snap.kind.copyFromBasic
+
+                import me.tbsten.cream.CopyFrom
+
+                data class Source(
+                    val shared: String,
+                    val onlyOnSource: Int,
+                )
+
+                @CopyFrom(Source::class)
+                data class Target(
+                    val shared: String,
+                    val onlyOnTarget: Boolean,
+                )
+                """.trimIndent(),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertMatchesSnapshot(
+            "KindMatrixSnapshotTest.copyFromBasic",
+            result.generatedSourceText(),
+        )
+    }
+
+    @Test
+    fun `copyToChildren with mixed data class and data object subclasses generates expected source`() {
+        val result =
+            compileWithCream(
+                """
+                package snap.kind.sealedMixed
+
+                import me.tbsten.cream.CopyToChildren
+
+                @CopyToChildren
+                sealed interface State {
+                    val id: String
+
+                    data object Initial : State {
+                        override val id: String get() = "initial"
+                    }
+
+                    data class Loaded(override val id: String, val payload: Int) : State
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertMatchesSnapshot(
+            "KindMatrixSnapshotTest.copyToChildrenMixed",
+            result.generatedSourceText(),
+        )
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/ObjectTargetSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/ObjectTargetSnapshotTest.kt
@@ -28,7 +28,9 @@ internal class ObjectTargetSnapshotTest {
         assertMatchesSnapshot(
             "ObjectTargetSnapshotTest.combineToObject.default",
             result.generatedSourceText(),
-        )
+        ) {
+            "Input" facetOf combineToObjectSource
+        }
     }
 
     @Test
@@ -43,6 +45,8 @@ internal class ObjectTargetSnapshotTest {
         assertMatchesSnapshot(
             "ObjectTargetSnapshotTest.combineToObject.notCopyToObject",
             result.generatedSourceText(),
-        )
+        ) {
+            "Input" facetOf combineToObjectSource
+        }
     }
 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/ObjectTargetSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/ObjectTargetSnapshotTest.kt
@@ -1,0 +1,48 @@
+package me.tbsten.cream.ksp.snapshot
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class ObjectTargetSnapshotTest {
+    private val combineToObjectSource: String =
+        """
+        package snap.objtarget
+
+        import me.tbsten.cream.CombineTo
+
+        @CombineTo(Singleton::class)
+        data class Source(val prop: String)
+
+        data object Singleton
+        """.trimIndent()
+
+    @Test
+    fun `combineTo with object target generates expected source`() {
+        val result = compileWithCream(combineToObjectSource)
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertMatchesSnapshot(
+            "ObjectTargetSnapshotTest.combineToObject.default",
+            result.generatedSourceText(),
+        )
+    }
+
+    @Test
+    fun `combineTo with object target and notCopyToObject=true generates expected source`() {
+        val result =
+            compileWithCream(
+                combineToObjectSource,
+                options = mapOf("cream.notCopyToObject" to "true"),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertMatchesSnapshot(
+            "ObjectTargetSnapshotTest.combineToObject.notCopyToObject",
+            result.generatedSourceText(),
+        )
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/ObjectTargetSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/ObjectTargetSnapshotTest.kt
@@ -25,10 +25,8 @@ internal class ObjectTargetSnapshotTest {
         val result = compileWithCream(combineToObjectSource)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot(
-            "ObjectTargetSnapshotTest.combineToObject.default",
-            result.generatedSourceText(),
-        ) {
+        assertMatchesSnapshot("ObjectTargetSnapshotTest.combineToObject.default") {
+            "Generated" facetOf result.generatedSourceText()
             "Input" facetOf combineToObjectSource
         }
     }
@@ -42,10 +40,8 @@ internal class ObjectTargetSnapshotTest {
             )
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot(
-            "ObjectTargetSnapshotTest.combineToObject.notCopyToObject",
-            result.generatedSourceText(),
-        ) {
+        assertMatchesSnapshot("ObjectTargetSnapshotTest.combineToObject.notCopyToObject") {
+            "Generated" facetOf result.generatedSourceText()
             "Input" facetOf combineToObjectSource
         }
     }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/SealedSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/SealedSnapshotTest.kt
@@ -1,0 +1,33 @@
+package me.tbsten.cream.ksp.snapshot
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class SealedSnapshotTest {
+    @Test
+    fun `copyToChildren sealed interface generates expected source`() {
+        val result =
+            compileWithCream(
+                """
+                package snap.sealed
+
+                import me.tbsten.cream.CopyToChildren
+
+                @CopyToChildren
+                sealed interface State {
+                    val id: String
+
+                    data class Loading(override val id: String) : State
+                    data class Loaded(override val id: String, val payload: Int) : State
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertMatchesSnapshot("SealedSnapshotTest.copyToChildren", result.generatedSourceText())
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/SealedSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/SealedSnapshotTest.kt
@@ -10,24 +10,25 @@ import kotlin.test.assertEquals
 internal class SealedSnapshotTest {
     @Test
     fun `copyToChildren sealed interface generates expected source`() {
-        val result =
-            compileWithCream(
-                """
-                package snap.sealed
+        val source =
+            """
+            package snap.sealed
 
-                import me.tbsten.cream.CopyToChildren
+            import me.tbsten.cream.CopyToChildren
 
-                @CopyToChildren
-                sealed interface State {
-                    val id: String
+            @CopyToChildren
+            sealed interface State {
+                val id: String
 
-                    data class Loading(override val id: String) : State
-                    data class Loaded(override val id: String, val payload: Int) : State
-                }
-                """.trimIndent(),
-            )
+                data class Loading(override val id: String) : State
+                data class Loaded(override val id: String, val payload: Int) : State
+            }
+            """.trimIndent()
+        val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("SealedSnapshotTest.copyToChildren", result.generatedSourceText())
+        assertMatchesSnapshot("SealedSnapshotTest.copyToChildren", result.generatedSourceText()) {
+            "Input" facetOf source
+        }
     }
 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/SealedSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/SealedSnapshotTest.kt
@@ -27,7 +27,8 @@ internal class SealedSnapshotTest {
         val result = compileWithCream(source)
 
         assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("SealedSnapshotTest.copyToChildren", result.generatedSourceText()) {
+        assertMatchesSnapshot("SealedSnapshotTest.copyToChildren") {
+            "Generated" facetOf result.generatedSourceText()
             "Input" facetOf source
         }
     }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilation.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilation.kt
@@ -57,7 +57,13 @@ internal fun compileWithCream(
  * Single-source convenience overload. Equivalent to:
  *
  * ```kt
- * compileWithCream(options) { sourceFileName source source }
+ * compileWithCream(
+ *     """
+ *         @CopyTo(Target::class)
+ *         data class Source(...)
+ *     """,
+ *     options,
+ * )
  * ```
  */
 internal fun compileWithCream(

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilation.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilation.kt
@@ -1,0 +1,121 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package me.tbsten.cream.ksp.testing
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.kspProcessorOptions
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import com.tschuchort.compiletesting.useKsp2
+import me.tbsten.cream.ksp.CreamSymbolProcessorProvider
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+
+/**
+ * DSL receiver for collecting source files. Use [source] from a [String] receiver
+ * (file name) to add a Kotlin source. See the multi-source overload of
+ * [compileWithCream].
+ */
+internal class CreamSourcesBuilder {
+    private val sources = mutableListOf<SourceFile>()
+
+    infix fun String.source(
+        @Language("kotlin") code: String,
+    ) {
+        sources += SourceFile.kotlin(this, code)
+    }
+
+    internal fun build(): List<SourceFile> = sources.toList()
+}
+
+/**
+ * Multi-source overload. Use when a test needs more than one input file:
+ *
+ * ```kt
+ * compileWithCream(options = mapOf(...)) {
+ *     "Source.kt" source """
+ *         @CopyTo(Target::class)
+ *         data class Source(...)
+ *     """.trimIndent()
+ *     "Target.kt" source """
+ *         data class Target(...)
+ *     """.trimIndent()
+ * }
+ * ```
+ */
+internal fun compileWithCream(
+    options: Map<String, String> = emptyMap(),
+    block: CreamSourcesBuilder.() -> Unit,
+): CreamCompilationResult {
+    val sources = CreamSourcesBuilder().apply(block).build()
+    return runCompilation(sources, options)
+}
+
+/**
+ * Single-source convenience overload. Equivalent to:
+ *
+ * ```kt
+ * compileWithCream(options) { sourceFileName source source }
+ * ```
+ */
+internal fun compileWithCream(
+    @Language("kotlin") source: String,
+    options: Map<String, String> = emptyMap(),
+    sourceFileName: String = "Test.kt",
+): CreamCompilationResult =
+    compileWithCream(options = options) {
+        sourceFileName source source
+    }
+
+private fun runCompilation(
+    sources: List<SourceFile>,
+    options: Map<String, String>,
+): CreamCompilationResult {
+    // Multiplex compiler output: keep printing to System.out for local debugging,
+    // and also capture into a buffer so tests can snapshot it via
+    // CreamCompilationResult.compilerOutput.
+    val captured = ByteArrayOutputStream()
+    val tee = TeeOutputStream(System.out, captured)
+    val compilation =
+        KotlinCompilation().apply {
+            inheritClassPath = true
+            useKsp2()
+            symbolProcessorProviders += CreamSymbolProcessorProvider()
+            if (options.isNotEmpty()) {
+                kspProcessorOptions = options.toMutableMap()
+            }
+            this.sources = sources
+            messageOutputStream = tee
+        }
+    return CreamCompilationResult(
+        raw = compilation.compile(),
+        compilation = compilation,
+        compilerOutputBuffer = captured,
+    )
+}
+
+private class TeeOutputStream(
+    private val a: OutputStream,
+    private val b: OutputStream,
+) : OutputStream() {
+    override fun write(byte: Int) {
+        a.write(byte)
+        b.write(byte)
+    }
+
+    override fun write(
+        buffer: ByteArray,
+        offset: Int,
+        length: Int,
+    ) {
+        a.write(buffer, offset, length)
+        b.write(buffer, offset, length)
+    }
+
+    override fun flush() {
+        a.flush()
+        b.flush()
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilationResult.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilationResult.kt
@@ -1,0 +1,30 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package me.tbsten.cream.ksp.testing
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.sourcesGeneratedBySymbolProcessor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+internal data class CreamCompilationResult(
+    private val raw: JvmCompilationResult,
+    val compilation: KotlinCompilation,
+    private val compilerOutputBuffer: ByteArrayOutputStream,
+) {
+    val exitCode: KotlinCompilation.ExitCode get() = raw.exitCode
+    val messages: String get() = raw.messages
+
+    /**
+     * Everything the Kotlin compiler / KSP printed to `messageOutputStream` during this run.
+     * Use with [me.tbsten.cream.ksp.testing.normalizedCompilerOutput] when snapshotting, since
+     * the raw text contains absolute temp-dir paths.
+     */
+    val compilerOutput: String get() = compilerOutputBuffer.toString(Charsets.UTF_8)
+
+    fun generatedSources(): List<File> = raw.sourcesGeneratedBySymbolProcessor.toList()
+
+    fun loadGeneratedClass(fqName: String): Class<*> = raw.classLoader.loadClass(fqName)
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilationResultUtils.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilationResultUtils.kt
@@ -1,0 +1,40 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package me.tbsten.cream.ksp.testing
+
+import com.tschuchort.compiletesting.kspSourcesDir
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import java.io.File
+
+internal fun CreamCompilationResult.generatedSourceText(): String =
+    generatedSources()
+        .sortedBy { it.name }
+        .joinToString(separator = "\n\n// ----- next file -----\n\n") { file ->
+            "// file: ${file.name}\n" + file.readText().trimEnd()
+        }
+
+internal fun CreamCompilationResult.kspSourcesDir(): File = compilation.kspSourcesDir
+
+/**
+ * The captured compiler / KSP output with machine-specific bits replaced by stable
+ * placeholders, so the result can be checked into snapshot golden files. Currently this
+ * redacts:
+ *
+ * - The JVM temp directory (`java.io.tmpdir`) → `<TMPDIR>`
+ * - The per-run kctfork working directory name (`Kotlin-CompilationNNN`) → `Kotlin-Compilation<N>`
+ * - Consecutive stack-trace frames (`\tat ...`) and the `\t... NN more` continuation marker
+ *   that follows a `Caused by:` block → a single `\t<stack trace omitted>` line. Both the
+ *   frame contents and the `NN` depth count vary with the JVM / Gradle / JUnit / KSP version
+ *   and with cream's own line moves; snapshot tests are concerned with the error message
+ *   body, not the exact frames. If a snapshot ever needs to assert on a specific frame,
+ *   prefer a targeted contains-style check alongside the snapshot instead of disabling
+ *   this collapse.
+ */
+internal fun CreamCompilationResult.normalizedCompilerOutput(): String {
+    val tmpDir = System.getProperty("java.io.tmpdir").trimEnd('/', '\\')
+    return compilerOutput
+        .replace(tmpDir, "<TMPDIR>")
+        .replace(Regex("Kotlin-Compilation\\d+"), "Kotlin-Compilation<N>")
+        .replace(Regex("(?:\\n\\tat [^\\n]+|\\n\\t\\.\\.\\. \\d+ more)+"), "\n\t<stack trace omitted>")
+        .trimEnd() + if (compilerOutput.isEmpty()) "" else "\n"
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilationSmokeTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilationSmokeTest.kt
@@ -1,0 +1,61 @@
+package me.tbsten.cream.ksp.testing
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class CreamCompilationSmokeTest {
+    @Test
+    fun `compiles a minimal @CopyTo source and generates a copy function`() {
+        val result =
+            compileWithCream(
+                """
+                package smoke
+
+                import me.tbsten.cream.CopyTo
+
+                @CopyTo(Target::class)
+                data class Source(val shared: String)
+
+                data class Target(val shared: String, val extra: Int)
+                """.trimIndent(),
+            )
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+
+        val generatedText = result.generatedSourceText()
+        assertTrue(
+            generatedText.contains("copyToTarget"),
+            "Generated source should contain copyToTarget function. Generated:\n$generatedText",
+        )
+    }
+
+    @Test
+    fun `multi-source DSL compiles when source and target live in separate files`() {
+        val result =
+            compileWithCream {
+                "Source.kt" source
+                    """
+                    package smoke.multi
+
+                    import me.tbsten.cream.CopyTo
+
+                    @CopyTo(Target::class)
+                    data class Source(val shared: String)
+                    """.trimIndent()
+                "Target.kt" source
+                    """
+                    package smoke.multi
+
+                    data class Target(val shared: String, val extra: Int)
+                    """.trimIndent()
+            }
+
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        assertTrue(
+            result.generatedSourceText().contains("copyToTarget"),
+            "Multi-source compilation should still produce copyToTarget. Generated:\n${result.generatedSourceText()}",
+        )
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/SnapshotAssertion.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/SnapshotAssertion.kt
@@ -1,0 +1,99 @@
+package me.tbsten.cream.ksp.testing
+
+import java.io.File
+import kotlin.test.fail
+
+/**
+ * Run with `-Dcream.snapshot.update=true` to (re-)generate snapshot files.
+ */
+private val updateSnapshots: Boolean
+    get() = System.getProperty("cream.snapshot.update")?.equals("true", ignoreCase = true) == true
+
+private val snapshotRoot: File by lazy {
+    val dir = File("src/test/resources/snapshots")
+    if (!dir.exists()) dir.mkdirs()
+    dir
+}
+
+/**
+ * Compare [actual] against a checked-in golden snapshot at
+ * `src/test/resources/snapshots/<name>.md`.
+ *
+ * The golden file is a Markdown document containing a single fenced code block whose
+ * language is [lang]. Wrapping the captured text in a fenced block gives diffs
+ * Kotlin (or other) syntax highlighting on GitHub and keeps the file
+ * self-describing when opened standalone.
+ *
+ * Pass `lang = "kt"` (the default) for generated Kotlin source. Pass `lang = "text"`
+ * for compiler output, stack traces, or anything else that is not valid Kotlin.
+ *
+ * Comparison is whole-file (fences included), so any drift in the wrapping itself
+ * is also caught.
+ */
+internal fun assertMatchesSnapshot(
+    name: String,
+    actual: String,
+    lang: String = "kt",
+) {
+    val file = File(snapshotRoot, "$name.md")
+    val normalizedActual = wrapAsMarkdown(actual, lang)
+
+    if (!file.exists()) {
+        if (updateSnapshots) {
+            file.parentFile.mkdirs()
+            file.writeText(normalizedActual, Charsets.UTF_8)
+            return
+        }
+        fail(
+            """
+            Snapshot file not found: ${file.path}
+            Run with -Dcream.snapshot.update=true to create it.
+            Actual content:
+            $normalizedActual
+            """.trimIndent(),
+        )
+    }
+
+    val expected = file.readText(Charsets.UTF_8)
+    if (expected != normalizedActual) {
+        if (updateSnapshots) {
+            file.writeText(normalizedActual, Charsets.UTF_8)
+            return
+        }
+        fail(
+            """
+            Snapshot mismatch for ${file.path}
+            Run with -Dcream.snapshot.update=true to update.
+            --- Expected ---
+            $expected
+            --- Actual ---
+            $normalizedActual
+            """.trimIndent(),
+        )
+    }
+}
+
+/**
+ * Wrap [actual] in a fenced Markdown code block. To stay correct when the body itself
+ * contains backtick runs (e.g. cream emits KDoc with embedded ` ```kt ` examples),
+ * the outer fence is one backtick longer than the longest backtick run inside the body,
+ * with a minimum of 3.
+ */
+private fun wrapAsMarkdown(
+    actual: String,
+    lang: String,
+): String {
+    val trimmed = actual.trimEnd()
+    val longestInternalRun =
+        Regex("`+").findAll(trimmed).maxOfOrNull { it.value.length } ?: 0
+    val fence = "`".repeat(maxOf(3, longestInternalRun + 1))
+    return buildString {
+        append(fence)
+        append(lang)
+        append('\n')
+        append(trimmed)
+        append('\n')
+        append(fence)
+        append('\n')
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/SnapshotAssertion.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/SnapshotAssertion.kt
@@ -19,24 +19,46 @@ private val snapshotRoot: File by lazy {
  * Compare [actual] against a checked-in golden snapshot at
  * `src/test/resources/snapshots/<name>.md`.
  *
- * The golden file is a Markdown document containing a single fenced code block whose
- * language is [lang]. Wrapping the captured text in a fenced block gives diffs
- * Kotlin (or other) syntax highlighting on GitHub and keeps the file
- * self-describing when opened standalone.
+ * The golden is a Markdown document. When [block] is empty (the default) the file
+ * is a single fenced code block whose language is [lang] — the minimal form,
+ * back-compatible with snapshots authored before the facet DSL existed.
  *
- * Pass `lang = "kt"` (the default) for generated Kotlin source. Pass `lang = "text"`
- * for compiler output, stack traces, or anything else that is not valid Kotlin.
+ * When [block] adds facets, the file becomes a multi-section document: [actual]
+ * appears under an `## [mainTitle]` heading, followed by one `## <name>` section per
+ * facet in declaration order. Fence lengths are computed per section so embedded
+ * backtick runs (e.g. cream emits KDoc with ` ```kt ... ``` ` examples) never
+ * collide with the wrapping. Comparison stays whole-file, so any drift in headings
+ * or fences is also caught.
  *
- * Comparison is whole-file (fences included), so any drift in the wrapping itself
- * is also caught.
+ * Pass `lang = "kt"` (the default) for Kotlin source. Pass `lang = "text"` for
+ * compiler output, stack traces, or anything else that is not valid Kotlin. Each
+ * facet may carry its own [SnapshotFacetBuilder.facet] `lang`.
+ *
+ * ```kt
+ * assertMatchesSnapshot("MyTest.scenario", result.generatedSourceText()) {
+ *     "Input" facetOf result.inputSourceText()
+ *     facet("Compiler messages", result.messages, lang = "text")
+ * }
+ * ```
  */
 internal fun assertMatchesSnapshot(
     name: String,
     actual: String,
     lang: String = "kt",
+    mainTitle: String = "Generated",
+    block: SnapshotFacetBuilder.() -> Unit = {},
 ) {
+    val builder = SnapshotFacetBuilderImpl()
+    builder.block()
+    val facets = builder.build()
+
     val file = File(snapshotRoot, "$name.md")
-    val normalizedActual = wrapAsMarkdown(actual, lang)
+    val normalizedActual =
+        if (facets.isEmpty()) {
+            renderSingleSection(actual, lang)
+        } else {
+            renderMultiSection(actual, lang, mainTitle, facets)
+        }
 
     if (!file.exists()) {
         if (updateSnapshots) {
@@ -74,16 +96,79 @@ internal fun assertMatchesSnapshot(
 }
 
 /**
- * Wrap [actual] in a fenced Markdown code block. To stay correct when the body itself
- * contains backtick runs (e.g. cream emits KDoc with embedded ` ```kt ` examples),
- * the outer fence is one backtick longer than the longest backtick run inside the body,
- * with a minimum of 3.
+ * Builder for the optional facets block of [assertMatchesSnapshot]. Each facet
+ * becomes a `## <name>` section in the golden file, in declaration order.
  */
-private fun wrapAsMarkdown(
-    actual: String,
+internal interface SnapshotFacetBuilder {
+    /**
+     * Add a facet whose language is `kt`. Equivalent to `facet(this, content)`.
+     * Use the long form [facet] when a non-Kotlin language is needed.
+     */
+    infix fun String.facetOf(content: String)
+
+    /** Add a facet with an explicit fence language (e.g. `"text"`, `"properties"`). */
+    fun facet(
+        name: String,
+        content: String,
+        lang: String = "kt",
+    )
+}
+
+private class SnapshotFacetBuilderImpl : SnapshotFacetBuilder {
+    private val facets = mutableListOf<Facet>()
+
+    override infix fun String.facetOf(content: String) {
+        facets += Facet(this, content, "kt")
+    }
+
+    override fun facet(
+        name: String,
+        content: String,
+        lang: String,
+    ) {
+        facets += Facet(name, content, lang)
+    }
+
+    fun build(): List<Facet> = facets.toList()
+}
+
+private data class Facet(
+    val name: String,
+    val content: String,
+    val lang: String,
+)
+
+private fun renderSingleSection(
+    content: String,
+    lang: String,
+): String = renderFencedBlock(content, lang) + "\n"
+
+private fun renderMultiSection(
+    main: String,
+    mainLang: String,
+    mainTitle: String,
+    facets: List<Facet>,
+): String =
+    buildString {
+        append("## ").append(mainTitle).append("\n\n")
+        append(renderFencedBlock(main, mainLang)).append('\n')
+        for (facet in facets) {
+            append("\n## ").append(facet.name).append("\n\n")
+            append(renderFencedBlock(facet.content, facet.lang)).append('\n')
+        }
+    }
+
+/**
+ * Wrap [content] in a fenced Markdown code block. To stay correct when the body
+ * itself contains backtick runs (e.g. cream emits KDoc with embedded
+ * ` ```kt ` examples), the outer fence is one backtick longer than the longest
+ * backtick run inside the body, with a minimum of 3.
+ */
+private fun renderFencedBlock(
+    content: String,
     lang: String,
 ): String {
-    val trimmed = actual.trimEnd()
+    val trimmed = content.trimEnd()
     val longestInternalRun =
         Regex("`+").findAll(trimmed).maxOfOrNull { it.value.length } ?: 0
     val fence = "`".repeat(maxOf(3, longestInternalRun + 1))
@@ -94,6 +179,5 @@ private fun wrapAsMarkdown(
         append(trimmed)
         append('\n')
         append(fence)
-        append('\n')
     }
 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/SnapshotAssertion.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/SnapshotAssertion.kt
@@ -16,49 +16,41 @@ private val snapshotRoot: File by lazy {
 }
 
 /**
- * Compare [actual] against a checked-in golden snapshot at
- * `src/test/resources/snapshots/<name>.md`.
+ * Compare a Markdown golden snapshot at `src/test/resources/snapshots/<name>.md`
+ * against the facets declared in [block].
  *
- * The golden is a Markdown document. When [block] is empty (the default) the file
- * is a single fenced code block whose language is [lang] — the minimal form,
- * back-compatible with snapshots authored before the facet DSL existed.
- *
- * When [block] adds facets, the file becomes a multi-section document: [actual]
- * appears under an `## [mainTitle]` heading, followed by one `## <name>` section per
- * facet in declaration order. Fence lengths are computed per section so embedded
- * backtick runs (e.g. cream emits KDoc with ` ```kt ... ``` ` examples) never
- * collide with the wrapping. Comparison stays whole-file, so any drift in headings
- * or fences is also caught.
- *
- * Pass `lang = "kt"` (the default) for Kotlin source. Pass `lang = "text"` for
- * compiler output, stack traces, or anything else that is not valid Kotlin. Each
- * facet may carry its own [SnapshotFacetBuilder.facet] `lang`.
+ * Every captured value is a facet — there is no special "main" content. Each facet
+ * becomes a `## <facet name>` section in declaration order, followed by a single
+ * fenced code block. Fence lengths are computed per section so embedded backtick
+ * runs (e.g. cream emits KDoc with ` ```kt ... ``` ` examples) never collide with
+ * the wrapping. Comparison is whole-file (headings + fences included), so any drift
+ * in the wrapping itself is also caught.
  *
  * ```kt
- * assertMatchesSnapshot("MyTest.scenario", result.generatedSourceText()) {
- *     "Input" facetOf result.inputSourceText()
+ * assertMatchesSnapshot("MyTest.scenario") {
+ *     "Output" facetOf result.generatedSourceText()
+ *     "Input" facetOf source
  *     facet("Compiler messages", result.messages, lang = "text")
  * }
  * ```
+ *
+ * At least one facet is required. The infix [SnapshotFacetBuilder.facetOf] form
+ * defaults `lang` to `"kt"`; use [SnapshotFacetBuilder.facet] to pick a different
+ * fence language.
  */
 internal fun assertMatchesSnapshot(
     name: String,
-    actual: String,
-    lang: String = "kt",
-    mainTitle: String = "Generated",
-    block: SnapshotFacetBuilder.() -> Unit = {},
+    block: SnapshotFacetBuilder.() -> Unit,
 ) {
     val builder = SnapshotFacetBuilderImpl()
     builder.block()
     val facets = builder.build()
+    require(facets.isNotEmpty()) {
+        "assertMatchesSnapshot(\"$name\") requires at least one facet inside its block."
+    }
 
     val file = File(snapshotRoot, "$name.md")
-    val normalizedActual =
-        if (facets.isEmpty()) {
-            renderSingleSection(actual, lang)
-        } else {
-            renderMultiSection(actual, lang, mainTitle, facets)
-        }
+    val normalizedActual = renderFacets(facets)
 
     if (!file.exists()) {
         if (updateSnapshots) {
@@ -96,12 +88,12 @@ internal fun assertMatchesSnapshot(
 }
 
 /**
- * Builder for the optional facets block of [assertMatchesSnapshot]. Each facet
- * becomes a `## <name>` section in the golden file, in declaration order.
+ * Builder for the facets block of [assertMatchesSnapshot]. Each facet becomes a
+ * `## <name>` section in the golden file, in declaration order.
  */
 internal interface SnapshotFacetBuilder {
     /**
-     * Add a facet whose language is `kt`. Equivalent to `facet(this, content)`.
+     * Add a facet whose fence language is `kt`. Equivalent to `facet(this, content)`.
      * Use the long form [facet] when a non-Kotlin language is needed.
      */
     infix fun String.facetOf(content: String)
@@ -138,22 +130,11 @@ private data class Facet(
     val lang: String,
 )
 
-private fun renderSingleSection(
-    content: String,
-    lang: String,
-): String = renderFencedBlock(content, lang) + "\n"
-
-private fun renderMultiSection(
-    main: String,
-    mainLang: String,
-    mainTitle: String,
-    facets: List<Facet>,
-): String =
+private fun renderFacets(facets: List<Facet>): String =
     buildString {
-        append("## ").append(mainTitle).append("\n\n")
-        append(renderFencedBlock(main, mainLang)).append('\n')
-        for (facet in facets) {
-            append("\n## ").append(facet.name).append("\n\n")
+        for ((index, facet) in facets.withIndex()) {
+            if (index > 0) append('\n')
+            append("## ").append(facet.name).append("\n\n")
             append(renderFencedBlock(facet.content, facet.lang)).append('\n')
         }
     }

--- a/cream-ksp/src/test/resources/snapshots/BasicSnapshotTest.copyTo.md
+++ b/cream-ksp/src/test/resources/snapshots/BasicSnapshotTest.copyTo.md
@@ -1,0 +1,37 @@
+````kt
+// file: CopyTo__Source.kt
+package snap.basic
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [Source])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  snap.basic.Source.copyToTarget(
+    shared: String = this.shared,
+    onlyOnTarget: Boolean,
+) : snap.basic.Target = snap.basic.Target(
+    shared = shared,
+    onlyOnTarget = onlyOnTarget,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/BasicSnapshotTest.copyTo.md
+++ b/cream-ksp/src/test/resources/snapshots/BasicSnapshotTest.copyTo.md
@@ -1,3 +1,5 @@
+## Generated
+
 ````kt
 // file: CopyTo__Source.kt
 package snap.basic
@@ -35,3 +37,22 @@ public fun  snap.basic.Source.copyToTarget(
     onlyOnTarget = onlyOnTarget,
 )
 ````
+
+## Input
+
+```kt
+package snap.basic
+
+import me.tbsten.cream.CopyTo
+
+@CopyTo(Target::class)
+data class Source(
+    val shared: String,
+    val onlyOnSource: Int,
+)
+
+data class Target(
+    val shared: String,
+    val onlyOnTarget: Boolean,
+)
+```

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.dataClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.dataClass.output.md
@@ -1,0 +1,13 @@
+```text
+Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false
+
+Solution: 
+  
+
+me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false
+
+Solution: 
+  
+
+	<stack trace omitted>
+```

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.dataClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.dataClass.output.md
@@ -1,3 +1,5 @@
+## Compiler output
+
 ```text
 Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false
 
@@ -10,4 +12,15 @@ Solution:
   
 
 	<stack trace omitted>
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren
+data class JustData(val prop: String)
 ```

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.nonSealedClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.nonSealedClass.output.md
@@ -1,0 +1,13 @@
+```text
+Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false
+
+Solution: 
+  
+
+me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false
+
+Solution: 
+  
+
+	<stack trace omitted>
+```

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.nonSealedClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.nonSealedClass.output.md
@@ -1,3 +1,5 @@
+## Compiler output
+
 ```text
 Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false
 
@@ -10,4 +12,15 @@ Solution:
   
 
 	<stack trace omitted>
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren
+class NotSealed(val prop: String)
 ```

--- a/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.annotationTarget.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.annotationTarget.output.md
@@ -1,3 +1,5 @@
+## Compiler output
+
 ```text
 Invalid cream usage: Unsupported copy to annotation class (diag.Marker).
 
@@ -10,4 +12,17 @@ Solution:
   Please make diag.Marker a class or object or sealed interface.
 
 	<stack trace omitted>
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CopyTo
+
+annotation class Marker
+
+@CopyTo(Marker::class)
+data class Source(val name: String)
 ```

--- a/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.annotationTarget.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.annotationTarget.output.md
@@ -1,0 +1,13 @@
+```text
+Invalid cream usage: Unsupported copy to annotation class (diag.Marker).
+
+Solution: 
+  Please make diag.Marker a class or object or sealed interface.
+
+me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: Unsupported copy to annotation class (diag.Marker).
+
+Solution: 
+  Please make diag.Marker a class or object or sealed interface.
+
+	<stack trace omitted>
+```

--- a/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.enumTarget.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.enumTarget.output.md
@@ -1,3 +1,5 @@
+## Compiler output
+
 ```text
 Invalid cream usage: Unsupported copy to enum class (diag.Color).
 
@@ -10,4 +12,17 @@ Solution:
   Please make diag.Color a class or object or sealed interface.
 
 	<stack trace omitted>
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CopyTo
+
+enum class Color { RED, BLUE }
+
+@CopyTo(Color::class)
+data class Source(val name: String)
 ```

--- a/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.enumTarget.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.enumTarget.output.md
@@ -1,0 +1,13 @@
+```text
+Invalid cream usage: Unsupported copy to enum class (diag.Color).
+
+Solution: 
+  Please make diag.Color a class or object or sealed interface.
+
+me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: Unsupported copy to enum class (diag.Color).
+
+Solution: 
+  Please make diag.Color a class or object or sealed interface.
+
+	<stack trace omitted>
+```

--- a/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.nonSealedInterface.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.nonSealedInterface.output.md
@@ -1,3 +1,5 @@
+## Compiler output
+
 ```text
 Invalid cream usage: Unsupported copy to interface (diag.Plain).It must be a sealed interface.
 
@@ -10,4 +12,19 @@ Solution:
   Please make diag.Plain a sealed interface.
 
 	<stack trace omitted>
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CopyTo
+
+interface Plain {
+    val id: String
+}
+
+@CopyTo(Plain::class)
+data class Source(val id: String)
 ```

--- a/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.nonSealedInterface.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToDiagnosticTest.nonSealedInterface.output.md
@@ -1,0 +1,13 @@
+```text
+Invalid cream usage: Unsupported copy to interface (diag.Plain).It must be a sealed interface.
+
+Solution: 
+  Please make diag.Plain a sealed interface.
+
+me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: Unsupported copy to interface (diag.Plain).It must be a sealed interface.
+
+Solution: 
+  Please make diag.Plain a sealed interface.
+
+	<stack trace omitted>
+```

--- a/cream-ksp/src/test/resources/snapshots/GenericSnapshotTest.copyFromGeneric.md
+++ b/cream-ksp/src/test/resources/snapshots/GenericSnapshotTest.copyFromGeneric.md
@@ -1,3 +1,5 @@
+## Generated
+
 ````kt
 // file: CopyFrom__Target.kt
 package snap.generic
@@ -35,3 +37,22 @@ public fun <T : Any?> snap.generic.Source<T>.copyToTarget(
     label = label,
 )
 ````
+
+## Input
+
+```kt
+package snap.generic
+
+import me.tbsten.cream.CopyFrom
+
+@CopyFrom(Source::class)
+data class Target<T>(
+    val value: T,
+    val label: String,
+)
+
+data class Source<T>(
+    val value: T,
+    val label: String,
+)
+```

--- a/cream-ksp/src/test/resources/snapshots/GenericSnapshotTest.copyFromGeneric.md
+++ b/cream-ksp/src/test/resources/snapshots/GenericSnapshotTest.copyFromGeneric.md
@@ -1,0 +1,37 @@
+````kt
+// file: CopyFrom__Target.kt
+package snap.generic
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyFrom] annotation of [Target])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun <T : Any?> snap.generic.Source<T>.copyToTarget(
+    value: T = this.value,
+    label: String = this.label,
+) : snap.generic.Target<T> = snap.generic.Target(
+    value = value,
+    label = label,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyFromBasic.md
+++ b/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyFromBasic.md
@@ -1,0 +1,37 @@
+````kt
+// file: CopyFrom__Target.kt
+package snap.kind.copyFromBasic
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyFrom] annotation of [Target])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  snap.kind.copyFromBasic.Source.copyToTarget(
+    shared: String = this.shared,
+    onlyOnTarget: Boolean,
+) : snap.kind.copyFromBasic.Target = snap.kind.copyFromBasic.Target(
+    shared = shared,
+    onlyOnTarget = onlyOnTarget,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyFromBasic.md
+++ b/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyFromBasic.md
@@ -1,3 +1,5 @@
+## Generated
+
 ````kt
 // file: CopyFrom__Target.kt
 package snap.kind.copyFromBasic
@@ -35,3 +37,22 @@ public fun  snap.kind.copyFromBasic.Source.copyToTarget(
     onlyOnTarget = onlyOnTarget,
 )
 ````
+
+## Input
+
+```kt
+package snap.kind.copyFromBasic
+
+import me.tbsten.cream.CopyFrom
+
+data class Source(
+    val shared: String,
+    val onlyOnSource: Int,
+)
+
+@CopyFrom(Source::class)
+data class Target(
+    val shared: String,
+    val onlyOnTarget: Boolean,
+)
+```

--- a/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToChildrenMixed.md
+++ b/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToChildrenMixed.md
@@ -1,0 +1,53 @@
+````kt
+// file: CopyToChildren__State.kt
+package snap.kind.sealedMixed
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [State])
+ * 
+ * State -> State.Initial copy function.
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateInitial()
+ * ```
+ * 
+ * 
+ * @see State
+ * @see State.Initial
+ */
+public fun snap.kind.sealedMixed.State.copyToStateInitial() = snap.kind.sealedMixed.State.Initial
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [State])
+ * 
+ * State -> State.Loaded copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateLoaded()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateLoaded(property = value)
+ * ```
+ * 
+ * 
+ * @see State
+ * @see State.Loaded
+ */
+public fun  snap.kind.sealedMixed.State.copyToStateLoaded(
+    id: String = this.id,
+    payload: Int,
+) : snap.kind.sealedMixed.State.Loaded = snap.kind.sealedMixed.State.Loaded(
+    id = id,
+    payload = payload,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToChildrenMixed.md
+++ b/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToChildrenMixed.md
@@ -1,3 +1,5 @@
+## Generated
+
 ````kt
 // file: CopyToChildren__State.kt
 package snap.kind.sealedMixed
@@ -51,3 +53,22 @@ public fun  snap.kind.sealedMixed.State.copyToStateLoaded(
     payload = payload,
 )
 ````
+
+## Input
+
+```kt
+package snap.kind.sealedMixed
+
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren
+sealed interface State {
+    val id: String
+
+    data object Initial : State {
+        override val id: String get() = "initial"
+    }
+
+    data class Loaded(override val id: String, val payload: Int) : State
+}
+```

--- a/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToDataObject.md
+++ b/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToDataObject.md
@@ -1,3 +1,5 @@
+## Generated
+
 ````kt
 // file: CopyTo__Source.kt
 package snap.kind.classToObject
@@ -21,3 +23,16 @@ import me.tbsten.cream.*
  */
 public fun snap.kind.classToObject.Source.copyToLoaded() = snap.kind.classToObject.Loaded
 ````
+
+## Input
+
+```kt
+package snap.kind.classToObject
+
+import me.tbsten.cream.CopyTo
+
+@CopyTo(Loaded::class)
+data class Source(val id: String)
+
+data object Loaded
+```

--- a/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToDataObject.md
+++ b/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToDataObject.md
@@ -1,0 +1,23 @@
+````kt
+// file: CopyTo__Source.kt
+package snap.kind.classToObject
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [Source])
+ * 
+ * Source -> Loaded copy function.
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToLoaded()
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Loaded
+ */
+public fun snap.kind.classToObject.Source.copyToLoaded() = snap.kind.classToObject.Loaded
+````

--- a/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToSealedInterface.md
+++ b/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToSealedInterface.md
@@ -1,0 +1,126 @@
+````kt
+// file: CopyTo__Source.kt
+package snap.kind.classToSealed
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [Source])
+ * 
+ * Source -> State.Loaded copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToStateLoaded()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToStateLoaded(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see State.Loaded
+ */
+public fun  snap.kind.classToSealed.Source.copyToStateLoaded(
+    id: String = this.id,
+    payload: Int,
+) : snap.kind.classToSealed.State.Loaded = snap.kind.classToSealed.State.Loaded(
+    id = id,
+    payload = payload,
+)
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [Source])
+ * 
+ * Source -> State.Loading copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToStateLoading()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToStateLoading(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see State.Loading
+ */
+public fun  snap.kind.classToSealed.Source.copyToStateLoading(
+    id: String = this.id,
+) : snap.kind.classToSealed.State.Loading = snap.kind.classToSealed.State.Loading(
+    id = id,
+)
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [Source])
+ * 
+ * State -> State.Loaded copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateLoaded()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateLoaded(property = value)
+ * ```
+ * 
+ * 
+ * @see State
+ * @see State.Loaded
+ */
+public fun  snap.kind.classToSealed.State.copyToStateLoaded(
+    id: String = this.id,
+    payload: Int,
+) : snap.kind.classToSealed.State.Loaded = snap.kind.classToSealed.State.Loaded(
+    id = id,
+    payload = payload,
+)
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [Source])
+ * 
+ * State -> State.Loading copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateLoading()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateLoading(property = value)
+ * ```
+ * 
+ * 
+ * @see State
+ * @see State.Loading
+ */
+public fun  snap.kind.classToSealed.State.copyToStateLoading(
+    id: String = this.id,
+) : snap.kind.classToSealed.State.Loading = snap.kind.classToSealed.State.Loading(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToSealedInterface.md
+++ b/cream-ksp/src/test/resources/snapshots/KindMatrixSnapshotTest.copyToSealedInterface.md
@@ -1,3 +1,5 @@
+## Generated
+
 ````kt
 // file: CopyTo__Source.kt
 package snap.kind.classToSealed
@@ -124,3 +126,21 @@ public fun  snap.kind.classToSealed.State.copyToStateLoading(
     id = id,
 )
 ````
+
+## Input
+
+```kt
+package snap.kind.classToSealed
+
+import me.tbsten.cream.CopyTo
+
+@CopyTo(State::class)
+data class Source(val id: String)
+
+sealed interface State {
+    val id: String
+
+    data class Loading(override val id: String) : State
+    data class Loaded(override val id: String, val payload: Int) : State
+}
+```

--- a/cream-ksp/src/test/resources/snapshots/ObjectTargetSnapshotTest.combineToObject.default.md
+++ b/cream-ksp/src/test/resources/snapshots/ObjectTargetSnapshotTest.combineToObject.default.md
@@ -1,3 +1,5 @@
+## Generated
+
 ````kt
 // file: CombineTo__Source__Singleton.kt
 package snap.objtarget
@@ -22,3 +24,16 @@ import me.tbsten.cream.*
  */
 public fun snap.objtarget.Source.copyToSingleton() = snap.objtarget.Singleton
 ````
+
+## Input
+
+```kt
+package snap.objtarget
+
+import me.tbsten.cream.CombineTo
+
+@CombineTo(Singleton::class)
+data class Source(val prop: String)
+
+data object Singleton
+```

--- a/cream-ksp/src/test/resources/snapshots/ObjectTargetSnapshotTest.combineToObject.default.md
+++ b/cream-ksp/src/test/resources/snapshots/ObjectTargetSnapshotTest.combineToObject.default.md
@@ -1,0 +1,24 @@
+````kt
+// file: CombineTo__Source__Singleton.kt
+package snap.objtarget
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CombineTo] annotation of [Source])
+ * 
+ * [Source] -> [Singleton] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToSingleton()
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Singleton
+ */
+public fun snap.objtarget.Source.copyToSingleton() = snap.objtarget.Singleton
+````

--- a/cream-ksp/src/test/resources/snapshots/ObjectTargetSnapshotTest.combineToObject.notCopyToObject.md
+++ b/cream-ksp/src/test/resources/snapshots/ObjectTargetSnapshotTest.combineToObject.notCopyToObject.md
@@ -1,0 +1,6 @@
+```kt
+// file: CombineTo__Source__Singleton.kt
+package snap.objtarget
+
+import me.tbsten.cream.*
+```

--- a/cream-ksp/src/test/resources/snapshots/ObjectTargetSnapshotTest.combineToObject.notCopyToObject.md
+++ b/cream-ksp/src/test/resources/snapshots/ObjectTargetSnapshotTest.combineToObject.notCopyToObject.md
@@ -1,6 +1,21 @@
+## Generated
+
 ```kt
 // file: CombineTo__Source__Singleton.kt
 package snap.objtarget
 
 import me.tbsten.cream.*
+```
+
+## Input
+
+```kt
+package snap.objtarget
+
+import me.tbsten.cream.CombineTo
+
+@CombineTo(Singleton::class)
+data class Source(val prop: String)
+
+data object Singleton
 ```

--- a/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output.md
+++ b/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output.md
@@ -1,3 +1,5 @@
+## Compiler output
+
 ```text
 Invalid cream usage: Invalid option: Invalid ksp.arg["cream.copyFunNamingStrategy"] = not-a-strategy.
 It must be on of under-package, diff, simple-name, full-name, inner-name
@@ -30,4 +32,17 @@ Solution:
 	<stack trace omitted>
 Caused by: java.lang.IllegalArgumentException: No enum constant me.tbsten.cream.ksp.options.CopyFunNamingStrategy.not-a-strategy
 	<stack trace omitted>
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CopyTo
+
+@CopyTo(Target::class)
+data class Source(val prop: String)
+
+data class Target(val prop: String)
 ```

--- a/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output.md
+++ b/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output.md
@@ -1,0 +1,33 @@
+```text
+Invalid cream usage: Invalid option: Invalid ksp.arg["cream.copyFunNamingStrategy"] = not-a-strategy.
+It must be on of under-package, diff, simple-name, full-name, inner-name
+
+Solution: 
+  Set one of the following for ksp.arg: 
+  
+  
+    - "under-package"
+    - "diff"
+    - "simple-name"
+    - "full-name"
+    - "inner-name"
+  
+
+me.tbsten.cream.ksp.InvalidCreamOptionException: Invalid cream usage: Invalid option: Invalid ksp.arg["cream.copyFunNamingStrategy"] = not-a-strategy.
+It must be on of under-package, diff, simple-name, full-name, inner-name
+
+Solution: 
+  Set one of the following for ksp.arg: 
+  
+  
+    - "under-package"
+    - "diff"
+    - "simple-name"
+    - "full-name"
+    - "inner-name"
+  
+
+	<stack trace omitted>
+Caused by: java.lang.IllegalArgumentException: No enum constant me.tbsten.cream.ksp.options.CopyFunNamingStrategy.not-a-strategy
+	<stack trace omitted>
+```

--- a/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest.invalidEscapeDot.output.md
+++ b/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest.invalidEscapeDot.output.md
@@ -1,0 +1,25 @@
+```text
+Invalid cream usage: Invalid option: Invalid ksp.arg["cream.escapeDot"] = not-an-escape
+
+Solution: 
+  Set one of the following for ksp.arg:
+  
+    - lower-camel-case
+    - replace-to-underscore
+    - backquote
+  
+
+me.tbsten.cream.ksp.InvalidCreamOptionException: Invalid cream usage: Invalid option: Invalid ksp.arg["cream.escapeDot"] = not-an-escape
+
+Solution: 
+  Set one of the following for ksp.arg:
+  
+    - lower-camel-case
+    - replace-to-underscore
+    - backquote
+  
+
+	<stack trace omitted>
+Caused by: java.lang.IllegalArgumentException: No enum constant me.tbsten.cream.ksp.options.EscapeDot.not-an-escape
+	<stack trace omitted>
+```

--- a/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest.invalidEscapeDot.output.md
+++ b/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest.invalidEscapeDot.output.md
@@ -1,3 +1,5 @@
+## Compiler output
+
 ```text
 Invalid cream usage: Invalid option: Invalid ksp.arg["cream.escapeDot"] = not-an-escape
 
@@ -22,4 +24,17 @@ Solution:
 	<stack trace omitted>
 Caused by: java.lang.IllegalArgumentException: No enum constant me.tbsten.cream.ksp.options.EscapeDot.not-an-escape
 	<stack trace omitted>
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CopyTo
+
+@CopyTo(Target::class)
+data class Source(val prop: String)
+
+data class Target(val prop: String)
 ```

--- a/cream-ksp/src/test/resources/snapshots/SealedSnapshotTest.copyToChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedSnapshotTest.copyToChildren.md
@@ -1,3 +1,5 @@
+## Generated
+
 ````kt
 // file: CopyToChildren__State.kt
 package snap.sealed
@@ -64,3 +66,19 @@ public fun  snap.sealed.State.copyToStateLoading(
     id = id,
 )
 ````
+
+## Input
+
+```kt
+package snap.sealed
+
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren
+sealed interface State {
+    val id: String
+
+    data class Loading(override val id: String) : State
+    data class Loaded(override val id: String, val payload: Int) : State
+}
+```

--- a/cream-ksp/src/test/resources/snapshots/SealedSnapshotTest.copyToChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedSnapshotTest.copyToChildren.md
@@ -1,0 +1,66 @@
+````kt
+// file: CopyToChildren__State.kt
+package snap.sealed
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [State])
+ * 
+ * State -> State.Loaded copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateLoaded()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateLoaded(property = value)
+ * ```
+ * 
+ * 
+ * @see State
+ * @see State.Loaded
+ */
+public fun  snap.sealed.State.copyToStateLoaded(
+    id: String = this.id,
+    payload: Int,
+) : snap.sealed.State.Loaded = snap.sealed.State.Loaded(
+    id = id,
+    payload = payload,
+)
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [State])
+ * 
+ * State -> State.Loading copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateLoading()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = State(...)
+ * val target = source.copyToStateLoading(property = value)
+ * ```
+ * 
+ * 
+ * @see State
+ * @see State.Loading
+ */
+public fun  snap.sealed.State.copyToStateLoading(
+    id: String = this.id,
+) : snap.sealed.State.Loading = snap.sealed.State.Loading(
+    id = id,
+)
+````

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ android-compileSdk = "36"
 ksp = "2.2.20-2.0.4"
 kotest = "6.0.4"
 mockk = "1.14.6"
+kctfork = "0.12.1"
 ktlint = "1.7.1"
 ktlintGradlePlugin = "13.1.0"
 
@@ -24,6 +25,8 @@ kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotli
 kotest = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kspApi = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+kctforkCore = { module = "dev.zacsweers.kctfork:core", version.ref = "kctfork" }
+kctforkKsp = { module = "dev.zacsweers.kctfork:ksp", version.ref = "kctfork" }
 kotlinxCoroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinxSerializationCore = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationJson" }
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }


### PR DESCRIPTION
Closes #56

## Summary
- Wire `dev.zacsweers.kctfork:core / :ksp` 0.12.1 into `cream-ksp` tests and add a thin `compileWithCream` / `CreamCompilationResult` / `SnapshotAssertion` layer for running the cream processor end-to-end on inline source strings (`useKsp2()`).
- Add three new test categories under `cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/`:
  - `diagnostic/` — assert that invalid `@CopyTo` / `@CopyToChildren` targets and invalid `cream.copyFunNamingStrategy` / `cream.escapeDot` values fail compilation with the helpful messages from `InvalidCreamUsageException` / `InvalidCreamOptionException` (this code path had **zero** prior coverage).
  - `options/` — first end-to-end coverage of `cream.copyFunNamePrefix`, `cream.copyFunNamingStrategy` (all 5 values), `cream.escapeDot` (all 3 values), and `cream.notCopyToObject` against generated function names.
  - `snapshot/` — golden-file comparison of the full generated Kotlin source for basic `@CopyTo`, sealed `@CopyToChildren`, generic `@CopyFrom`, and object-target `@CombineTo` (default + `notCopyToObject=true`). Goldens live under `cream-ksp/src/test/resources/snapshots/` and are regenerated with `./gradlew :cream-ksp:test -Dcream.snapshot.update=true`.
- The multiplatform `test/` module is untouched — kctfork is added as a parallel layer per the agreed plan, complementing the existing assertEquals-style tests with diagnostic and snapshot coverage that kctfork uniquely enables.

## Findings worth noting in review
- `cream.notCopyToObject` only takes effect through the `@CombineTo` path (`Transform.kt:94`); for `@CopyToChildren` the annotation's own `notCopyToObject` parameter always wins because of the `?:` ordering in `CreamSymbolProcessor.kt:263`. The new test asserts only the working path.
- `EscapeDot.backquote` combined with any naming strategy that yields a dotted name (or any non-`simple-name` setup) emits an identifier that Kotlin cannot parse, since the `copyTo` prefix sits outside the backticks. The new test exercises only the dotless `simple-name` case and documents the limitation in code.

## Test plan
- [x] `./gradlew :cream-ksp:test` — 43/43 pass (15 existing unit tests + 28 new kctfork-based tests)
- [x] `./gradlew :test:jvmTest` — no regression in the existing multiplatform tests
- [x] `./gradlew ktlintCheck` — clean
- [ ] Reviewer to confirm CI matrix (`jvmTest`, `iosSimulatorArm64Test`, `testDebugUnitTest`, etc.) still passes on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)