### PR TITLE
docs: correct copyFunNamingStrategy value from diff-parent to diff (#62)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -633,7 +633,7 @@ ksp {
 | オプション名                            | 説明                                                          | 設定例                                                                      | デフォルト              |
 |-----------------------------------|-------------------------------------------------------------|--------------------------------------------------------------------------|--------------------|
 | **`cream.copyFunNamePrefix`**     | 生成されるコピー関数の先頭につく文字列                                         | `copyTo`, `transitionTo`, `to`, `mapTo`                                  | `copyTo`           |
-| **`cream.copyFunNamingStrategy`** | コピー関数の命名方法。                                                 | `under-package`, `diff-parent`, `simple-name`, `full-name`, `inner-name` | `under-package`    |
+| **`cream.copyFunNamingStrategy`** | コピー関数の命名方法。                                                 | `under-package`, `diff`, `simple-name`, `full-name`, `inner-name` | `under-package`    |
 | **`cream.escapeDot`**             | `cream.copyFunNamingStrategy` で命名された名前に含まれる `.` をエスケープする方法。 | `replace-to-underscore`, `pascal-case`, `backquote`                      | `lower-camel-case` |
 | **`cream.notCopyToObject`**       | `true` の場合 @CopyToChildren で object へのコピー関数を生成しないようにします。    | `true` , `false`                                                         | `false`            |
 
@@ -650,7 +650,7 @@ ksp {
 
 | デフォルト           | 設定可能な値                                                                          |
 |-----------------|---------------------------------------------------------------------------------|
-| `under-package` | `under-package`, `diff-parent`, `simple-name`, `full-name`, `inner-name`　のいずれか。 |
+| `under-package` | `under-package`, `diff`, `simple-name`, `full-name`, `inner-name`　のいずれか。 |
 
 コピー関数の prefix 以降のクラス名文字列の設定方法です。以下の表に示す設定方法をサポートします。
 これら以外の命名方法が欲しい場合は [issue](https://github.com/TBSten/cream/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen)
@@ -659,7 +659,7 @@ ksp {
 | 設定値             | 説明                                                                | `com.example.Aaa.Bbb` -> `com.example.Aaa.Bbb.Ccc.Ddd` に遷移するコピー関数を生成する例 |
 |-----------------|-------------------------------------------------------------------|-------------------------------------------------------------------------|
 | `under-package` | パッケージ階層を反映した名前を使用します。                                             | Hoge.Fuga.copyTo **`Aaa.Bbb.Ccc.Ddd`** (...)                            |
-| `diff-parent`   | 遷移元クラスとの差分のみを含めた名前を使用する。                                          | Hoge.Fuga.copyTo **`CccDdd`** (...)                                     |
+| `diff`          | 遷移元クラスとの差分のみを含めた名前を使用する。                                          | Hoge.Fuga.copyTo **`CccDdd`** (...)                                     |
 | `simple-name`   | 遷移先クラス::class.simpleName を使用する。                                   | Hoge.Fuga.copyTo **`Ddd`** (...)                                        |
 | `full-name`     | 対象クラス::class.qualifiedName を使用する。                                 | Hoge.Fuga.copyTo **`ComExampleAaaBbbCccDdd`** (...)                     |
 | `inner-name`    | ネストされたクラスの 2 階層目以降のクラス名を使用する。（ネストされていないクラスの場合は `simple-name` と同じ） | Hoge.Fuga.copyTo **`BbbCccDdd`** (...)                                  |

--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ ksp {
 | Option name                       | Description                                                                 | Example                                                                  | Default            |
 |-----------------------------------|-----------------------------------------------------------------------------|--------------------------------------------------------------------------|--------------------|
 | **`cream.copyFunNamePrefix`**     | String prefixed to the generated copy function                              | `copyTo`, `transitionTo`, `to`, `mapTo`                                  | `copyTo`           |
-| **`cream.copyFunNamingStrategy`** | Copy function naming conventions.                                           | `under-package`, `diff-parent`, `simple-name`, `full-name`, `inner-name` | `under-package`    |
+| **`cream.copyFunNamingStrategy`** | Copy function naming conventions.                                           | `under-package`, `diff`, `simple-name`, `full-name`, `inner-name` | `under-package`    |
 | **`cream.escapeDot`**             | How to escape `. ` in the name given by `cream.copyFunNamingStrategy`.      | `replace-to-underscore`, `pascal-case`, `backquote`                      | `lower-camel-case` |
 | **`cream.notCopyToObject`**       | If `true`, @CopyToChildren will not generate a copy function to the object. | `true` , `false`                                                         | `false`            |
 
@@ -656,7 +656,7 @@ Set a straightforward string that describes the copy or state transition, such a
 
 | Default         | `under-package`                                                                 |
 |-----------------|---------------------------------------------------------------------------------|
-| Possible values | One of `under-package`, `diff-parent`, `simple-name`, `full-name`, `inner-name` |
+| Possible values | One of `under-package`, `diff`, `simple-name`, `full-name`, `inner-name` |
 
 How to set the class name string after the prefix of the copy function. The following table shows
 the supported configuration methods.
@@ -666,7 +666,7 @@ to [issue](https://github.com/TBSten/cream/issues?q=sort%3Aupdated-desc+is%3Aiss
 | Value           | Description                                                                                                         | Example of generating a copy function that transitions from `com.example.Aaa.Bbb` -> `com.example.Aaa.Bbb.Ccc.Ddd`. |
 |-----------------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | `under-package` | Use names that reflect the package hierarchy.                                                                       | Hoge.Fuga.copyTo **`Aaa.Bbb.Ccc.Ddd`** (...)                                                                        |
-| `diff-parent`   | Use a name that includes only the difference from the transition source class.                                      | Hoge.Fuga.copyTo **`CccDdd`** (...)                                                                                 |
+| `diff`          | Use a name that includes only the difference from the transition source class.                                      | Hoge.Fuga.copyTo **`CccDdd`** (...)                                                                                 |
 | `simple-name`   | Transition destination class::class.simpleName.                                                                     | Hoge.Fuga.copyTo **`Ddd`** (...)                                                                                    |
 | `full-name`     | Target class::class.qualifiedName.                                                                                  | Hoge.Fuga.copyTo **`ComExampleAaaBbbCccDdd`** (...)                                                                 |
 | `inner-name`    | Use the class name from the second level of the nested class onward. (Same as `simple-name` for non-nested classes) | Hoge.Fuga.copyTo **`BbbCccDdd`** (...)                                                                              |


### PR DESCRIPTION
## 概要

README で `cream.copyFunNamingStrategy` の値として `diff-parent` が記載されていましたが、実際の enum 値は `diff` です (`CopyFunNamingStrategy.kt`)。`diff-parent` を指定するとコンパイルに失敗します。

ドキュメント側を修正する方針 (コード変更なし) に従い、`README.md` と `README.ja.md` の `diff-parent` をすべて `diff` に置き換えました (各ファイル 3 箇所、計 6 箇所)。

## 変更内容
- `README.md`: オプション概要テーブル / Possible values 行 / strategy 説明テーブルの 3 箇所
- `README.ja.md`: 同上 3 箇所

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)