### PR TITLE
fix: describe annotated class kind in @CopyToChildren error message (#61)

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToChildrenProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToChildrenProcessor.kt
@@ -53,8 +53,10 @@ internal fun CreamSymbolProcessor.processCopyToChildren(resolver: Resolver): Lis
 
                 if (!copyToChildren.isSealed()) {
                     throw InvalidCreamUsageException(
-                        message = "@${CopyToChildren::class.simpleName} annotation must be applied to a sealed class/interface, but ${copyToChildren.isSealed()}",
-                        solution = "",
+                        message =
+                            "@${CopyToChildren::class.simpleName} annotation must be applied to a sealed class/interface, " +
+                                "but ${copyToChildren.fullName} is not sealed (classKind: ${copyToChildren.classKind}).",
+                        solution = "Make ${copyToChildren.fullName} a sealed class/interface.",
                     )
                 }
 

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToChildrenProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToChildrenProcessor.kt
@@ -52,11 +52,16 @@ internal fun CreamSymbolProcessor.processCopyToChildren(resolver: Resolver): Lis
                 }
 
                 if (!copyToChildren.isSealed()) {
+                    // Avoid `fullName`, which throws UnknownCreamException when qualifiedName is null
+                    // (e.g. local/anonymous declarations) and would mask this InvalidCreamUsageException.
+                    val displayName =
+                        copyToChildren.qualifiedName?.asString()
+                            ?: copyToChildren.simpleName.asString()
                     throw InvalidCreamUsageException(
                         message =
                             "@${CopyToChildren::class.simpleName} annotation must be applied to a sealed class/interface, " +
-                                "but ${copyToChildren.fullName} is not sealed (classKind: ${copyToChildren.classKind}).",
-                        solution = "Make ${copyToChildren.fullName} a sealed class/interface.",
+                                "but $displayName is not sealed (classKind: ${copyToChildren.classKind}).",
+                        solution = "Make $displayName a sealed class/interface.",
                     )
                 }
 

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/SealedCopyProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/SealedCopyProcessor.kt
@@ -33,11 +33,14 @@ internal fun CreamSymbolProcessor.processSealedCopy(resolver: Resolver): List<KS
             )
         }
         if (!annotated.isSealed()) {
+            // Avoid `fullName`, which throws UnknownCreamException when qualifiedName is null
+            // (e.g. local/anonymous declarations) and would mask this InvalidCreamUsageException.
+            val displayName = annotated.qualifiedName?.asString() ?: annotated.simpleName.asString()
             throw InvalidCreamUsageException(
                 message =
                     "@${SealedCopy::class.simpleName} must be applied to a sealed class/interface, " +
-                        "but ${annotated.fullName} is not sealed.",
-                solution = "Make ${annotated.fullName} a `sealed class` or `sealed interface`.",
+                        "but $displayName is not sealed.",
+                solution = "Make $displayName a `sealed class` or `sealed interface`.",
             )
         }
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.dataClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.dataClass.output.md
@@ -1,15 +1,15 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false
+Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.JustData is not sealed (classKind: CLASS).
 
 Solution: 
-  
+  Make diag.JustData a sealed class/interface.
 
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false
+me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.JustData is not sealed (classKind: CLASS).
 
 Solution: 
-  
+  Make diag.JustData a sealed class/interface.
 
 	<stack trace omitted>
 ```

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.nonSealedClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.nonSealedClass.output.md
@@ -1,15 +1,15 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false
+Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.NotSealed is not sealed (classKind: CLASS).
 
 Solution: 
-  
+  Make diag.NotSealed a sealed class/interface.
 
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false
+me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.NotSealed is not sealed (classKind: CLASS).
 
 Solution: 
-  
+  Make diag.NotSealed a sealed class/interface.
 
 	<stack trace omitted>
 ```


### PR DESCRIPTION
## 概要

`@CopyToChildren` を sealed でないクラスに付与したときの診断メッセージが、末尾に意味のないリテラル `false` で終わってしまう問題 (#61) を修正します。

`false` は `copyToChildren.isSealed()` の結果ですが、このブランチに到達する時点で必ず `false` になるため何の情報も持っていませんでした。また `solution = ""` のため `Solution:` ブロックが空で表示され、壊れているように見えていました。

## 変更内容

`CreamSymbolProcessor` (現在は `process/CopyToChildrenProcessor.kt`) の `!isSealed()` ブランチを修正し、隣接する `SealedCopy` プロセッサと同じトーンで、対象クラスの完全修飾名と `classKind` を示し、実行可能な solution を出力するようにしました。

## エラーメッセージの before / after

Before:
```text
Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but false

Solution: 
  
```

After:
```text
Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.NotSealed is not sealed (classKind: CLASS).

Solution: 
  Make diag.NotSealed a sealed class/interface.
```

## テスト

- `cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.nonSealedClass.output.md`
- `cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest.dataClass.output.md`

上記のスナップショットを `-Dcream.snapshot.update=true` で再生成し、`./gradlew :cream-ksp:test` がパスすることを確認済みです。

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)