### PR TITLE
fix: remove dangling comma in generated KDoc usage example (#69)

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CombineExample.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CombineExample.kt
@@ -23,26 +23,29 @@ internal fun KDocWriter.appendCombineAutoDescription(
  * ```
  * val a = A(...)
  * val b = B(...)
- * val target = a.funName(b = B(...)<extraArgs>)
+ * val target = a.funName(b = B(...), <extraArgs>)
  * ```
  *
- * [extraArgs] is appended inside the call parentheses after the source params — e.g.
- * `", property = value"` for the "Override property values" example.
+ * [extraArgs] are appended inside the call parentheses after the source params — e.g.
+ * `listOf("property = value")` for the "Override property values" example. The source
+ * params and extra args are comma-joined together, so no dangling comma is produced when
+ * either side is empty (e.g. a single source with no extra args -> `funName()`).
  */
 internal fun combineExampleBody(
     sources: List<KSClassDeclaration>,
     funName: String,
-    extraArgs: String = "",
+    extraArgs: List<String> = emptyList(),
 ): String {
     val primarySource = sources.first()
     val otherSourceParams =
-        sources.drop(1).joinToString(", ") {
+        sources.drop(1).map {
             "${it.lowerCamelName()} = ${it.simpleName.asString()}(...)"
         }
+    val callArgs = (otherSourceParams + extraArgs).joinToString(", ")
     return buildString {
         sources.forEach { source ->
             appendLine("val ${source.lowerCamelName()} = ${source.simpleName.asString()}(...)")
         }
-        append("val target = ${primarySource.lowerCamelName()}.$funName($otherSourceParams$extraArgs)")
+        append("val target = ${primarySource.lowerCamelName()}.$funName($callArgs)")
     }
 }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CombineToClass.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CombineToClass.kt
@@ -242,7 +242,7 @@ private fun BufferedWriter.appendCombineToClassKDoc(
             appendExample("Example: Basic", combineExampleBody(sources, funName))
             appendExample(
                 "Example: Override property values",
-                combineExampleBody(sources, funName, extraArgs = ", property = value"),
+                combineExampleBody(sources, funName, extraArgs = listOf("property = value")),
             )
         },
     )

--- a/cream-ksp/src/test/resources/snapshots/KDocPatternsSnapshotTest.CombineToLastWins.md
+++ b/cream-ksp/src/test/resources/snapshots/KDocPatternsSnapshotTest.CombineToLastWins.md
@@ -25,7 +25,7 @@ import me.tbsten.cream.*
  * 
  * ```kt
  * val serverState = ServerState(...)
- * val target = serverState.copyToMergedState(, property = value)
+ * val target = serverState.copyToMergedState(property = value)
  * ```
  * 
  * 

--- a/cream-ksp/src/test/resources/snapshots/KDocPatternsSnapshotTest.NumberedList.md
+++ b/cream-ksp/src/test/resources/snapshots/KDocPatternsSnapshotTest.NumberedList.md
@@ -27,7 +27,7 @@ import me.tbsten.cream.*
  * 
  * ```kt
  * val cartState = CartState(...)
- * val target = cartState.copyToCheckout(, property = value)
+ * val target = cartState.copyToCheckout(property = value)
  * ```
  * 
  * 


### PR DESCRIPTION
## 概要

生成される KDoc の usage example が不正な Kotlin (先頭カンマ) を出力していた問題を修正します。

`@CombineTo` の "Override property values" 例で、source が 1 つだけの場合に
呼び出し引数の先頭にカンマが付いてしまっていました。

## Before / After

Before:
```
 * val target = serverState.copyToMergedState(, property = value)
```

After:
```
 * val target = serverState.copyToMergedState(property = value)
```

## 原因と修正

`combineExampleBody` は `extraArgs` を `", property = value"` のように
**先頭カンマ付きの文字列**として、空になりうる source param 文字列に無条件で連結していました。
source が 1 つだけ (= 他の source param が空) のとき、`funName(, property = value)` という
dangling comma が発生していました。

修正として `extraArgs` を先頭カンマなしの `List<String>` に変更し、
source param と extra args をまとめて `", "` で join するようにしました。
これにより引数が 0 / 1 / N 個のいずれの場合でも有効な Kotlin を生成します。

## テスト

- snapshot を再生成 (`-Dcream.snapshot.update=true`)
- フラグなしの `./gradlew :cream-ksp:test` が PASS することを確認
- リポジトリ全体を `(, ` で grep し、他に同じパターンが残っていないことを確認

再生成された snapshot:
- `cream-ksp/src/test/resources/snapshots/KDocPatternsSnapshotTest.CombineToLastWins.md`
- `cream-ksp/src/test/resources/snapshots/KDocPatternsSnapshotTest.NumberedList.md`

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)