### PR TITLE
Migrate test suite from kotlin.test to kotest FunSpec

### DIFF
--- a/.claude/rules/ksp-test.md
+++ b/.claude/rules/ksp-test.md
@@ -10,6 +10,12 @@ paths:
 (`dev.zacsweers.kctfork:core` / `:ksp`) を使った JVM 専用の end-to-end テストを置いている。
 マルチプラットフォームの `test/` モジュールでは表現しにくいシナリオを補完する。
 
+テストは [kotest](https://kotest.io) の `FunSpec` スタイルで書く
+(`internal class XxxTest : FunSpec({ test("...") { ... } })`)。assert は kotest matcher を使い、
+**語順は `actual shouldBe expected`** (kotlin.test の `assertEquals(expected, actual)` とは逆)。
+失敗時メッセージは `withClue(message) { ... }` で保持する。cream-ksp は JVM のみなので
+`kotest-runner-junit5` + `tasks.test { useJUnitPlatform() }` で動く (KSP も io.kotest プラグインも不要)。
+
 ## レイアウト
 
 - `testing/` — テスト基盤
@@ -21,8 +27,8 @@ paths:
   - `SnapshotAssertion.kt` — golden 比較ヘルパー
 - `diagnostic/` — 不正な annotation 使用や不正な KSP option 値に対して、`InvalidCreamUsageException` /
   `InvalidCreamOptionException` がコンパイル失敗としてメッセージに乗ることを assert する。
-  exit code を `assertNotEquals(OK, ...)` で確認したうえで、`normalizedCompilerOutput()` を
-  `*.output.md` の golden と突き合わせて error message 全文を固定化する
+  exit code を `result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK` で確認したうえで、
+  `normalizedCompilerOutput()` を `*.output.md` の golden と突き合わせて error message 全文を固定化する
 - `options/` — `cream.copyFunNamePrefix` / `cream.copyFunNamingStrategy` / `cream.escapeDot`
   / `cream.notCopyToObject` のあらゆる値を end-to-end で走らせ、生成された関数名を検証
 - `snapshot/` — 代表的な成功シナリオ (basic `@CopyTo`, sealed `@CopyToChildren`, generic `@CopyFrom`,
@@ -36,17 +42,21 @@ golden ファイルは `*.md` (Markdown)。すべての captured 値は **facet*
 として書き出される:
 
 ```kt
-val source = """
-    @CopyTo(Target::class)
-    data class Source(...)
-""".trimIndent()
-val result = compileWithCream(source)
+internal class MyTest : FunSpec({
+    test("scenario") {
+        val source = """
+            @CopyTo(Target::class)
+            data class Source(...)
+        """.trimIndent()
+        val result = compileWithCream(source)
 
-assertMatchesSnapshot("MyTest.scenario") {
-    "Generated" facetOf result.generatedSourceText()            // default lang = "kt"
-    "Input" facetOf source                                      // default lang = "kt"
-    facet("Compiler messages", result.messages, lang = "text")  // 明示で別言語
-}
+        assertMatchesSnapshot("MyTest.scenario") {
+            "Generated" facetOf result.generatedSourceText()            // default lang = "kt"
+            "Input" facetOf source                                      // default lang = "kt"
+            facet("Compiler messages", result.messages, lang = "text")  // 明示で別言語
+        }
+    }
+})
 ```
 
 infix `facetOf` は default `lang = "kt"`。違う言語が必要な facet は
@@ -103,7 +113,7 @@ snapshot 本文に backtick run (例: cream が出す KDoc の ` ```kt ... ``` `
 
 stack frame は Gradle / JUnit / KSP / cream 自身の line 変更や `... NN more` の depth count
 で簡単にずれるため、diagnostic snapshot で固定化しているのは「error message 本文」だけ。
-特定 frame の存在を assert したいなら、snapshot とは別に `messages.contains(...)` を併用する。
+特定 frame の存在を assert したいなら、snapshot とは別に `result.messages shouldContain "..."` を併用する。
 
 ## 運用
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,13 @@ cream/
 
 ## Testing Approach
 
+All tests use the [kotest](https://kotest.io) `FunSpec` style (`class XxxTest : FunSpec({ test("...") { ... } })`)
+with kotest matchers (`actual shouldBe expected`, `shouldBeInstanceOf`, `shouldContain`, …). The JVM
+(`cream-ksp`, `test` jvm) and Android unit-test tasks run via the JUnit Platform (`kotest-runner-junit5`
++ `useJUnitPlatform()`); native/`commonTest` runs via `kotest-framework-engine` and the `io.kotest`
+KSP plugin (which generates a per-target spec launcher). Note for native: spec classes must have unique
+simple names across packages on older kotest, but 6.1.x emits aliased imports so duplicates are fine.
+
 ### Integration Tests (`test/` module)
 
 The `test/` module uses KSP to generate code from test data and verifies the generated functions work correctly:
@@ -179,15 +186,14 @@ data class Source(val prop: String)
 data class Target(val prop: String, val extra: Int)
 
 // test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/CopyToTest.kt
-class CopyToTest {
-    @Test
-    fun testCopyFunction() {
+class CopyToTest : FunSpec({
+    test("testCopyFunction") {
         val source = Source("value")
         val target = source.copyToTarget(extra = 42)
-        assertEquals("value", target.prop)
-        assertEquals(42, target.extra)
+        target.prop shouldBe "value"
+        target.extra shouldBe 42
     }
-}
+})
 ```
 
 ### Unit Tests (`cream-ksp/src/test/`)

--- a/cream-ksp/build.gradle.kts
+++ b/cream-ksp/build.gradle.kts
@@ -19,13 +19,15 @@ dependencies {
     implementation(project(":cream-ksp:shared"))
     implementation(libs.kspApi)
     implementation(kotlin("reflect"))
-    testImplementation(libs.kotlinTest)
+    testImplementation(libs.kotest)
+    testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
     testImplementation(libs.kctforkCore)
     testImplementation(libs.kctforkKsp)
 }
 
 tasks.named<Test>("test") {
+    useJUnitPlatform()
     // Allow snapshot regeneration via `-Dcream.snapshot.update=true` on the gradle command line.
     System.getProperty("cream.snapshot.update")?.let {
         systemProperty("cream.snapshot.update", it)

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToChildrenDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToChildrenDiagnosticTest.kt
@@ -1,85 +1,78 @@
 package me.tbsten.cream.ksp.diagnostic
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
-internal class CopyToChildrenDiagnosticTest {
-    @Test
-    fun `non-sealed class with @CopyToChildren fails compilation`() {
-        val source =
-            """
-            package diag
-
-            import me.tbsten.cream.CopyToChildren
-
-            @CopyToChildren
-            class NotSealed(val prop: String)
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("CopyToChildrenDiagnosticTest.nonSealedClass.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `data class with @CopyToChildren fails compilation`() {
-        val source =
-            """
-            package diag
-
-            import me.tbsten.cream.CopyToChildren
-
-            @CopyToChildren
-            data class JustData(val prop: String)
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("CopyToChildrenDiagnosticTest.dataClass.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `sealed interface with @CopyToChildren compiles successfully`() {
-        val result =
-            compileWithCream(
+internal class CopyToChildrenDiagnosticTest :
+    FunSpec({
+        test("non-sealed class with @CopyToChildren fails compilation") {
+            val source =
                 """
                 package diag
 
                 import me.tbsten.cream.CopyToChildren
 
                 @CopyToChildren
-                sealed interface State {
-                    val id: String
+                class NotSealed(val prop: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
 
-                    data class Loading(override val id: String) : State
-                    data class Loaded(override val id: String, val value: Int) : State
-                }
-                """.trimIndent(),
-            )
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("CopyToChildrenDiagnosticTest.nonSealedClass.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
+        }
 
-        assertEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}",
-        )
-    }
-}
+        test("data class with @CopyToChildren fails compilation") {
+            val source =
+                """
+                package diag
+
+                import me.tbsten.cream.CopyToChildren
+
+                @CopyToChildren
+                data class JustData(val prop: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("CopyToChildrenDiagnosticTest.dataClass.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
+        }
+
+        test("sealed interface with @CopyToChildren compiles successfully") {
+            val result =
+                compileWithCream(
+                    """
+                    package diag
+
+                    import me.tbsten.cream.CopyToChildren
+
+                    @CopyToChildren
+                    sealed interface State {
+                        val id: String
+
+                        data class Loading(override val id: String) : State
+                        data class Loaded(override val id: String, val value: Int) : State
+                    }
+                    """.trimIndent(),
+                )
+
+            withClue("Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToDiagnosticTest.kt
@@ -1,90 +1,83 @@
 package me.tbsten.cream.ksp.diagnostic
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldNotBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
-import kotlin.test.Test
-import kotlin.test.assertNotEquals
 
-internal class CopyToDiagnosticTest {
-    @Test
-    fun `@CopyTo targeting an enum class fails compilation`() {
-        val source =
-            """
-            package diag
+internal class CopyToDiagnosticTest :
+    FunSpec({
+        test("@CopyTo targeting an enum class fails compilation") {
+            val source =
+                """
+                package diag
 
-            import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.CopyTo
 
-            enum class Color { RED, BLUE }
+                enum class Color { RED, BLUE }
 
-            @CopyTo(Color::class)
-            data class Source(val name: String)
-            """.trimIndent()
-        val result = compileWithCream(source)
+                @CopyTo(Color::class)
+                data class Source(val name: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
 
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("CopyToDiagnosticTest.enumTarget.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `@CopyTo targeting a non-sealed interface fails compilation`() {
-        val source =
-            """
-            package diag
-
-            import me.tbsten.cream.CopyTo
-
-            interface Plain {
-                val id: String
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
             }
-
-            @CopyTo(Plain::class)
-            data class Source(val id: String)
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("CopyToDiagnosticTest.nonSealedInterface.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf source
+            assertMatchesSnapshot("CopyToDiagnosticTest.enumTarget.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
         }
-    }
 
-    @Test
-    fun `@CopyTo targeting an annotation class fails compilation`() {
-        val source =
-            """
-            package diag
+        test("@CopyTo targeting a non-sealed interface fails compilation") {
+            val source =
+                """
+                package diag
 
-            import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.CopyTo
 
-            annotation class Marker
+                interface Plain {
+                    val id: String
+                }
 
-            @CopyTo(Marker::class)
-            data class Source(val name: String)
-            """.trimIndent()
-        val result = compileWithCream(source)
+                @CopyTo(Plain::class)
+                data class Source(val id: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
 
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("CopyToDiagnosticTest.annotationTarget.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf source
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("CopyToDiagnosticTest.nonSealedInterface.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
         }
-    }
-}
+
+        test("@CopyTo targeting an annotation class fails compilation") {
+            val source =
+                """
+                package diag
+
+                import me.tbsten.cream.CopyTo
+
+                annotation class Marker
+
+                @CopyTo(Marker::class)
+                data class Source(val name: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("CopyToDiagnosticTest.annotationTarget.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/OptionsDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/OptionsDiagnosticTest.kt
@@ -1,76 +1,69 @@
 package me.tbsten.cream.ksp.diagnostic
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
-internal class OptionsDiagnosticTest {
-    private val validSource: String =
-        """
-        package diag
+internal class OptionsDiagnosticTest :
+    FunSpec({
+        val validSource: String =
+            """
+            package diag
 
-        import me.tbsten.cream.CopyTo
+            import me.tbsten.cream.CopyTo
 
-        @CopyTo(Target::class)
-        data class Source(val prop: String)
+            @CopyTo(Target::class)
+            data class Source(val prop: String)
 
-        data class Target(val prop: String)
-        """.trimIndent()
+            data class Target(val prop: String)
+            """.trimIndent()
 
-    @Test
-    fun `invalid copyFunNamingStrategy fails compilation with helpful message`() {
-        val result =
-            compileWithCream(
-                validSource,
-                options = mapOf("cream.copyFunNamingStrategy" to "not-a-strategy"),
-            )
+        test("invalid copyFunNamingStrategy fails compilation with helpful message") {
+            val result =
+                compileWithCream(
+                    validSource,
+                    options = mapOf("cream.copyFunNamingStrategy" to "not-a-strategy"),
+                )
 
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf validSource
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf validSource
+            }
         }
-    }
 
-    @Test
-    fun `invalid escapeDot fails compilation with helpful message`() {
-        val result =
-            compileWithCream(
-                validSource,
-                options = mapOf("cream.escapeDot" to "not-an-escape"),
-            )
+        test("invalid escapeDot fails compilation with helpful message") {
+            val result =
+                compileWithCream(
+                    validSource,
+                    options = mapOf("cream.escapeDot" to "not-an-escape"),
+                )
 
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("OptionsDiagnosticTest.invalidEscapeDot.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf validSource
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("OptionsDiagnosticTest.invalidEscapeDot.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf validSource
+            }
         }
-    }
 
-    @Test
-    fun `valid copyFunNamingStrategy value compiles successfully`() {
-        val result =
-            compileWithCream(
-                validSource,
-                options = mapOf("cream.copyFunNamingStrategy" to "full-name"),
-            )
+        test("valid copyFunNamingStrategy value compiles successfully") {
+            val result =
+                compileWithCream(
+                    validSource,
+                    options = mapOf("cream.copyFunNamingStrategy" to "full-name"),
+                )
 
-        assertEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}",
-        )
-    }
-}
+            withClue("Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/SealedCopyDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/SealedCopyDiagnosticTest.kt
@@ -1,122 +1,111 @@
 package me.tbsten.cream.ksp.diagnostic
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldNotBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
-internal class SealedCopyDiagnosticTest {
-    @Test
-    fun `object subtype under default ERROR strategy fails compilation`() {
-        val source =
-            """
-            package diag.sealedCopy
+internal class SealedCopyDiagnosticTest :
+    FunSpec({
+        test("object subtype under default ERROR strategy fails compilation") {
+            val source =
+                """
+                package diag.sealedCopy
 
-            import me.tbsten.cream.SealedCopy
+                import me.tbsten.cream.SealedCopy
 
-            @SealedCopy
-            sealed interface MyState {
-                val name: String
+                @SealedCopy
+                sealed interface MyState {
+                    val name: String
 
-                data class Loading(override val name: String) : MyState
-                data object Empty : MyState { override val name: String = "" }
+                    data class Loading(override val name: String) : MyState
+                    data object Empty : MyState { override val name: String = "" }
+                }
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
             }
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("SealedCopyDiagnosticTest.objectErrorDefault.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `non-data class without compatible copy under default ERROR strategy fails compilation`() {
-        val source =
-            """
-            package diag.sealedCopy
-
-            import me.tbsten.cream.SealedCopy
-
-            @SealedCopy
-            sealed interface MyState {
-                val name: String
-
-                data class Loading(override val name: String) : MyState
-                class Frozen(override val name: String) : MyState
+            assertMatchesSnapshot("SealedCopyDiagnosticTest.objectErrorDefault.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
             }
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("SealedCopyDiagnosticTest.missingCopy.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf source
         }
-    }
 
-    @Test
-    fun `missing-copy diagnostic names 'copy' even when funName is customized`() {
-        val source =
-            """
-            package diag.sealedCopy
+        test("non-data class without compatible copy under default ERROR strategy fails compilation") {
+            val source =
+                """
+                package diag.sealedCopy
 
-            import me.tbsten.cream.SealedCopy
+                import me.tbsten.cream.SealedCopy
 
-            @SealedCopy(funName = "updated")
-            sealed interface MyState {
-                val name: String
+                @SealedCopy
+                sealed interface MyState {
+                    val name: String
 
-                data class Loading(override val name: String) : MyState
-                class Frozen(override val name: String) : MyState
+                    data class Loading(override val name: String) : MyState
+                    class Frozen(override val name: String) : MyState
+                }
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
             }
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("SealedCopyDiagnosticTest.missingCopyCustomFunName.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf source
+            assertMatchesSnapshot("SealedCopyDiagnosticTest.missingCopy.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
         }
-    }
 
-    @Test
-    fun `non-sealed class with @SealedCopy fails compilation`() {
-        val source =
-            """
-            package diag.sealedCopy
+        test("missing-copy diagnostic names 'copy' even when funName is customized") {
+            val source =
+                """
+                package diag.sealedCopy
 
-            import me.tbsten.cream.SealedCopy
+                import me.tbsten.cream.SealedCopy
 
-            @SealedCopy
-            class NotSealed(val name: String)
-            """.trimIndent()
-        val result = compileWithCream(source)
+                @SealedCopy(funName = "updated")
+                sealed interface MyState {
+                    val name: String
 
-        assertNotEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should fail. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot("SealedCopyDiagnosticTest.nonSealedClass.output") {
-            facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
-            "Input" facetOf source
+                    data class Loading(override val name: String) : MyState
+                    class Frozen(override val name: String) : MyState
+                }
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("SealedCopyDiagnosticTest.missingCopyCustomFunName.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
         }
-    }
-}
+
+        test("non-sealed class with @SealedCopy fails compilation") {
+            val source =
+                """
+                package diag.sealedCopy
+
+                import me.tbsten.cream.SealedCopy
+
+                @SealedCopy
+                class NotSealed(val name: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("SealedCopyDiagnosticTest.nonSealedClass.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/CopyFunNamePrefixOptionTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/CopyFunNamePrefixOptionTest.kt
@@ -1,71 +1,72 @@
 package me.tbsten.cream.ksp.options
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
-internal class CopyFunNamePrefixOptionTest {
-    private val sampleSource: String =
-        """
-        package opts.prefix
+internal class CopyFunNamePrefixOptionTest :
+    FunSpec({
+        val sampleSource: String =
+            """
+            package opts.prefix
 
-        import me.tbsten.cream.CopyTo
+            import me.tbsten.cream.CopyTo
 
-        @CopyTo(Target::class)
-        data class Source(val prop: String)
+            @CopyTo(Target::class)
+            data class Source(val prop: String)
 
-        data class Target(val prop: String)
-        """.trimIndent()
+            data class Target(val prop: String)
+            """.trimIndent()
 
-    @Test
-    fun `default prefix copyTo is used when option is not set`() {
-        val result = compileWithCream(sampleSource)
+        test("default prefix copyTo is used when option is not set") {
+            val result = compileWithCream(sampleSource)
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("copyToTarget"),
-            "Generated source should contain 'copyToTarget'. Actual:\n$generated",
-        )
-    }
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("Generated source should contain 'copyToTarget'. Actual:\n$generated") {
+                generated shouldContain "copyToTarget"
+            }
+        }
 
-    @Test
-    fun `prefix transitionTo is used when configured`() {
-        val result =
-            compileWithCream(
-                sampleSource,
-                options = mapOf("cream.copyFunNamePrefix" to "transitionTo"),
-            )
+        test("prefix transitionTo is used when configured") {
+            val result =
+                compileWithCream(
+                    sampleSource,
+                    options = mapOf("cream.copyFunNamePrefix" to "transitionTo"),
+                )
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("transitionToTarget"),
-            "Generated source should contain 'transitionToTarget'. Actual:\n$generated",
-        )
-        assertFalse(
-            generated.contains("copyToTarget"),
-            "Default prefix should not appear when custom prefix is set. Actual:\n$generated",
-        )
-    }
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("Generated source should contain 'transitionToTarget'. Actual:\n$generated") {
+                generated shouldContain "transitionToTarget"
+            }
+            withClue("Default prefix should not appear when custom prefix is set. Actual:\n$generated") {
+                generated shouldNotContain "copyToTarget"
+            }
+        }
 
-    @Test
-    fun `prefix ending with non-letter does not capitalize target name`() {
-        val result =
-            compileWithCream(
-                sampleSource,
-                options = mapOf("cream.copyFunNamePrefix" to "to_"),
-            )
+        test("prefix ending with non-letter does not capitalize target name") {
+            val result =
+                compileWithCream(
+                    sampleSource,
+                    options = mapOf("cream.copyFunNamePrefix" to "to_"),
+                )
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("to_target"),
-            "Generated source should contain 'to_target' (no capitalization rewrite for underscore-ending prefix). Actual:\n$generated",
-        )
-    }
-}
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("Generated source should contain 'to_target' (no capitalization rewrite for underscore-ending prefix). Actual:\n$generated") {
+                generated shouldContain "to_target"
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/CopyFunNamingStrategyOptionTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/CopyFunNamingStrategyOptionTest.kt
@@ -1,106 +1,108 @@
 package me.tbsten.cream.ksp.options
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
-internal class CopyFunNamingStrategyOptionTest {
-    private val sampleSource: String =
-        """
-        package opts.strategy
+internal class CopyFunNamingStrategyOptionTest :
+    FunSpec({
+        val sampleSource: String =
+            """
+            package opts.strategy
 
-        import me.tbsten.cream.CopyTo
+            import me.tbsten.cream.CopyTo
 
-        @CopyTo(Target::class)
-        data class Source(val prop: String)
+            @CopyTo(Target::class)
+            data class Source(val prop: String)
 
-        data class Target(val prop: String)
-        """.trimIndent()
+            data class Target(val prop: String)
+            """.trimIndent()
 
-    private fun runWithStrategy(strategy: String) =
-        compileWithCream(
-            sampleSource,
-            options = mapOf("cream.copyFunNamingStrategy" to strategy),
-        )
-
-    @Test
-    fun `under-package strategy uses target name relative to package`() {
-        val result = runWithStrategy("under-package")
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        // under-package: "opts.strategy.Target" minus "opts.strategy." = "Target"
-        // escape lower-camel-case: "Target" -> "target"
-        // prefix "copyTo" capitalizes -> "copyToTarget"
-        assertTrue(
-            result.generatedSourceText().contains("copyToTarget"),
-            "Expected 'copyToTarget'. Actual:\n${result.generatedSourceText()}",
-        )
-    }
-
-    @Test
-    fun `simple-name strategy uses target simpleName`() {
-        val result = runWithStrategy("simple-name")
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertTrue(
-            result.generatedSourceText().contains("copyToTarget"),
-            "Expected 'copyToTarget'. Actual:\n${result.generatedSourceText()}",
-        )
-    }
-
-    @Test
-    fun `full-name strategy includes the package in the function name`() {
-        val result = runWithStrategy("full-name")
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        // full-name: "opts.strategy.Target"
-        // escape lower-camel-case: -> "optsStrategyTarget"
-        // prefix capitalizes -> "copyToOptsStrategyTarget"
-        assertTrue(
-            result.generatedSourceText().contains("copyToOptsStrategyTarget"),
-            "Expected 'copyToOptsStrategyTarget'. Actual:\n${result.generatedSourceText()}",
-        )
-    }
-
-    @Test
-    fun `diff strategy uses difference between source and target`() {
-        val result = runWithStrategy("diff")
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        // common prefix "opts.strategy." then S vs T differ -> diff = "Target"
-        // escape lower-camel-case "Target" -> "target"
-        // prefix capitalize -> "copyToTarget"
-        assertTrue(
-            result.generatedSourceText().contains("copyToTarget"),
-            "Expected 'copyToTarget'. Actual:\n${result.generatedSourceText()}",
-        )
-    }
-
-    @Test
-    fun `inner-name strategy drops the leading segment of underPackageName`() {
-        val result =
+        fun runWithStrategy(strategy: String) =
             compileWithCream(
-                """
-                package opts.strategy
-
-                import me.tbsten.cream.CopyTo
-
-                data class Outer(val prop: String) {
-                    @CopyTo(Inner::class)
-                    data class Source(val prop: String)
-
-                    data class Inner(val prop: String)
-                }
-                """.trimIndent(),
-                options = mapOf("cream.copyFunNamingStrategy" to "inner-name"),
+                sampleSource,
+                options = mapOf("cream.copyFunNamingStrategy" to strategy),
             )
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        // inner-name for Outer.Inner: underPackageName "Outer.Inner".split(".") -> ["Outer","Inner"], size>1
-        // subList(1, 2) -> ["Inner"], joinToString(".") -> "Inner"
-        // escape lower-camel-case "Inner" -> "inner"
-        // prefix capitalize -> "copyToInner"
-        assertTrue(
-            result.generatedSourceText().contains("copyToInner"),
-            "Expected 'copyToInner'. Actual:\n${result.generatedSourceText()}",
-        )
-    }
-}
+
+        test("under-package strategy uses target name relative to package") {
+            val result = runWithStrategy("under-package")
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            // under-package: "opts.strategy.Target" minus "opts.strategy." = "Target"
+            // escape lower-camel-case: "Target" -> "target"
+            // prefix "copyTo" capitalizes -> "copyToTarget"
+            withClue("Expected 'copyToTarget'. Actual:\n${result.generatedSourceText()}") {
+                result.generatedSourceText() shouldContain "copyToTarget"
+            }
+        }
+
+        test("simple-name strategy uses target simpleName") {
+            val result = runWithStrategy("simple-name")
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            withClue("Expected 'copyToTarget'. Actual:\n${result.generatedSourceText()}") {
+                result.generatedSourceText() shouldContain "copyToTarget"
+            }
+        }
+
+        test("full-name strategy includes the package in the function name") {
+            val result = runWithStrategy("full-name")
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            // full-name: "opts.strategy.Target"
+            // escape lower-camel-case: -> "optsStrategyTarget"
+            // prefix capitalizes -> "copyToOptsStrategyTarget"
+            withClue("Expected 'copyToOptsStrategyTarget'. Actual:\n${result.generatedSourceText()}") {
+                result.generatedSourceText() shouldContain "copyToOptsStrategyTarget"
+            }
+        }
+
+        test("diff strategy uses difference between source and target") {
+            val result = runWithStrategy("diff")
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            // common prefix "opts.strategy." then S vs T differ -> diff = "Target"
+            // escape lower-camel-case "Target" -> "target"
+            // prefix capitalize -> "copyToTarget"
+            withClue("Expected 'copyToTarget'. Actual:\n${result.generatedSourceText()}") {
+                result.generatedSourceText() shouldContain "copyToTarget"
+            }
+        }
+
+        test("inner-name strategy drops the leading segment of underPackageName") {
+            val result =
+                compileWithCream(
+                    """
+                    package opts.strategy
+
+                    import me.tbsten.cream.CopyTo
+
+                    data class Outer(val prop: String) {
+                        @CopyTo(Inner::class)
+                        data class Source(val prop: String)
+
+                        data class Inner(val prop: String)
+                    }
+                    """.trimIndent(),
+                    options = mapOf("cream.copyFunNamingStrategy" to "inner-name"),
+                )
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            // inner-name for Outer.Inner: underPackageName "Outer.Inner".split(".") -> ["Outer","Inner"], size>1
+            // subList(1, 2) -> ["Inner"], joinToString(".") -> "Inner"
+            // escape lower-camel-case "Inner" -> "inner"
+            // prefix capitalize -> "copyToInner"
+            withClue("Expected 'copyToInner'. Actual:\n${result.generatedSourceText()}") {
+                result.generatedSourceText() shouldContain "copyToInner"
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/EscapeDotOptionTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/EscapeDotOptionTest.kt
@@ -1,85 +1,85 @@
 package me.tbsten.cream.ksp.options
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
-internal class EscapeDotOptionTest {
-    // full-name strategy makes the dotted full FQN show up in the function name,
-    // which lets us observe how each EscapeDot variant rewrites it.
-    private val fullNameSource: String =
-        """
-        package opts.escape
+internal class EscapeDotOptionTest :
+    FunSpec({
+        // full-name strategy makes the dotted full FQN show up in the function name,
+        // which lets us observe how each EscapeDot variant rewrites it.
+        val fullNameSource: String =
+            """
+            package opts.escape
 
-        import me.tbsten.cream.CopyTo
+            import me.tbsten.cream.CopyTo
 
-        @CopyTo(Target::class)
-        data class Source(val prop: String)
+            @CopyTo(Target::class)
+            data class Source(val prop: String)
 
-        data class Target(val prop: String)
-        """.trimIndent()
+            data class Target(val prop: String)
+            """.trimIndent()
 
-    private fun runWithEscape(escape: String) =
-        compileWithCream(
-            fullNameSource,
-            options =
-                mapOf(
-                    "cream.copyFunNamingStrategy" to "full-name",
-                    "cream.escapeDot" to escape,
-                ),
-        )
-
-    @Test
-    fun `lower-camel-case removes dots and capitalizes each segment`() {
-        val result = runWithEscape("lower-camel-case")
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        // "opts.escape.Target" -> "optsEscapeTarget" -> first lower "optsEscapeTarget"
-        // prefix capitalizes -> "copyToOptsEscapeTarget"
-        assertTrue(
-            result.generatedSourceText().contains("copyToOptsEscapeTarget"),
-            "Expected 'copyToOptsEscapeTarget'. Actual:\n${result.generatedSourceText()}",
-        )
-    }
-
-    @Test
-    fun `replace-to-underscore prefixes underscore and substitutes dots`() {
-        val result = runWithEscape("replace-to-underscore")
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        // "opts.escape.Target" -> "_opts_escape_Target"
-        // prefix "copyTo" ends with letter; first char is '_' (non-letter) -> no further capitalization
-        // -> "copyTo_opts_escape_Target"
-        assertTrue(
-            result.generatedSourceText().contains("copyTo_opts_escape_Target"),
-            "Expected 'copyTo_opts_escape_Target'. Actual:\n${result.generatedSourceText()}",
-        )
-    }
-
-    @Test
-    fun `backquote wraps the target name in backticks in generated source`() {
-        // backquote produces the literal substring `copyTo\`Target\`` in the generated function
-        // name. Note that Kotlin currently cannot parse a function declaration whose name has
-        // a non-quoted prefix followed by a backquote-wrapped suffix, so downstream compilation
-        // would fail — this test only verifies the KSP code-generation behavior of the option.
-        val result =
+        fun runWithEscape(escape: String) =
             compileWithCream(
                 fullNameSource,
                 options =
                     mapOf(
-                        "cream.copyFunNamingStrategy" to "simple-name",
-                        "cream.escapeDot" to "backquote",
+                        "cream.copyFunNamingStrategy" to "full-name",
+                        "cream.escapeDot" to escape,
                     ),
             )
-        // simple-name -> "Target"
-        // backquote -> "`Target`"
-        // first char `\`` non-letter -> no capitalize change
-        // -> "copyTo`Target`" (matches CopyFunctionNameTest unit-test expectations)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("copyTo`Target`"),
-            "Expected 'copyTo`Target`' in generated source. Actual:\n$generated",
-        )
-    }
-}
+
+        test("lower-camel-case removes dots and capitalizes each segment") {
+            val result = runWithEscape("lower-camel-case")
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            // "opts.escape.Target" -> "optsEscapeTarget" -> first lower "optsEscapeTarget"
+            // prefix capitalizes -> "copyToOptsEscapeTarget"
+            withClue("Expected 'copyToOptsEscapeTarget'. Actual:\n${result.generatedSourceText()}") {
+                result.generatedSourceText() shouldContain "copyToOptsEscapeTarget"
+            }
+        }
+
+        test("replace-to-underscore prefixes underscore and substitutes dots") {
+            val result = runWithEscape("replace-to-underscore")
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            // "opts.escape.Target" -> "_opts_escape_Target"
+            // prefix "copyTo" ends with letter; first char is '_' (non-letter) -> no further capitalization
+            // -> "copyTo_opts_escape_Target"
+            withClue("Expected 'copyTo_opts_escape_Target'. Actual:\n${result.generatedSourceText()}") {
+                result.generatedSourceText() shouldContain "copyTo_opts_escape_Target"
+            }
+        }
+
+        test("backquote wraps the target name in backticks in generated source") {
+            // backquote produces the literal substring `copyTo\`Target\`` in the generated function
+            // name. Note that Kotlin currently cannot parse a function declaration whose name has
+            // a non-quoted prefix followed by a backquote-wrapped suffix, so downstream compilation
+            // would fail — this test only verifies the KSP code-generation behavior of the option.
+            val result =
+                compileWithCream(
+                    fullNameSource,
+                    options =
+                        mapOf(
+                            "cream.copyFunNamingStrategy" to "simple-name",
+                            "cream.escapeDot" to "backquote",
+                        ),
+                )
+            // simple-name -> "Target"
+            // backquote -> "`Target`"
+            // first char `\`` non-letter -> no capitalize change
+            // -> "copyTo`Target`" (matches CopyFunctionNameTest unit-test expectations)
+            val generated = result.generatedSourceText()
+            withClue("Expected 'copyTo`Target`' in generated source. Actual:\n$generated") {
+                generated shouldContain "copyTo`Target`"
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/NotCopyToObjectOptionTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/NotCopyToObjectOptionTest.kt
@@ -1,54 +1,56 @@
 package me.tbsten.cream.ksp.options
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
-internal class NotCopyToObjectOptionTest {
-    // @CombineTo is the path that actually consults options.notCopyToObject (Transform.kt:94),
-    // so we exercise it here. @CopyToChildren has its own annotation parameter for the same
-    // intent, which is covered by the existing test/ module.
-    private val combineToSource: String =
-        """
-        package opts.notobj
+internal class NotCopyToObjectOptionTest :
+    FunSpec({
+        // @CombineTo is the path that actually consults options.notCopyToObject (Transform.kt:94),
+        // so we exercise it here. @CopyToChildren has its own annotation parameter for the same
+        // intent, which is covered by the existing test/ module.
+        val combineToSource: String =
+            """
+            package opts.notobj
 
-        import me.tbsten.cream.CombineTo
+            import me.tbsten.cream.CombineTo
 
-        @CombineTo(Singleton::class)
-        data class Source(val prop: String)
+            @CombineTo(Singleton::class)
+            data class Source(val prop: String)
 
-        data object Singleton
-        """.trimIndent()
+            data object Singleton
+            """.trimIndent()
 
-    @Test
-    fun `default behavior generates combine function to object target`() {
-        val result = compileWithCream(combineToSource)
+        test("default behavior generates combine function to object target") {
+            val result = compileWithCream(combineToSource)
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("copyToSingleton"),
-            "Default behavior should include 'copyToSingleton' for the data object target. Actual:\n$generated",
-        )
-    }
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("Default behavior should include 'copyToSingleton' for the data object target. Actual:\n$generated") {
+                generated shouldContain "copyToSingleton"
+            }
+        }
 
-    @Test
-    fun `cream notCopyToObject=true suppresses combine function to data object`() {
-        val result =
-            compileWithCream(
-                combineToSource,
-                options = mapOf("cream.notCopyToObject" to "true"),
-            )
+        test("cream notCopyToObject=true suppresses combine function to data object") {
+            val result =
+                compileWithCream(
+                    combineToSource,
+                    options = mapOf("cream.notCopyToObject" to "true"),
+                )
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertFalse(
-            generated.contains("copyToSingleton"),
-            "'copyToSingleton' should be suppressed when cream.notCopyToObject=true. Actual:\n$generated",
-        )
-    }
-}
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("'copyToSingleton' should be suppressed when cream.notCopyToObject=true. Actual:\n$generated") {
+                generated shouldNotContain "copyToSingleton"
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/BasicSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/BasicSnapshotTest.kt
@@ -1,38 +1,41 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
-internal class BasicSnapshotTest {
-    @Test
-    fun `copyTo class generates expected source`() {
-        val source =
-            """
-            package snap.basic
+internal class BasicSnapshotTest :
+    FunSpec({
+        test("copyTo class generates expected source") {
+            val source =
+                """
+                package snap.basic
 
-            import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.CopyTo
 
-            @CopyTo(Target::class)
-            data class Source(
-                val shared: String,
-                val onlyOnSource: Int,
-            )
+                @CopyTo(Target::class)
+                data class Source(
+                    val shared: String,
+                    val onlyOnSource: Int,
+                )
 
-            data class Target(
-                val shared: String,
-                val onlyOnTarget: Boolean,
-            )
-            """.trimIndent()
-        val result = compileWithCream(source)
+                data class Target(
+                    val shared: String,
+                    val onlyOnTarget: Boolean,
+                )
+                """.trimIndent()
+            val result = compileWithCream(source)
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("BasicSnapshotTest.copyTo") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("BasicSnapshotTest.copyTo") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
         }
-    }
-}
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/GenericSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/GenericSnapshotTest.kt
@@ -1,38 +1,41 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
-internal class GenericSnapshotTest {
-    @Test
-    fun `copyFrom with a single type parameter generates expected source`() {
-        val source =
-            """
-            package snap.generic
+internal class GenericSnapshotTest :
+    FunSpec({
+        test("copyFrom with a single type parameter generates expected source") {
+            val source =
+                """
+                package snap.generic
 
-            import me.tbsten.cream.CopyFrom
+                import me.tbsten.cream.CopyFrom
 
-            @CopyFrom(Source::class)
-            data class Target<T>(
-                val value: T,
-                val label: String,
-            )
+                @CopyFrom(Source::class)
+                data class Target<T>(
+                    val value: T,
+                    val label: String,
+                )
 
-            data class Source<T>(
-                val value: T,
-                val label: String,
-            )
-            """.trimIndent()
-        val result = compileWithCream(source)
+                data class Source<T>(
+                    val value: T,
+                    val label: String,
+                )
+                """.trimIndent()
+            val result = compileWithCream(source)
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("GenericSnapshotTest.copyFromGeneric") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("GenericSnapshotTest.copyFromGeneric") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
         }
-    }
-}
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KDocPatternsSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KDocPatternsSnapshotTest.kt
@@ -1,11 +1,12 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 /**
  * Pin every realistic shape of user-supplied KDoc content that cream is expected to
@@ -25,717 +26,691 @@ import kotlin.test.assertEquals
  * intentionally skipped: it would require extending the nested annotation and the
  * rendering pipeline, which is outside the scope of #64.
  */
-internal class KDocPatternsSnapshotTest {
-    private fun runSnapshot(
-        snapshotName: String,
-        sourceCode: String,
-    ) {
-        val result = compileWithCream(sourceCode)
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot(snapshotName) {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf sourceCode
-        }
-    }
-
-    @Test
-    fun `one-liner summary`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.OneLiner",
-            """
-            package snap.kdoc.oneliner
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "Loading から Success への状態遷移。"),
-            )
-            data class Source(val shared: String)
-
-            data class Target(val shared: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `multi-paragraph description`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "KDocPatternsSnapshotTest.MultiParagraph",
-            """
-            package snap.kdoc.multiparagraph
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(
-                    description = $q
-                        フェッチ完了時に Loading から Success へ遷移させる。
-
-                        userName / password は前状態から引き継がれるため、
-                        呼び出し側では新しく取得した data のみ渡せばよい。
-                    $q,
-                ),
-            )
-            data class Source(val userName: String, val password: String)
-
-            data class Target(val userName: String, val password: String, val data: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `do-not-use warning`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/Warning",
-            """
-            package snap.kdoc.warning
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(
-                    description = $q
-                        エラー状態からの復帰には使用しないこと。
-                        その場合は retry() 経由で再フェッチすること。
-                    $q,
-                ),
-            )
-            data class Source(val shared: String)
-
-            data class Target(val shared: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `at-param tags`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "KDocPatternsSnapshotTest.AtParam",
-            """
-            package snap.kdoc.atparam
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(
-                    description = $q
-                        @param data API から取得したアイテム詳細。null 不可。
-                        @param itemId 省略時は遷移元の itemId を引き継ぐ。
-                    $q,
-                ),
-            )
-            data class Source(val itemId: String)
-
-            data class Target(val itemId: String, val data: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `at-return tag`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.AtReturn",
-            """
-            package snap.kdoc.atreturn
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "@return 入力が確定済みになった注文状態。以降は編集不可。"),
-            )
-            data class Source(val shared: String)
-
-            data class Target(val shared: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `at-throws tag on CopyFrom`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/AtThrowsCopyFrom",
-            """
-            package snap.kdoc.atthrowscopyfrom
-
-            import me.tbsten.cream.CopyFrom
-            import me.tbsten.cream.KDoc
-
-            data class RemoteUser(val email: String)
-
-            @CopyFrom(
-                RemoteUser::class,
-                kdoc = KDoc(description = "@throws IllegalArgumentException email が空文字の場合。"),
-            )
-            data class User(val email: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `at-see tag`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/AtSee",
-            """
-            package snap.kdoc.atsee
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "@see copyToLoading 逆方向の遷移にはこちらを使う。"),
-            )
-            data class Source(val shared: String)
-
-            data class Target(val shared: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `at-sample tag`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/AtSample",
-            """
-            package snap.kdoc.atsample
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "@sample com.example.samples.cartSummarySample"),
-            )
-            data class Source(val items: List<String>)
-
-            data class Target(val items: List<String>)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `at-since tag`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/AtSince",
-            """
-            package snap.kdoc.atsince
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "@since 2.3.0 API v2 移行に伴い追加。"),
-            )
-            data class Source(val body: String)
-
-            data class Target(val body: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `inline symbol link`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/InlineSymbolLink",
-            """
-            package snap.kdoc.inlinesymbollink
-
-            import me.tbsten.cream.CopyFrom
-            import me.tbsten.cream.KDoc
-
-            data class Entity(val id: String)
-
-            @CopyFrom(
-                Entity::class,
-                kdoc = KDoc(description = "永続化層の [Entity] からドメインモデルへ変換する。"),
-            )
-            data class DomainModel(val id: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `inline code span`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.InlineCode",
-            """
-            package snap.kdoc.inlinecode
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "`isLoading` は常に `false` に確定する点に注意。"),
-            )
-            data class Source(val isLoading: Boolean)
-
-            data class Target(val isLoading: Boolean)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `description with embedded code fence`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/CodeFenceInDescription",
-            """
-            package snap.kdoc.codefenceindescription
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(
-                    description = $q
-                        使用例:
-                        ${'`'}${'`'}${'`'}kotlin
-                        val next = prev.copyToTarget(answer = "yes")
-                        ${'`'}${'`'}${'`'}
-                    $q,
-                ),
-            )
-            data class Source(val shared: String)
-
-            data class Target(val shared: String, val answer: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `markdown bullet list`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "KDocPatternsSnapshotTest.BulletList",
-            """
-            package snap.kdoc.bulletlist
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(
-                    description = $q
-                        下書きから公開状態へ遷移する。
-
-                        - publishedAt は呼び出し時に必須
-                        - tags は引き継がれる
-                        - reviewerComment は破棄される
-                    $q,
-                ),
-            )
-            data class Source(val tags: List<String>, val reviewerComment: String?)
-
-            data class Target(val tags: List<String>, val publishedAt: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `at-suppress tag`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/AtSuppress",
-            """
-            package snap.kdoc.atsuppress
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "@suppress 内部遷移用。公開ドキュメントには出さない。"),
-            )
-            data class Source(val shared: String)
-
-            data class Target(val shared: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `migration guidance`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/MigrationGuidance",
-            """
-            package snap.kdoc.migrationguidance
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(
-                    description = $q
-                        旧形式への変換。新規コードでは copyToResultV2 を使うこと。
-                        本関数は v3.0 で削除予定。
-                    $q,
-                ),
-            )
-            data class Source(val payload: String)
-
-            data class Target(val payload: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `domain-language identifiers`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/DomainLanguage",
-            """
-            package snap.kdoc.domainlanguage
-
-            import me.tbsten.cream.CopyFrom
-            import me.tbsten.cream.KDoc
-
-            data class 注文Entity(val 税込金額: Int)
-
-            @CopyFrom(
-                注文Entity::class,
-                kdoc = KDoc(description = "DB の注文レコードを業務ドメインの注文集約へ変換する。金額は税込で保持する。"),
-            )
-            data class 注文(val 税込金額: Int)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `external URL link`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/ExternalUrl",
-            """
-            package snap.kdoc.externalurl
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "リクエスト仕様は [API ドキュメント](https://example.com/docs/orders) を参照。"),
-            )
-            data class Source(val amount: Int)
-
-            data class Target(val amount: Int)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `numbered list for CombineTo`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "KDocPatternsSnapshotTest.NumberedList",
-            """
-            package snap.kdoc.numberedlist
-
-            import me.tbsten.cream.CombineTo
-            import me.tbsten.cream.KDoc
-
-            @CombineTo(
-                Checkout::class,
-                kdoc = KDoc(
-                    description = $q
-                        カート確定の手順:
-                        1. CartState と PaymentInfo を用意する
-                        2. cart.copyToCheckout(paymentInfo = ...) を呼ぶ
-                        3. 戻り値を repository.submit() に渡す
-                    $q,
-                ),
-            )
-            data class CartState(val total: Int)
-
-            data class PaymentInfo(val method: String)
-
-            data class Checkout(val total: Int, val method: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `thread or coroutine safety note`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/ThreadSafety",
-            """
-            package snap.kdoc.threadsafety
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "純粋な変換のみで副作用なし。任意のディスパッチャから安全に呼べる。"),
-            )
-            data class Source(val payload: String)
-
-            data class Target(val payload: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `lossy conversion warning`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/LossyConversion",
-            """
-            package snap.kdoc.lossyconversion
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(
-                    description = $q
-                        詳細から要約への変換。
-                        本文 body と添付 attachments は要約側に存在しないため破棄される。
-                    $q,
-                ),
-            )
-            data class Source(val body: String, val attachments: List<String>)
-
-            data class Target(val title: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `performance note`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/PerformanceNote",
-            """
-            package snap.kdoc.performancenote
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "毎回新インスタンスを生成する。高頻度ループ内での呼び出しは避ける。"),
-            )
-            data class Source(val frame: Long)
-
-            data class Target(val frame: Long)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `at-receiver tag`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/AtReceiver",
-            """
-            package snap.kdoc.atreceiver
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "@receiver 承認前の申請。status は Pending である前提。"),
-            )
-            data class Source(val status: String)
-
-            data class Target(val status: String, val approvedBy: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `domain invariant on CopyFrom`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/DomainInvariant",
-            """
-            package snap.kdoc.domaininvariant
-
-            import me.tbsten.cream.CopyFrom
-            import me.tbsten.cream.KDoc
-
-            data class Quote(val amount: Int)
-
-            @CopyFrom(
-                Quote::class,
-                kdoc = KDoc(description = "確定見積から契約を生成する。契約金額は見積金額と必ず一致する（値引きは別途）。"),
-            )
-            data class Contract(val amount: Int)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `CombineTo last-wins ordering`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/CombineToLastWins",
-            """
-            package snap.kdoc.combinetolastwins
-
-            import me.tbsten.cream.CombineTo
-            import me.tbsten.cream.KDoc
-
-            @CombineTo(
-                MergedState::class,
-                kdoc = KDoc(
-                    description = $q
-                        ServerState と LocalEdit を統合する。
-                        同名プロパティは後勝ち（LocalEdit 側）が優先される点に注意。
-                    $q,
-                ),
-            )
-            data class ServerState(val title: String)
-
-            data class LocalEdit(val title: String)
-
-            data class MergedState(val title: String)
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `CopyToChildren shared description`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/CopyToChildrenShared",
-            """
-            package snap.kdoc.copytochildrenshared
-
-            import me.tbsten.cream.CopyToChildren
-            import me.tbsten.cream.KDoc
-
-            @CopyToChildren(
-                kdoc = KDoc(description = "UiState 内の任意の状態へ遷移するための生成関数。遷移元の共通プロパティは引き継がれる。"),
-            )
-            sealed interface UiState {
-                val sessionId: String
-
-                data class Loading(override val sessionId: String) : UiState
-                data class Success(override val sessionId: String, val data: String) : UiState
+internal class KDocPatternsSnapshotTest :
+    FunSpec({
+        fun runSnapshot(
+            snapshotName: String,
+            sourceCode: String,
+        ) {
+            val result = compileWithCream(sourceCode)
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
             }
-            """.trimIndent(),
-        )
-    }
+            assertMatchesSnapshot(snapshotName) {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf sourceCode
+            }
+        }
 
-    @Test
-    fun `CopyMapping for library boundary`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/CopyMappingLibraryBoundary",
-            """
-            package snap.kdoc.copymappinglibraryboundary
+        test("one-liner summary") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.OneLiner",
+                """
+                package snap.kdoc.oneliner
 
-            import me.tbsten.cream.CopyMapping
-            import me.tbsten.cream.KDoc
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
 
-            data class StripeCustomer(val id: String, val email: String)
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "Loading から Success への状態遷移。"),
+                )
+                data class Source(val shared: String)
 
-            data class AppUser(val id: String, val email: String)
-
-            @CopyMapping(
-                StripeCustomer::class,
-                AppUser::class,
-                kdoc = KDoc(description = "外部 SDK の StripeCustomer を自前ドメインへ隔離変換する腐敗防止層。"),
+                data class Target(val shared: String)
+                """.trimIndent(),
             )
-            private object StripeUserMapping
-            """.trimIndent(),
-        )
-    }
+        }
 
-    // Pattern 27 (`@CopyTo.Map(kdoc = ...)`) would need a separate `kdoc` field on
-    // the nested `Map` annotation and a new render path that surfaces the per-property
-    // note in the parent function's KDoc (most naturally as a `@param` line). That is
-    // outside the scope of #64 — left intentionally unimplemented here.
+        test("multi-paragraph description") {
+            val q = "\"\"\""
+            runSnapshot(
+                "KDocPatternsSnapshotTest.MultiParagraph",
+                """
+                package snap.kdoc.multiparagraph
 
-    @Test
-    fun `TODO note for known limitation`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/TodoNote",
-            """
-            package snap.kdoc.todonote
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
 
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(
+                        description = $q
+                            フェッチ完了時に Loading から Success へ遷移させる。
 
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "TODO: ネストした metadata の深いコピーは未対応。浅いコピーになる。"),
+                            userName / password は前状態から引き継がれるため、
+                            呼び出し側では新しく取得した data のみ渡せばよい。
+                        $q,
+                    ),
+                )
+                data class Source(val userName: String, val password: String)
+
+                data class Target(val userName: String, val password: String, val data: String)
+                """.trimIndent(),
             )
-            data class Source(val metadata: Map<String, Any>)
+        }
 
-            data class Target(val metadata: Map<String, Any>)
-            """.trimIndent(),
-        )
-    }
+        test("do-not-use warning") {
+            val q = "\"\"\""
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/Warning",
+                """
+                package snap.kdoc.warning
 
-    @Test
-    fun `CombineFrom multi-source intent on target`() {
-        runSnapshot(
-            "KDocPatternsSnapshotTest.edgeCase/CombineFromIntent",
-            """
-            package snap.kdoc.combinefromintent
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
 
-            import me.tbsten.cream.CombineFrom
-            import me.tbsten.cream.KDoc
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(
+                        description = $q
+                            エラー状態からの復帰には使用しないこと。
+                            その場合は retry() 経由で再フェッチすること。
+                        $q,
+                    ),
+                )
+                data class Source(val shared: String)
 
-            data class LoadingState(val itemId: String)
-
-            data class SuccessAction(val data: String)
-
-            @CombineFrom(
-                LoadingState::class,
-                SuccessAction::class,
-                kdoc = KDoc(description = "進行中の状態とアクション結果を合成して成功状態を組み立てる。lastUpdateAt は呼び出し側で指定する。"),
+                data class Target(val shared: String)
+                """.trimIndent(),
             )
-            data class SuccessState(val itemId: String, val data: String, val lastUpdateAt: String)
-            """.trimIndent(),
-        )
-    }
+        }
 
-    @Test
-    fun `rich multi-tag documentation`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "KDocPatternsSnapshotTest.RichMultiTag",
-            """
-            package snap.kdoc.richmultitag
+        test("at-param tags") {
+            val q = "\"\"\""
+            runSnapshot(
+                "KDocPatternsSnapshotTest.AtParam",
+                """
+                package snap.kdoc.atparam
 
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
 
-            @CopyTo(
-                OrderConfirmed::class,
-                kdoc = KDoc(
-                    description = $q
-                        カート確定処理。在庫確保後にこの遷移を行うこと。
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(
+                        description = $q
+                            @param data API から取得したアイテム詳細。null 不可。
+                            @param itemId 省略時は遷移元の itemId を引き継ぐ。
+                        $q,
+                    ),
+                )
+                data class Source(val itemId: String)
 
-                        @param paidAt 決済完了時刻。
-                        @return 確定済みの注文。以降キャンセルは別フローになる。
-                        @throws IllegalStateException カートが空の場合。
-                        @see copyToOrderDraft
-                        @sample com.example.samples.confirmOrderSample
-                        @since 1.4.0
-                    $q,
-                ),
+                data class Target(val itemId: String, val data: String)
+                """.trimIndent(),
             )
-            data class OrderCart(val items: List<String>)
+        }
 
-            data class OrderConfirmed(val items: List<String>, val paidAt: String)
-            """.trimIndent(),
-        )
-    }
-}
+        test("at-return tag") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.AtReturn",
+                """
+                package snap.kdoc.atreturn
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "@return 入力が確定済みになった注文状態。以降は編集不可。"),
+                )
+                data class Source(val shared: String)
+
+                data class Target(val shared: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("at-throws tag on CopyFrom") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/AtThrowsCopyFrom",
+                """
+                package snap.kdoc.atthrowscopyfrom
+
+                import me.tbsten.cream.CopyFrom
+                import me.tbsten.cream.KDoc
+
+                data class RemoteUser(val email: String)
+
+                @CopyFrom(
+                    RemoteUser::class,
+                    kdoc = KDoc(description = "@throws IllegalArgumentException email が空文字の場合。"),
+                )
+                data class User(val email: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("at-see tag") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/AtSee",
+                """
+                package snap.kdoc.atsee
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "@see copyToLoading 逆方向の遷移にはこちらを使う。"),
+                )
+                data class Source(val shared: String)
+
+                data class Target(val shared: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("at-sample tag") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/AtSample",
+                """
+                package snap.kdoc.atsample
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "@sample com.example.samples.cartSummarySample"),
+                )
+                data class Source(val items: List<String>)
+
+                data class Target(val items: List<String>)
+                """.trimIndent(),
+            )
+        }
+
+        test("at-since tag") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/AtSince",
+                """
+                package snap.kdoc.atsince
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "@since 2.3.0 API v2 移行に伴い追加。"),
+                )
+                data class Source(val body: String)
+
+                data class Target(val body: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("inline symbol link") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/InlineSymbolLink",
+                """
+                package snap.kdoc.inlinesymbollink
+
+                import me.tbsten.cream.CopyFrom
+                import me.tbsten.cream.KDoc
+
+                data class Entity(val id: String)
+
+                @CopyFrom(
+                    Entity::class,
+                    kdoc = KDoc(description = "永続化層の [Entity] からドメインモデルへ変換する。"),
+                )
+                data class DomainModel(val id: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("inline code span") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.InlineCode",
+                """
+                package snap.kdoc.inlinecode
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "`isLoading` は常に `false` に確定する点に注意。"),
+                )
+                data class Source(val isLoading: Boolean)
+
+                data class Target(val isLoading: Boolean)
+                """.trimIndent(),
+            )
+        }
+
+        test("description with embedded code fence") {
+            val q = "\"\"\""
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/CodeFenceInDescription",
+                """
+                package snap.kdoc.codefenceindescription
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(
+                        description = $q
+                            使用例:
+                            ${'`'}${'`'}${'`'}kotlin
+                            val next = prev.copyToTarget(answer = "yes")
+                            ${'`'}${'`'}${'`'}
+                        $q,
+                    ),
+                )
+                data class Source(val shared: String)
+
+                data class Target(val shared: String, val answer: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("markdown bullet list") {
+            val q = "\"\"\""
+            runSnapshot(
+                "KDocPatternsSnapshotTest.BulletList",
+                """
+                package snap.kdoc.bulletlist
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(
+                        description = $q
+                            下書きから公開状態へ遷移する。
+
+                            - publishedAt は呼び出し時に必須
+                            - tags は引き継がれる
+                            - reviewerComment は破棄される
+                        $q,
+                    ),
+                )
+                data class Source(val tags: List<String>, val reviewerComment: String?)
+
+                data class Target(val tags: List<String>, val publishedAt: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("at-suppress tag") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/AtSuppress",
+                """
+                package snap.kdoc.atsuppress
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "@suppress 内部遷移用。公開ドキュメントには出さない。"),
+                )
+                data class Source(val shared: String)
+
+                data class Target(val shared: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("migration guidance") {
+            val q = "\"\"\""
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/MigrationGuidance",
+                """
+                package snap.kdoc.migrationguidance
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(
+                        description = $q
+                            旧形式への変換。新規コードでは copyToResultV2 を使うこと。
+                            本関数は v3.0 で削除予定。
+                        $q,
+                    ),
+                )
+                data class Source(val payload: String)
+
+                data class Target(val payload: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("domain-language identifiers") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/DomainLanguage",
+                """
+                package snap.kdoc.domainlanguage
+
+                import me.tbsten.cream.CopyFrom
+                import me.tbsten.cream.KDoc
+
+                data class 注文Entity(val 税込金額: Int)
+
+                @CopyFrom(
+                    注文Entity::class,
+                    kdoc = KDoc(description = "DB の注文レコードを業務ドメインの注文集約へ変換する。金額は税込で保持する。"),
+                )
+                data class 注文(val 税込金額: Int)
+                """.trimIndent(),
+            )
+        }
+
+        test("external URL link") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/ExternalUrl",
+                """
+                package snap.kdoc.externalurl
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "リクエスト仕様は [API ドキュメント](https://example.com/docs/orders) を参照。"),
+                )
+                data class Source(val amount: Int)
+
+                data class Target(val amount: Int)
+                """.trimIndent(),
+            )
+        }
+
+        test("numbered list for CombineTo") {
+            val q = "\"\"\""
+            runSnapshot(
+                "KDocPatternsSnapshotTest.NumberedList",
+                """
+                package snap.kdoc.numberedlist
+
+                import me.tbsten.cream.CombineTo
+                import me.tbsten.cream.KDoc
+
+                @CombineTo(
+                    Checkout::class,
+                    kdoc = KDoc(
+                        description = $q
+                            カート確定の手順:
+                            1. CartState と PaymentInfo を用意する
+                            2. cart.copyToCheckout(paymentInfo = ...) を呼ぶ
+                            3. 戻り値を repository.submit() に渡す
+                        $q,
+                    ),
+                )
+                data class CartState(val total: Int)
+
+                data class PaymentInfo(val method: String)
+
+                data class Checkout(val total: Int, val method: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("thread or coroutine safety note") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/ThreadSafety",
+                """
+                package snap.kdoc.threadsafety
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "純粋な変換のみで副作用なし。任意のディスパッチャから安全に呼べる。"),
+                )
+                data class Source(val payload: String)
+
+                data class Target(val payload: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("lossy conversion warning") {
+            val q = "\"\"\""
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/LossyConversion",
+                """
+                package snap.kdoc.lossyconversion
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(
+                        description = $q
+                            詳細から要約への変換。
+                            本文 body と添付 attachments は要約側に存在しないため破棄される。
+                        $q,
+                    ),
+                )
+                data class Source(val body: String, val attachments: List<String>)
+
+                data class Target(val title: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("performance note") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/PerformanceNote",
+                """
+                package snap.kdoc.performancenote
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "毎回新インスタンスを生成する。高頻度ループ内での呼び出しは避ける。"),
+                )
+                data class Source(val frame: Long)
+
+                data class Target(val frame: Long)
+                """.trimIndent(),
+            )
+        }
+
+        test("at-receiver tag") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/AtReceiver",
+                """
+                package snap.kdoc.atreceiver
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "@receiver 承認前の申請。status は Pending である前提。"),
+                )
+                data class Source(val status: String)
+
+                data class Target(val status: String, val approvedBy: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("domain invariant on CopyFrom") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/DomainInvariant",
+                """
+                package snap.kdoc.domaininvariant
+
+                import me.tbsten.cream.CopyFrom
+                import me.tbsten.cream.KDoc
+
+                data class Quote(val amount: Int)
+
+                @CopyFrom(
+                    Quote::class,
+                    kdoc = KDoc(description = "確定見積から契約を生成する。契約金額は見積金額と必ず一致する（値引きは別途）。"),
+                )
+                data class Contract(val amount: Int)
+                """.trimIndent(),
+            )
+        }
+
+        test("CombineTo last-wins ordering") {
+            val q = "\"\"\""
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/CombineToLastWins",
+                """
+                package snap.kdoc.combinetolastwins
+
+                import me.tbsten.cream.CombineTo
+                import me.tbsten.cream.KDoc
+
+                @CombineTo(
+                    MergedState::class,
+                    kdoc = KDoc(
+                        description = $q
+                            ServerState と LocalEdit を統合する。
+                            同名プロパティは後勝ち（LocalEdit 側）が優先される点に注意。
+                        $q,
+                    ),
+                )
+                data class ServerState(val title: String)
+
+                data class LocalEdit(val title: String)
+
+                data class MergedState(val title: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("CopyToChildren shared description") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/CopyToChildrenShared",
+                """
+                package snap.kdoc.copytochildrenshared
+
+                import me.tbsten.cream.CopyToChildren
+                import me.tbsten.cream.KDoc
+
+                @CopyToChildren(
+                    kdoc = KDoc(description = "UiState 内の任意の状態へ遷移するための生成関数。遷移元の共通プロパティは引き継がれる。"),
+                )
+                sealed interface UiState {
+                    val sessionId: String
+
+                    data class Loading(override val sessionId: String) : UiState
+                    data class Success(override val sessionId: String, val data: String) : UiState
+                }
+                """.trimIndent(),
+            )
+        }
+
+        test("CopyMapping for library boundary") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/CopyMappingLibraryBoundary",
+                """
+                package snap.kdoc.copymappinglibraryboundary
+
+                import me.tbsten.cream.CopyMapping
+                import me.tbsten.cream.KDoc
+
+                data class StripeCustomer(val id: String, val email: String)
+
+                data class AppUser(val id: String, val email: String)
+
+                @CopyMapping(
+                    StripeCustomer::class,
+                    AppUser::class,
+                    kdoc = KDoc(description = "外部 SDK の StripeCustomer を自前ドメインへ隔離変換する腐敗防止層。"),
+                )
+                private object StripeUserMapping
+                """.trimIndent(),
+            )
+        }
+
+        // Pattern 27 (`@CopyTo.Map(kdoc = ...)`) would need a separate `kdoc` field on
+        // the nested `Map` annotation and a new render path that surfaces the per-property
+        // note in the parent function's KDoc (most naturally as a `@param` line). That is
+        // outside the scope of #64 — left intentionally unimplemented here.
+
+        test("TODO note for known limitation") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/TodoNote",
+                """
+                package snap.kdoc.todonote
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "TODO: ネストした metadata の深いコピーは未対応。浅いコピーになる。"),
+                )
+                data class Source(val metadata: Map<String, Any>)
+
+                data class Target(val metadata: Map<String, Any>)
+                """.trimIndent(),
+            )
+        }
+
+        test("CombineFrom multi-source intent on target") {
+            runSnapshot(
+                "KDocPatternsSnapshotTest.edgeCase/CombineFromIntent",
+                """
+                package snap.kdoc.combinefromintent
+
+                import me.tbsten.cream.CombineFrom
+                import me.tbsten.cream.KDoc
+
+                data class LoadingState(val itemId: String)
+
+                data class SuccessAction(val data: String)
+
+                @CombineFrom(
+                    LoadingState::class,
+                    SuccessAction::class,
+                    kdoc = KDoc(description = "進行中の状態とアクション結果を合成して成功状態を組み立てる。lastUpdateAt は呼び出し側で指定する。"),
+                )
+                data class SuccessState(val itemId: String, val data: String, val lastUpdateAt: String)
+                """.trimIndent(),
+            )
+        }
+
+        test("rich multi-tag documentation") {
+            val q = "\"\"\""
+            runSnapshot(
+                "KDocPatternsSnapshotTest.RichMultiTag",
+                """
+                package snap.kdoc.richmultitag
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    OrderConfirmed::class,
+                    kdoc = KDoc(
+                        description = $q
+                            カート確定処理。在庫確保後にこの遷移を行うこと。
+
+                            @param paidAt 決済完了時刻。
+                            @return 確定済みの注文。以降キャンセルは別フローになる。
+                            @throws IllegalStateException カートが空の場合。
+                            @see copyToOrderDraft
+                            @sample com.example.samples.confirmOrderSample
+                            @since 1.4.0
+                        $q,
+                    ),
+                )
+                data class OrderCart(val items: List<String>)
+
+                data class OrderConfirmed(val items: List<String>, val paidAt: String)
+                """.trimIndent(),
+            )
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KDocSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KDocSnapshotTest.kt
@@ -1,11 +1,12 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 /**
  * End-to-end snapshots for the `kdoc = KDoc(...)` parameter on cream annotations.
@@ -15,140 +16,145 @@ import kotlin.test.assertEquals
  * - Each `examples` entry is appended verbatim (after `trimIndent`) following the auto examples.
  * - Defaults (`KDoc()`) produce no user-content blocks.
  */
-internal class KDocSnapshotTest {
-    @Test
-    fun `copyTo with description and examples renders user kdoc`() {
-        val source =
-            """
-            package snap.kdoc
+internal class KDocSnapshotTest :
+    FunSpec({
+        test("copyTo with description and examples renders user kdoc") {
+            val source =
+                """
+                package snap.kdoc
 
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
 
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(
-                    description = "This function should not be used when the source is in transient state.",
-                    examples = [
-                        ${"\"\"\""}
-                        # Prefer this
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(
+                        description = "This function should not be used when the source is in transient state.",
+                        examples = [
+                            ${"\"\"\""}
+                            # Prefer this
 
-                        ```kt
-                        val target = source.copyToTarget()
-                        ```
-                        ${"\"\"\""},
-                        ${"\"\"\""}
-                        # Avoid this
+                            ```kt
+                            val target = source.copyToTarget()
+                            ```
+                            ${"\"\"\""},
+                            ${"\"\"\""}
+                            # Avoid this
 
-                        ```kt
-                        val target = source.copyToTarget() // do not!
-                        ```
-                        ${"\"\"\""},
-                    ],
-                ),
-            )
-            data class Source(val shared: String)
+                            ```kt
+                            val target = source.copyToTarget() // do not!
+                            ```
+                            ${"\"\"\""},
+                        ],
+                    ),
+                )
+                data class Source(val shared: String)
 
-            data class Target(val shared: String, val extra: Int)
-            """.trimIndent()
-        val result = compileWithCream(source)
+                data class Target(val shared: String, val extra: Int)
+                """.trimIndent()
+            val result = compileWithCream(source)
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("KDocSnapshotTest.copyToDescriptionAndExamples") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `copyTo with only description renders description before auto examples`() {
-        val source =
-            """
-            package snap.kdoc
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(description = "Deprecated. Migrate to TargetV2."),
-            )
-            data class Source(val shared: String)
-
-            data class Target(val shared: String)
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("KDocSnapshotTest.copyToDescriptionOnly") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `copyTo with only examples renders examples after auto examples`() {
-        val source =
-            """
-            package snap.kdoc
-
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.KDoc
-
-            @CopyTo(
-                Target::class,
-                kdoc = KDoc(
-                    examples = [
-                        ${"\"\"\""}
-                        # In a coroutine
-
-                        ```kt
-                        suspend fun reload(source: Source) = source.copyToTarget()
-                        ```
-                        ${"\"\"\""},
-                    ],
-                ),
-            )
-            data class Source(val shared: String)
-
-            data class Target(val shared: String)
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("KDocSnapshotTest.copyToExamplesOnly") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `copyToChildren propagates kdoc to every generated child function`() {
-        val source =
-            """
-            package snap.kdoc
-
-            import me.tbsten.cream.CopyToChildren
-            import me.tbsten.cream.KDoc
-
-            @CopyToChildren(
-                kdoc = KDoc(
-                    description = "Shared note for every State subclass.",
-                ),
-            )
-            sealed interface State {
-                val id: String
-
-                data class Initial(override val id: String) : State
-                data class Loaded(override val id: String, val payload: Int) : State
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
             }
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("KDocSnapshotTest.copyToChildrenSharedDescription") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
+            assertMatchesSnapshot("KDocSnapshotTest.copyToDescriptionAndExamples") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
         }
-    }
-}
+
+        test("copyTo with only description renders description before auto examples") {
+            val source =
+                """
+                package snap.kdoc
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(description = "Deprecated. Migrate to TargetV2."),
+                )
+                data class Source(val shared: String)
+
+                data class Target(val shared: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("KDocSnapshotTest.copyToDescriptionOnly") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
+        }
+
+        test("copyTo with only examples renders examples after auto examples") {
+            val source =
+                """
+                package snap.kdoc
+
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.KDoc
+
+                @CopyTo(
+                    Target::class,
+                    kdoc = KDoc(
+                        examples = [
+                            ${"\"\"\""}
+                            # In a coroutine
+
+                            ```kt
+                            suspend fun reload(source: Source) = source.copyToTarget()
+                            ```
+                            ${"\"\"\""},
+                        ],
+                    ),
+                )
+                data class Source(val shared: String)
+
+                data class Target(val shared: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("KDocSnapshotTest.copyToExamplesOnly") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
+        }
+
+        test("copyToChildren propagates kdoc to every generated child function") {
+            val source =
+                """
+                package snap.kdoc
+
+                import me.tbsten.cream.CopyToChildren
+                import me.tbsten.cream.KDoc
+
+                @CopyToChildren(
+                    kdoc = KDoc(
+                        description = "Shared note for every State subclass.",
+                    ),
+                )
+                sealed interface State {
+                    val id: String
+
+                    data class Initial(override val id: String) : State
+                    data class Loaded(override val id: String, val payload: Int) : State
+                }
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("KDocSnapshotTest.copyToChildrenSharedDescription") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KindMatrixSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/KindMatrixSnapshotTest.kt
@@ -1,119 +1,125 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 /**
  * Snapshot tests covering cross-kind source/target combinations that are not exercised by
  * [BasicSnapshotTest] / [GenericSnapshotTest] / [SealedSnapshotTest] / [ObjectTargetSnapshotTest].
  */
-internal class KindMatrixSnapshotTest {
-    @Test
-    fun `copyTo from data class to data object generates expected source`() {
-        val source =
-            """
-            package snap.kind.classToObject
+internal class KindMatrixSnapshotTest :
+    FunSpec({
+        test("copyTo from data class to data object generates expected source") {
+            val source =
+                """
+                package snap.kind.classToObject
 
-            import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.CopyTo
 
-            @CopyTo(Loaded::class)
-            data class Source(val id: String)
+                @CopyTo(Loaded::class)
+                data class Source(val id: String)
 
-            data object Loaded
-            """.trimIndent()
-        val result = compileWithCream(source)
+                data object Loaded
+                """.trimIndent()
+            val result = compileWithCream(source)
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("KindMatrixSnapshotTest.copyToDataObject") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `copyTo from data class to sealed interface expands across subclasses`() {
-        val source =
-            """
-            package snap.kind.classToSealed
-
-            import me.tbsten.cream.CopyTo
-
-            @CopyTo(State::class)
-            data class Source(val id: String)
-
-            sealed interface State {
-                val id: String
-
-                data class Loading(override val id: String) : State
-                data class Loaded(override val id: String, val payload: Int) : State
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
             }
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("KindMatrixSnapshotTest.copyToSealedInterface") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
+            assertMatchesSnapshot("KindMatrixSnapshotTest.copyToDataObject") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
         }
-    }
 
-    @Test
-    fun `copyFrom basic data class to data class generates expected source`() {
-        val source =
-            """
-            package snap.kind.copyFromBasic
+        test("copyTo from data class to sealed interface expands across subclasses") {
+            val source =
+                """
+                package snap.kind.classToSealed
 
-            import me.tbsten.cream.CopyFrom
+                import me.tbsten.cream.CopyTo
 
-            data class Source(
-                val shared: String,
-                val onlyOnSource: Int,
-            )
+                @CopyTo(State::class)
+                data class Source(val id: String)
 
-            @CopyFrom(Source::class)
-            data class Target(
-                val shared: String,
-                val onlyOnTarget: Boolean,
-            )
-            """.trimIndent()
-        val result = compileWithCream(source)
+                sealed interface State {
+                    val id: String
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("KindMatrixSnapshotTest.copyFromBasic") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `copyToChildren with mixed data class and data object subclasses generates expected source`() {
-        val source =
-            """
-            package snap.kind.sealedMixed
-
-            import me.tbsten.cream.CopyToChildren
-
-            @CopyToChildren
-            sealed interface State {
-                val id: String
-
-                data object Initial : State {
-                    override val id: String get() = "initial"
+                    data class Loading(override val id: String) : State
+                    data class Loaded(override val id: String, val payload: Int) : State
                 }
+                """.trimIndent()
+            val result = compileWithCream(source)
 
-                data class Loaded(override val id: String, val payload: Int) : State
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
             }
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("KindMatrixSnapshotTest.copyToChildrenMixed") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
+            assertMatchesSnapshot("KindMatrixSnapshotTest.copyToSealedInterface") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
         }
-    }
-}
+
+        test("copyFrom basic data class to data class generates expected source") {
+            val source =
+                """
+                package snap.kind.copyFromBasic
+
+                import me.tbsten.cream.CopyFrom
+
+                data class Source(
+                    val shared: String,
+                    val onlyOnSource: Int,
+                )
+
+                @CopyFrom(Source::class)
+                data class Target(
+                    val shared: String,
+                    val onlyOnTarget: Boolean,
+                )
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("KindMatrixSnapshotTest.copyFromBasic") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
+        }
+
+        test("copyToChildren with mixed data class and data object subclasses generates expected source") {
+            val source =
+                """
+                package snap.kind.sealedMixed
+
+                import me.tbsten.cream.CopyToChildren
+
+                @CopyToChildren
+                sealed interface State {
+                    val id: String
+
+                    data object Initial : State {
+                        override val id: String get() = "initial"
+                    }
+
+                    data class Loaded(override val id: String, val payload: Int) : State
+                }
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("KindMatrixSnapshotTest.copyToChildrenMixed") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/ObjectTargetSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/ObjectTargetSnapshotTest.kt
@@ -1,48 +1,52 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
-internal class ObjectTargetSnapshotTest {
-    private val combineToObjectSource: String =
-        """
-        package snap.objtarget
+private val combineToObjectSource: String =
+    """
+    package snap.objtarget
 
-        import me.tbsten.cream.CombineTo
+    import me.tbsten.cream.CombineTo
 
-        @CombineTo(Singleton::class)
-        data class Source(val prop: String)
+    @CombineTo(Singleton::class)
+    data class Source(val prop: String)
 
-        data object Singleton
-        """.trimIndent()
+    data object Singleton
+    """.trimIndent()
 
-    @Test
-    fun `combineTo with object target generates expected source`() {
-        val result = compileWithCream(combineToObjectSource)
+internal class ObjectTargetSnapshotTest :
+    FunSpec({
+        test("combineTo with object target generates expected source") {
+            val result = compileWithCream(combineToObjectSource)
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("ObjectTargetSnapshotTest.combineToObject.default") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf combineToObjectSource
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("ObjectTargetSnapshotTest.combineToObject.default") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf combineToObjectSource
+            }
         }
-    }
 
-    @Test
-    fun `combineTo with object target and notCopyToObject=true generates expected source`() {
-        val result =
-            compileWithCream(
-                combineToObjectSource,
-                options = mapOf("cream.notCopyToObject" to "true"),
-            )
+        test("combineTo with object target and notCopyToObject=true generates expected source") {
+            val result =
+                compileWithCream(
+                    combineToObjectSource,
+                    options = mapOf("cream.notCopyToObject" to "true"),
+                )
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("ObjectTargetSnapshotTest.combineToObject.notCopyToObject") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf combineToObjectSource
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("ObjectTargetSnapshotTest.combineToObject.notCopyToObject") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf combineToObjectSource
+            }
         }
-    }
-}
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/SealedCopySnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/SealedCopySnapshotTest.kt
@@ -1,12 +1,13 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 /**
  * Consolidated success-path snapshots for `@SealedCopy`. Pins one scenario per axis of
@@ -17,394 +18,376 @@ import kotlin.test.assertEquals
  *
  * Diagnostic / error paths live in `SealedCopyDiagnosticTest`.
  */
-internal class SealedCopySnapshotTest {
-    private fun runSnapshot(
-        snapshotName: String,
-        source: String,
-    ) {
-        val result = compileWithCream(source)
+internal class SealedCopySnapshotTest :
+    FunSpec({
+        fun runSnapshot(
+            snapshotName: String,
+            source: String,
+        ) {
+            val result = compileWithCream(source)
 
-        assertEquals(
-            KotlinCompilation.ExitCode.OK,
-            result.exitCode,
-            "Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}",
-        )
-        assertMatchesSnapshot(snapshotName) {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
+            withClue("Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot(snapshotName) {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
         }
-    }
 
-    @Test
-    fun `injects user KDoc supplied via the kdoc parameter`() {
-        val q = "\"\"\""
-        runSnapshot(
-            "SealedCopySnapshotTest.kdoc",
-            """
-            package snap.sealedCopy.kdoc
+        test("injects user KDoc supplied via the kdoc parameter") {
+            val q = "\"\"\""
+            runSnapshot(
+                "SealedCopySnapshotTest.kdoc",
+                """
+                package snap.sealedCopy.kdoc
 
-            import me.tbsten.cream.KDoc
-            import me.tbsten.cream.SealedCopy
+                import me.tbsten.cream.KDoc
+                import me.tbsten.cream.SealedCopy
 
-            @SealedCopy(
-                kdoc = KDoc(
-                    description = "Prefer this over a hand-written when().",
-                    examples = [
-                        $q
-                        # Note
+                @SealedCopy(
+                    kdoc = KDoc(
+                        description = "Prefer this over a hand-written when().",
+                        examples = [
+                            $q
+                            # Note
 
-                        ```kt
-                        val next = state.copy(name = "x")
-                        ```
-                        $q,
-                    ],
-                ),
+                            ```kt
+                            val next = state.copy(name = "x")
+                            ```
+                            $q,
+                        ],
+                    ),
+                )
+                sealed interface MyState {
+                    val name: String
+
+                    data class Loading(override val name: String) : MyState
+                    data class Success(override val name: String, val data: String) : MyState
+                }
+                """.trimIndent(),
             )
-            sealed interface MyState {
-                val name: String
+        }
 
-                data class Loading(override val name: String) : MyState
-                data class Success(override val name: String, val data: String) : MyState
-            }
-            """.trimIndent(),
-        )
-    }
+        test("data class only flat hierarchy") {
+            runSnapshot(
+                "SealedCopySnapshotTest.dataClassOnly",
+                """
+                package snap.sealedCopy
 
-    @Test
-    fun `data class only flat hierarchy`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.dataClassOnly",
-            """
-            package snap.sealedCopy
+                import me.tbsten.cream.SealedCopy
 
-            import me.tbsten.cream.SealedCopy
+                @SealedCopy
+                sealed interface MyState {
+                    val name: String
+                    val count: Int
 
-            @SealedCopy
-            sealed interface MyState {
-                val name: String
-                val count: Int
-
-                data class Loading(override val name: String, override val count: Int) : MyState
-                data class Success(override val name: String, override val count: Int, val data: String) : MyState
-            }
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `funName overrides the generated extension name`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.customExtensionName",
-            """
-            package snap.sealedCopy.funName
-
-            import me.tbsten.cream.SealedCopy
-
-            @SealedCopy(funName = "updated")
-            sealed interface MyState {
-                val name: String
-
-                data class Loading(override val name: String) : MyState
-                data class Success(override val name: String, val data: String) : MyState
-            }
-            """.trimIndent(),
-        )
-    }
-
-    @Test
-    fun `dispatches to a non-data class via a SealedCopy_Map annotated function`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.customFunName",
-            """
-            package snap.sealedCopy.custom
-
-            import me.tbsten.cream.SealedCopy
-
-            @SealedCopy
-            sealed interface MyState {
-                val name: String
-
-                data class Loading(override val name: String) : MyState
-
-                class Custom(override val name: String) : MyState {
-                    @SealedCopy.Map
-                    fun cloneWith(name: String = this.name): Custom = Custom(name)
+                    data class Loading(override val name: String, override val count: Int) : MyState
+                    data class Success(override val name: String, override val count: Int, val data: String) : MyState
                 }
-            }
-            """.trimIndent(),
-        )
-    }
+                """.trimIndent(),
+            )
+        }
 
-    @Test
-    fun `dispatches to a manually written copy on a non-data class`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.manualCopy",
-            """
-            package snap.sealedCopy.custom
+        test("funName overrides the generated extension name") {
+            runSnapshot(
+                "SealedCopySnapshotTest.customExtensionName",
+                """
+                package snap.sealedCopy.funName
 
-            import me.tbsten.cream.SealedCopy
+                import me.tbsten.cream.SealedCopy
 
-            @SealedCopy
-            sealed interface MyState {
-                val name: String
+                @SealedCopy(funName = "updated")
+                sealed interface MyState {
+                    val name: String
 
-                data class Loading(override val name: String) : MyState
-
-                class Manual(override val name: String, val cache: String) : MyState {
-                    fun copy(name: String = this.name): Manual = Manual(name, cache)
+                    data class Loading(override val name: String) : MyState
+                    data class Success(override val name: String, val data: String) : MyState
                 }
-            }
-            """.trimIndent(),
-        )
-    }
+                """.trimIndent(),
+            )
+        }
 
-    @Test
-    fun `forwards type parameters across the generated copy`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.edgeCase/typeParameterPropagation",
-            """
-            package snap.sealedCopy.generic
+        test("dispatches to a non-data class via a SealedCopy_Map annotated function") {
+            runSnapshot(
+                "SealedCopySnapshotTest.customFunName",
+                """
+                package snap.sealedCopy.custom
 
-            import me.tbsten.cream.SealedCopy
+                import me.tbsten.cream.SealedCopy
 
-            @SealedCopy
-            sealed interface Result<T> {
-                val timestamp: Long
+                @SealedCopy
+                sealed interface MyState {
+                    val name: String
 
-                data class Success<T>(override val timestamp: Long, val value: T) : Result<T>
-                data class Failure<T>(override val timestamp: Long, val error: Throwable) : Result<T>
-            }
-            """.trimIndent(),
-        )
-    }
+                    data class Loading(override val name: String) : MyState
 
-    @Test
-    fun `keeps subtype type arguments when copying a property of the type parameter`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.edgeCase/genericProperty",
-            """
-            package snap.sealedCopy.genericProp
+                    class Custom(override val name: String) : MyState {
+                        @SealedCopy.Map
+                        fun cloneWith(name: String = this.name): Custom = Custom(name)
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
 
-            import me.tbsten.cream.SealedCopy
+        test("dispatches to a manually written copy on a non-data class") {
+            runSnapshot(
+                "SealedCopySnapshotTest.manualCopy",
+                """
+                package snap.sealedCopy.custom
 
-            @SealedCopy
-            sealed interface Box<T> {
-                val value: T
+                import me.tbsten.cream.SealedCopy
 
-                data class Filled<T>(override val value: T, val label: String) : Box<T>
-                data class Plain<T>(override val value: T) : Box<T>
-            }
-            """.trimIndent(),
-        )
-    }
+                @SealedCopy
+                sealed interface MyState {
+                    val name: String
 
-    @Test
-    fun `forwards multiple type parameters into each subtype branch`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.edgeCase/multipleTypeParameters",
-            """
-            package snap.sealedCopy.multiGeneric
+                    data class Loading(override val name: String) : MyState
 
-            import me.tbsten.cream.SealedCopy
+                    class Manual(override val name: String, val cache: String) : MyState {
+                        fun copy(name: String = this.name): Manual = Manual(name, cache)
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
 
-            @SealedCopy
-            sealed interface Entry<K, V> {
-                val key: K
-                val value: V
+        test("forwards type parameters across the generated copy") {
+            runSnapshot(
+                "SealedCopySnapshotTest.edgeCase/typeParameterPropagation",
+                """
+                package snap.sealedCopy.generic
 
-                data class Impl<K, V>(override val key: K, override val value: V, val tag: String) : Entry<K, V>
-            }
-            """.trimIndent(),
-        )
-    }
+                import me.tbsten.cream.SealedCopy
 
-    @Test
-    fun `covariant out type parameter is preserved`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.edgeCase/covariantOutTypeParameter",
-            """
-            package snap.sealedCopy.cov
+                @SealedCopy
+                sealed interface Result<T> {
+                    val timestamp: Long
 
-            import me.tbsten.cream.SealedCopy
+                    data class Success<T>(override val timestamp: Long, val value: T) : Result<T>
+                    data class Failure<T>(override val timestamp: Long, val error: Throwable) : Result<T>
+                }
+                """.trimIndent(),
+            )
+        }
 
-            @SealedCopy
-            sealed interface Box<out T> {
-                val value: T
+        test("keeps subtype type arguments when copying a property of the type parameter") {
+            runSnapshot(
+                "SealedCopySnapshotTest.edgeCase/genericProperty",
+                """
+                package snap.sealedCopy.genericProp
 
-                data class Filled<T>(override val value: T) : Box<T>
-                data class Plain<T>(override val value: T) : Box<T>
-            }
-            """.trimIndent(),
-        )
-    }
+                import me.tbsten.cream.SealedCopy
 
-    @Test
-    fun `subtype with an extra type parameter is star-projected`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.edgeCase/subtypeExtraTypeParameter",
-            """
-            package snap.sealedCopy.extra
+                @SealedCopy
+                sealed interface Box<T> {
+                    val value: T
 
-            import me.tbsten.cream.SealedCopy
+                    data class Filled<T>(override val value: T, val label: String) : Box<T>
+                    data class Plain<T>(override val value: T) : Box<T>
+                }
+                """.trimIndent(),
+            )
+        }
 
-            @SealedCopy
-            sealed interface Box<T> {
-                val value: T
+        test("forwards multiple type parameters into each subtype branch") {
+            runSnapshot(
+                "SealedCopySnapshotTest.edgeCase/multipleTypeParameters",
+                """
+                package snap.sealedCopy.multiGeneric
 
-                data class Tagged<T, M>(override val value: T, val meta: M) : Box<T>
-                data class Plain<T>(override val value: T) : Box<T>
-            }
-            """.trimIndent(),
-        )
-    }
+                import me.tbsten.cream.SealedCopy
 
-    @Test
-    fun `flattens a nested generic sealed hierarchy`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.edgeCase/nestedGenericSealed",
-            """
-            package snap.sealedCopy.nestedGen
+                @SealedCopy
+                sealed interface Entry<K, V> {
+                    val key: K
+                    val value: V
 
-            import me.tbsten.cream.SealedCopy
+                    data class Impl<K, V>(override val key: K, override val value: V, val tag: String) : Entry<K, V>
+                }
+                """.trimIndent(),
+            )
+        }
 
-            @SealedCopy
-            sealed interface Outer<T> {
-                val value: T
-            }
+        test("covariant out type parameter is preserved") {
+            runSnapshot(
+                "SealedCopySnapshotTest.edgeCase/covariantOutTypeParameter",
+                """
+                package snap.sealedCopy.cov
 
-            sealed interface Mid<T> : Outer<T>
+                import me.tbsten.cream.SealedCopy
 
-            data class Leaf<T>(override val value: T) : Mid<T>
-            data class Other<T>(override val value: T) : Outer<T>
-            """.trimIndent(),
-        )
-    }
+                @SealedCopy
+                sealed interface Box<out T> {
+                    val value: T
 
-    @Test
-    fun `renders a where clause for multiple upper bounds`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.edgeCase/multipleUpperBounds",
-            """
-            package snap.sealedCopy.bounds
+                    data class Filled<T>(override val value: T) : Box<T>
+                    data class Plain<T>(override val value: T) : Box<T>
+                }
+                """.trimIndent(),
+            )
+        }
 
-            import me.tbsten.cream.SealedCopy
+        test("subtype with an extra type parameter is star-projected") {
+            runSnapshot(
+                "SealedCopySnapshotTest.edgeCase/subtypeExtraTypeParameter",
+                """
+                package snap.sealedCopy.extra
 
-            @SealedCopy
-            sealed interface Box<T> where T : Comparable<T>, T : Any {
-                val value: T
+                import me.tbsten.cream.SealedCopy
 
-                data class Filled<T>(override val value: T) : Box<T> where T : Comparable<T>, T : Any
-            }
-            """.trimIndent(),
-        )
-    }
+                @SealedCopy
+                sealed interface Box<T> {
+                    val value: T
 
-    @Test
-    fun `supports a subtype that fixes the type parameter to a concrete type`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.edgeCase/subtypeFixesTypeParameter",
-            """
-            package snap.sealedCopy.fixed
+                    data class Tagged<T, M>(override val value: T, val meta: M) : Box<T>
+                    data class Plain<T>(override val value: T) : Box<T>
+                }
+                """.trimIndent(),
+            )
+        }
 
-            import me.tbsten.cream.SealedCopy
+        test("flattens a nested generic sealed hierarchy") {
+            runSnapshot(
+                "SealedCopySnapshotTest.edgeCase/nestedGenericSealed",
+                """
+                package snap.sealedCopy.nestedGen
 
-            @SealedCopy
-            sealed interface Box<T> {
-                val value: T
+                import me.tbsten.cream.SealedCopy
 
-                data class Filled<T>(override val value: T) : Box<T>
-                data class IntBox(override val value: Int) : Box<Int>
-            }
-            """.trimIndent(),
-        )
-    }
+                @SealedCopy
+                sealed interface Outer<T> {
+                    val value: T
+                }
 
-    @Test
-    fun `recursively flattens nested sealed into concrete subclasses`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.edgeCase/flattensIntermediateSealed",
-            """
-            package snap.sealedCopy.nested
+                sealed interface Mid<T> : Outer<T>
 
-            import me.tbsten.cream.SealedCopy
+                data class Leaf<T>(override val value: T) : Mid<T>
+                data class Other<T>(override val value: T) : Outer<T>
+                """.trimIndent(),
+            )
+        }
 
-            @SealedCopy
-            sealed interface Animal {
-                val name: String
-            }
+        test("renders a where clause for multiple upper bounds") {
+            runSnapshot(
+                "SealedCopySnapshotTest.edgeCase/multipleUpperBounds",
+                """
+                package snap.sealedCopy.bounds
 
-            sealed interface Human : Animal
+                import me.tbsten.cream.SealedCopy
 
-            data class Man(override val name: String, val beard: Boolean) : Human
-            data class Woman(override val name: String, val hairLength: Int) : Human
-            data class Dog(override val name: String, val breed: String) : Animal
-            """.trimIndent(),
-        )
-    }
+                @SealedCopy
+                sealed interface Box<T> where T : Comparable<T>, T : Any {
+                    val value: T
 
-    @Test
-    fun `RETURN_AS_IS collapses non-copyable branches to this`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.returnAsIs",
-            """
-            package snap.sealedCopy.asIs
+                    data class Filled<T>(override val value: T) : Box<T> where T : Comparable<T>, T : Any
+                }
+                """.trimIndent(),
+            )
+        }
 
-            import me.tbsten.cream.NonCopyableStrategy
-            import me.tbsten.cream.SealedCopy
+        test("supports a subtype that fixes the type parameter to a concrete type") {
+            runSnapshot(
+                "SealedCopySnapshotTest.edgeCase/subtypeFixesTypeParameter",
+                """
+                package snap.sealedCopy.fixed
 
-            @SealedCopy(nonCopyableStrategy = NonCopyableStrategy.RETURN_AS_IS)
-            sealed interface MyState {
-                val name: String
+                import me.tbsten.cream.SealedCopy
 
-                data class Loading(override val name: String) : MyState
-                data object Empty : MyState { override val name: String = "" }
-                class Frozen(override val name: String) : MyState
-            }
-            """.trimIndent(),
-        )
-    }
+                @SealedCopy
+                sealed interface Box<T> {
+                    val value: T
 
-    @Test
-    fun `RETURN_NULL widens the return type to nullable`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.returnNull",
-            """
-            package snap.sealedCopy.returnNull
+                    data class Filled<T>(override val value: T) : Box<T>
+                    data class IntBox(override val value: Int) : Box<Int>
+                }
+                """.trimIndent(),
+            )
+        }
 
-            import me.tbsten.cream.NonCopyableStrategy
-            import me.tbsten.cream.SealedCopy
+        test("recursively flattens nested sealed into concrete subclasses") {
+            runSnapshot(
+                "SealedCopySnapshotTest.edgeCase/flattensIntermediateSealed",
+                """
+                package snap.sealedCopy.nested
 
-            @SealedCopy(nonCopyableStrategy = NonCopyableStrategy.RETURN_NULL)
-            sealed interface MyState {
-                val name: String
+                import me.tbsten.cream.SealedCopy
 
-                data class Loading(override val name: String) : MyState
-                data object Empty : MyState { override val name: String = "" }
-                class Frozen(override val name: String) : MyState
-            }
-            """.trimIndent(),
-        )
-    }
+                @SealedCopy
+                sealed interface Animal {
+                    val name: String
+                }
 
-    @Test
-    fun `stacking multiple SealedCopy emits one function per annotation`() {
-        runSnapshot(
-            "SealedCopySnapshotTest.repeatableMultipleVariants",
-            """
-            package snap.sealedCopy.repeatable
+                sealed interface Human : Animal
 
-            import me.tbsten.cream.NonCopyableStrategy
-            import me.tbsten.cream.SealedCopy
+                data class Man(override val name: String, val beard: Boolean) : Human
+                data class Woman(override val name: String, val hairLength: Int) : Human
+                data class Dog(override val name: String, val breed: String) : Animal
+                """.trimIndent(),
+            )
+        }
 
-            @SealedCopy(funName = "withUpdated", nonCopyableStrategy = NonCopyableStrategy.RETURN_AS_IS)
-            @SealedCopy(funName = "withUpdatedOrNull", nonCopyableStrategy = NonCopyableStrategy.RETURN_NULL)
-            sealed interface MyState {
-                val name: String
+        test("RETURN_AS_IS collapses non-copyable branches to this") {
+            runSnapshot(
+                "SealedCopySnapshotTest.returnAsIs",
+                """
+                package snap.sealedCopy.asIs
 
-                data class Loading(override val name: String) : MyState
-                data object Empty : MyState { override val name: String = "" }
-            }
-            """.trimIndent(),
-        )
-    }
-}
+                import me.tbsten.cream.NonCopyableStrategy
+                import me.tbsten.cream.SealedCopy
+
+                @SealedCopy(nonCopyableStrategy = NonCopyableStrategy.RETURN_AS_IS)
+                sealed interface MyState {
+                    val name: String
+
+                    data class Loading(override val name: String) : MyState
+                    data object Empty : MyState { override val name: String = "" }
+                    class Frozen(override val name: String) : MyState
+                }
+                """.trimIndent(),
+            )
+        }
+
+        test("RETURN_NULL widens the return type to nullable") {
+            runSnapshot(
+                "SealedCopySnapshotTest.returnNull",
+                """
+                package snap.sealedCopy.returnNull
+
+                import me.tbsten.cream.NonCopyableStrategy
+                import me.tbsten.cream.SealedCopy
+
+                @SealedCopy(nonCopyableStrategy = NonCopyableStrategy.RETURN_NULL)
+                sealed interface MyState {
+                    val name: String
+
+                    data class Loading(override val name: String) : MyState
+                    data object Empty : MyState { override val name: String = "" }
+                    class Frozen(override val name: String) : MyState
+                }
+                """.trimIndent(),
+            )
+        }
+
+        test("stacking multiple SealedCopy emits one function per annotation") {
+            runSnapshot(
+                "SealedCopySnapshotTest.repeatableMultipleVariants",
+                """
+                package snap.sealedCopy.repeatable
+
+                import me.tbsten.cream.NonCopyableStrategy
+                import me.tbsten.cream.SealedCopy
+
+                @SealedCopy(funName = "withUpdated", nonCopyableStrategy = NonCopyableStrategy.RETURN_AS_IS)
+                @SealedCopy(funName = "withUpdatedOrNull", nonCopyableStrategy = NonCopyableStrategy.RETURN_NULL)
+                sealed interface MyState {
+                    val name: String
+
+                    data class Loading(override val name: String) : MyState
+                    data object Empty : MyState { override val name: String = "" }
+                }
+                """.trimIndent(),
+            )
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/SealedSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/SealedSnapshotTest.kt
@@ -1,35 +1,38 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
-internal class SealedSnapshotTest {
-    @Test
-    fun `copyToChildren sealed interface generates expected source`() {
-        val source =
-            """
-            package snap.sealed
+internal class SealedSnapshotTest :
+    FunSpec({
+        test("copyToChildren sealed interface generates expected source") {
+            val source =
+                """
+                package snap.sealed
 
-            import me.tbsten.cream.CopyToChildren
+                import me.tbsten.cream.CopyToChildren
 
-            @CopyToChildren
-            sealed interface State {
-                val id: String
+                @CopyToChildren
+                sealed interface State {
+                    val id: String
 
-                data class Loading(override val id: String) : State
-                data class Loaded(override val id: String, val payload: Int) : State
+                    data class Loading(override val id: String) : State
+                    data class Loaded(override val id: String, val payload: Int) : State
+                }
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
             }
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertMatchesSnapshot("SealedSnapshotTest.copyToChildren") {
-            "Generated" facetOf result.generatedSourceText()
-            "Input" facetOf source
+            assertMatchesSnapshot("SealedSnapshotTest.copyToChildren") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
         }
-    }
-}
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/VisibilitySnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/VisibilitySnapshotTest.kt
@@ -1,237 +1,238 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
-internal class VisibilitySnapshotTest {
-    @Test
-    fun `copyTo internal visibility generates internal function`() {
-        val source =
-            """
-            package snap.visibility
+internal class VisibilitySnapshotTest :
+    FunSpec({
+        test("copyTo internal visibility generates internal function") {
+            val source =
+                """
+                package snap.visibility
 
-            import me.tbsten.cream.CopyTo
-            import me.tbsten.cream.CopyVisibility
+                import me.tbsten.cream.CopyTo
+                import me.tbsten.cream.CopyVisibility
 
-            @CopyTo(Target::class, visibility = CopyVisibility.INTERNAL)
-            data class Source(
-                val shared: String,
-            )
+                @CopyTo(Target::class, visibility = CopyVisibility.INTERNAL)
+                data class Source(
+                    val shared: String,
+                )
 
-            data class Target(
-                val shared: String,
-                val extra: Int,
-            )
-            """.trimIndent()
-        val result = compileWithCream(source)
+                data class Target(
+                    val shared: String,
+                    val extra: Int,
+                )
+                """.trimIndent()
+            val result = compileWithCream(source)
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("internal fun"),
-            "expected an internal function, but got:\n$generated",
-        )
-        assertMatchesSnapshot("VisibilitySnapshotTest.copyToInternal") {
-            "Generated" facetOf generated
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `copyTo without visibility keeps public default`() {
-        val source =
-            """
-            package snap.visibility
-
-            import me.tbsten.cream.CopyTo
-
-            @CopyTo(Target::class)
-            data class Source(
-                val shared: String,
-            )
-
-            data class Target(
-                val shared: String,
-                val extra: Int,
-            )
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("public fun"),
-            "expected a public function (inherited default), but got:\n$generated",
-        )
-        assertTrue(
-            !generated.contains("internal fun") && !generated.contains("private fun"),
-            "expected no internal/private modifier in default case, but got:\n$generated",
-        )
-    }
-
-    @Test
-    fun `copyFrom internal visibility generates internal function`() {
-        val source =
-            """
-            package snap.visibility
-
-            import me.tbsten.cream.CopyFrom
-            import me.tbsten.cream.CopyVisibility
-
-            data class Source(
-                val shared: String,
-            )
-
-            @CopyFrom(Source::class, visibility = CopyVisibility.INTERNAL)
-            data class Target(
-                val shared: String,
-                val extra: Int,
-            )
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("internal fun"),
-            "expected an internal function, but got:\n$generated",
-        )
-        assertMatchesSnapshot("VisibilitySnapshotTest.copyFromInternal") {
-            "Generated" facetOf generated
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `copyToChildren internal visibility generates internal functions`() {
-        val source =
-            """
-            package snap.visibility
-
-            import me.tbsten.cream.CopyToChildren
-            import me.tbsten.cream.CopyVisibility
-
-            @CopyToChildren(visibility = CopyVisibility.INTERNAL)
-            sealed interface State {
-                val id: String
-
-                data class Loading(override val id: String) : State
-                data class Loaded(override val id: String, val payload: Int) : State
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
             }
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("internal fun") && !generated.contains("public fun"),
-            "expected only internal functions, but got:\n$generated",
-        )
-        assertMatchesSnapshot("VisibilitySnapshotTest.copyToChildrenInternal") {
-            "Generated" facetOf generated
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `combineTo internal visibility generates internal function`() {
-        val source =
-            """
-            package snap.visibility
-
-            import me.tbsten.cream.CombineTo
-            import me.tbsten.cream.CopyVisibility
-
-            @CombineTo(Target::class, visibility = CopyVisibility.INTERNAL)
-            data class Source(
-                val shared: String,
-            )
-
-            data class Target(
-                val shared: String,
-                val extra: Int,
-            )
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("internal fun"),
-            "expected an internal function, but got:\n$generated",
-        )
-        assertMatchesSnapshot("VisibilitySnapshotTest.combineToInternal") {
-            "Generated" facetOf generated
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `combineFrom internal visibility generates internal function`() {
-        val source =
-            """
-            package snap.visibility
-
-            import me.tbsten.cream.CombineFrom
-            import me.tbsten.cream.CopyVisibility
-
-            data class Source(
-                val shared: String,
-            )
-
-            @CombineFrom(Source::class, visibility = CopyVisibility.INTERNAL)
-            data class Target(
-                val shared: String,
-                val extra: Int,
-            )
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("internal fun"),
-            "expected an internal function, but got:\n$generated",
-        )
-        assertMatchesSnapshot("VisibilitySnapshotTest.combineFromInternal") {
-            "Generated" facetOf generated
-            "Input" facetOf source
-        }
-    }
-
-    @Test
-    fun `sealedCopy internal visibility generates internal function`() {
-        val source =
-            """
-            package snap.visibility
-
-            import me.tbsten.cream.SealedCopy
-            import me.tbsten.cream.CopyVisibility
-
-            @SealedCopy(visibility = CopyVisibility.INTERNAL)
-            sealed interface State {
-                val id: String
-
-                data class Loading(override val id: String) : State
-                data class Loaded(override val id: String, val payload: Int) : State
+            val generated = result.generatedSourceText()
+            withClue("expected an internal function, but got:\n$generated") {
+                generated shouldContain "internal fun"
             }
-            """.trimIndent()
-        val result = compileWithCream(source)
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        val generated = result.generatedSourceText()
-        assertTrue(
-            generated.contains("internal fun"),
-            "expected an internal function, but got:\n$generated",
-        )
-        assertMatchesSnapshot("VisibilitySnapshotTest.sealedCopyInternal") {
-            "Generated" facetOf generated
-            "Input" facetOf source
+            assertMatchesSnapshot("VisibilitySnapshotTest.copyToInternal") {
+                "Generated" facetOf generated
+                "Input" facetOf source
+            }
         }
-    }
-}
+
+        test("copyTo without visibility keeps public default") {
+            val source =
+                """
+                package snap.visibility
+
+                import me.tbsten.cream.CopyTo
+
+                @CopyTo(Target::class)
+                data class Source(
+                    val shared: String,
+                )
+
+                data class Target(
+                    val shared: String,
+                    val extra: Int,
+                )
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("expected a public function (inherited default), but got:\n$generated") {
+                generated shouldContain "public fun"
+            }
+            withClue("expected no internal/private modifier in default case, but got:\n$generated") {
+                (!generated.contains("internal fun") && !generated.contains("private fun")) shouldBe true
+            }
+        }
+
+        test("copyFrom internal visibility generates internal function") {
+            val source =
+                """
+                package snap.visibility
+
+                import me.tbsten.cream.CopyFrom
+                import me.tbsten.cream.CopyVisibility
+
+                data class Source(
+                    val shared: String,
+                )
+
+                @CopyFrom(Source::class, visibility = CopyVisibility.INTERNAL)
+                data class Target(
+                    val shared: String,
+                    val extra: Int,
+                )
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("expected an internal function, but got:\n$generated") {
+                generated shouldContain "internal fun"
+            }
+            assertMatchesSnapshot("VisibilitySnapshotTest.copyFromInternal") {
+                "Generated" facetOf generated
+                "Input" facetOf source
+            }
+        }
+
+        test("copyToChildren internal visibility generates internal functions") {
+            val source =
+                """
+                package snap.visibility
+
+                import me.tbsten.cream.CopyToChildren
+                import me.tbsten.cream.CopyVisibility
+
+                @CopyToChildren(visibility = CopyVisibility.INTERNAL)
+                sealed interface State {
+                    val id: String
+
+                    data class Loading(override val id: String) : State
+                    data class Loaded(override val id: String, val payload: Int) : State
+                }
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("expected only internal functions, but got:\n$generated") {
+                (generated.contains("internal fun") && !generated.contains("public fun")) shouldBe true
+            }
+            assertMatchesSnapshot("VisibilitySnapshotTest.copyToChildrenInternal") {
+                "Generated" facetOf generated
+                "Input" facetOf source
+            }
+        }
+
+        test("combineTo internal visibility generates internal function") {
+            val source =
+                """
+                package snap.visibility
+
+                import me.tbsten.cream.CombineTo
+                import me.tbsten.cream.CopyVisibility
+
+                @CombineTo(Target::class, visibility = CopyVisibility.INTERNAL)
+                data class Source(
+                    val shared: String,
+                )
+
+                data class Target(
+                    val shared: String,
+                    val extra: Int,
+                )
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("expected an internal function, but got:\n$generated") {
+                generated shouldContain "internal fun"
+            }
+            assertMatchesSnapshot("VisibilitySnapshotTest.combineToInternal") {
+                "Generated" facetOf generated
+                "Input" facetOf source
+            }
+        }
+
+        test("combineFrom internal visibility generates internal function") {
+            val source =
+                """
+                package snap.visibility
+
+                import me.tbsten.cream.CombineFrom
+                import me.tbsten.cream.CopyVisibility
+
+                data class Source(
+                    val shared: String,
+                )
+
+                @CombineFrom(Source::class, visibility = CopyVisibility.INTERNAL)
+                data class Target(
+                    val shared: String,
+                    val extra: Int,
+                )
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("expected an internal function, but got:\n$generated") {
+                generated shouldContain "internal fun"
+            }
+            assertMatchesSnapshot("VisibilitySnapshotTest.combineFromInternal") {
+                "Generated" facetOf generated
+                "Input" facetOf source
+            }
+        }
+
+        test("sealedCopy internal visibility generates internal function") {
+            val source =
+                """
+                package snap.visibility
+
+                import me.tbsten.cream.SealedCopy
+                import me.tbsten.cream.CopyVisibility
+
+                @SealedCopy(visibility = CopyVisibility.INTERNAL)
+                sealed interface State {
+                    val id: String
+
+                    data class Loading(override val id: String) : State
+                    data class Loaded(override val id: String, val payload: Int) : State
+                }
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("expected an internal function, but got:\n$generated") {
+                generated shouldContain "internal fun"
+            }
+            assertMatchesSnapshot("VisibilitySnapshotTest.sealedCopyInternal") {
+                "Generated" facetOf generated
+                "Input" facetOf source
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilationSmokeTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/CreamCompilationSmokeTest.kt
@@ -1,61 +1,63 @@
 package me.tbsten.cream.ksp.testing
 
 import com.tschuchort.compiletesting.KotlinCompilation
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
-internal class CreamCompilationSmokeTest {
-    @Test
-    fun `compiles a minimal @CopyTo source and generates a copy function`() {
-        val result =
-            compileWithCream(
-                """
-                package smoke
-
-                import me.tbsten.cream.CopyTo
-
-                @CopyTo(Target::class)
-                data class Source(val shared: String)
-
-                data class Target(val shared: String, val extra: Int)
-                """.trimIndent(),
-            )
-
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-
-        val generatedText = result.generatedSourceText()
-        assertTrue(
-            generatedText.contains("copyToTarget"),
-            "Generated source should contain copyToTarget function. Generated:\n$generatedText",
-        )
-    }
-
-    @Test
-    fun `multi-source DSL compiles when source and target live in separate files`() {
-        val result =
-            compileWithCream {
-                "Source.kt" source
+internal class CreamCompilationSmokeTest :
+    FunSpec({
+        test("compiles a minimal @CopyTo source and generates a copy function") {
+            val result =
+                compileWithCream(
                     """
-                    package smoke.multi
+                    package smoke
 
                     import me.tbsten.cream.CopyTo
 
                     @CopyTo(Target::class)
                     data class Source(val shared: String)
-                    """.trimIndent()
-                "Target.kt" source
-                    """
-                    package smoke.multi
 
                     data class Target(val shared: String, val extra: Int)
-                    """.trimIndent()
+                    """.trimIndent(),
+                )
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
             }
 
-        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
-        assertTrue(
-            result.generatedSourceText().contains("copyToTarget"),
-            "Multi-source compilation should still produce copyToTarget. Generated:\n${result.generatedSourceText()}",
-        )
-    }
-}
+            val generatedText = result.generatedSourceText()
+            withClue("Generated source should contain copyToTarget function. Generated:\n$generatedText") {
+                generatedText shouldContain "copyToTarget"
+            }
+        }
+
+        test("multi-source DSL compiles when source and target live in separate files") {
+            val result =
+                compileWithCream {
+                    "Source.kt" source
+                        """
+                        package smoke.multi
+
+                        import me.tbsten.cream.CopyTo
+
+                        @CopyTo(Target::class)
+                        data class Source(val shared: String)
+                        """.trimIndent()
+                    "Target.kt" source
+                        """
+                        package smoke.multi
+
+                        data class Target(val shared: String, val extra: Int)
+                        """.trimIndent()
+                }
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            withClue("Multi-source compilation should still produce copyToTarget. Generated:\n${result.generatedSourceText()}") {
+                result.generatedSourceText() shouldContain "copyToTarget"
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/SnapshotAssertion.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/SnapshotAssertion.kt
@@ -1,7 +1,7 @@
 package me.tbsten.cream.ksp.testing
 
+import io.kotest.assertions.fail
 import java.io.File
-import kotlin.test.fail
 
 /**
  * Run with `-Dcream.snapshot.update=true` to (re-)generate snapshot files.

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/transform/CopyFunctionNameTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/transform/CopyFunctionNameTest.kt
@@ -2,392 +2,389 @@ package me.tbsten.cream.ksp.transform
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSName
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import me.tbsten.cream.ksp.options.CopyFunNamingStrategy
 import me.tbsten.cream.ksp.options.CreamOptions
 import me.tbsten.cream.ksp.options.EscapeDot
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
-@Suppress("RemoveRedundantBackticks")
-internal class CopyFunctionNameTest {
-    private inline fun testCopyFunctionName(
-        options: CreamOptions,
-        vararg triples: Triple<KSClassDeclaration, KSClassDeclaration, String>,
-    ) {
-        triples.forEach { (source, target, expectedFunName) ->
-            val resultFunName = copyFunctionName(source, target, options).toString()
-
-            assertEquals(
-                expectedFunName,
-                resultFunName,
+internal class CopyFunctionNameTest :
+    FunSpec({
+        test("under-package, lower-camel-case") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`under-package`,
+                    escapeDot = EscapeDot.`lower-camel-case`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyToTarget",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyToStateSuccess",
+                ),
             )
         }
+
+        test("diff-parent, lower-camel-case") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`diff`,
+                    escapeDot = EscapeDot.`lower-camel-case`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration(
+                        "me.tbsten.example.source",
+                        "Source",
+                    ),
+                    mockKSClassDeclaration(
+                        "me.tbsten.example.target",
+                        "Target",
+                    ),
+                    "copyToTargetTarget",
+                ),
+                Triple(
+                    mockKSClassDeclaration(
+                        "me.tbsten.example",
+                        "State",
+                    ),
+                    mockKSClassDeclaration(
+                        "me.tbsten.example",
+                        "State.Success",
+                    ),
+                    "copyToSuccess",
+                ),
+            )
+        }
+
+        test("simple-name, lower-camel-case") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`simple-name`,
+                    escapeDot = EscapeDot.`lower-camel-case`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration(
+                        "me.tbsten.example.source",
+                        "Source",
+                    ),
+                    mockKSClassDeclaration(
+                        "me.tbsten.example.target",
+                        "Target",
+                    ),
+                    "copyToTarget",
+                ),
+                Triple(
+                    mockKSClassDeclaration(
+                        "me.tbsten.example",
+                        "State",
+                    ),
+                    mockKSClassDeclaration(
+                        "me.tbsten.example",
+                        "State.Success",
+                    ),
+                    "copyToSuccess",
+                ),
+            )
+        }
+
+        test("full-name, lower-camel-case") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`full-name`,
+                    escapeDot = EscapeDot.`lower-camel-case`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration(
+                        "me.tbsten.example.target",
+                        "Target",
+                    ),
+                    "copyToMeTbstenExampleTargetTarget",
+                ),
+                Triple(
+                    mockKSClassDeclaration(
+                        "me.tbsten.example",
+                        "State",
+                    ),
+                    mockKSClassDeclaration(
+                        "me.tbsten.example",
+                        "State.Success",
+                    ),
+                    "copyToMeTbstenExampleStateSuccess",
+                ),
+            )
+        }
+
+        test("inner-name, lower-camel-case") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`inner-name`,
+                    escapeDot = EscapeDot.`lower-camel-case`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyToTarget",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyToSuccess",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success.MoreLoading"),
+                    "copyToSuccessMoreLoading",
+                ),
+            )
+        }
+
+        test("under-package, replace-to-underscore") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`under-package`,
+                    escapeDot = EscapeDot.`replace-to-underscore`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyTo_Target",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyTo_State_Success",
+                ),
+            )
+        }
+
+        test("diff-parent, replace-to-underscore") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`diff`,
+                    escapeDot = EscapeDot.`replace-to-underscore`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyTo_target_Target",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyTo_Success",
+                ),
+            )
+        }
+
+        test("simple-name, replace-to-underscore") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`simple-name`,
+                    escapeDot = EscapeDot.`replace-to-underscore`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyTo_Target",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyTo_Success",
+                ),
+            )
+        }
+
+        test("full-name, replace-to-underscore") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`full-name`,
+                    escapeDot = EscapeDot.`replace-to-underscore`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyTo_me_tbsten_example_target_Target",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyTo_me_tbsten_example_State_Success",
+                ),
+            )
+        }
+
+        test("inner-name, replace-to-underscore") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`inner-name`,
+                    escapeDot = EscapeDot.`replace-to-underscore`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyTo_Target",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyTo_Success",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success.MoreLoading"),
+                    "copyTo_Success_MoreLoading",
+                ),
+            )
+        }
+
+        test("under-package, backquote") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`under-package`,
+                    escapeDot = EscapeDot.`backquote`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyTo`Target`",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyTo`State.Success`",
+                ),
+            )
+        }
+
+        test("diff-parent, backquote") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`diff`,
+                    escapeDot = EscapeDot.`backquote`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyTo`target.Target`",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyTo`.Success`",
+                ),
+            )
+        }
+
+        test("simple-name, backquote") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`simple-name`,
+                    escapeDot = EscapeDot.`backquote`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyTo`Target`",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyTo`Success`",
+                ),
+            )
+        }
+
+        test("full-name, backquote") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`full-name`,
+                    escapeDot = EscapeDot.`backquote`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyTo`me.tbsten.example.target.Target`",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyTo`me.tbsten.example.State.Success`",
+                ),
+            )
+        }
+
+        test("inner-name, backquote") {
+            testCopyFunctionName(
+                CreamOptions(
+                    copyFunNamePrefix = "copyTo",
+                    copyFunNamingStrategy = CopyFunNamingStrategy.`inner-name`,
+                    escapeDot = EscapeDot.`backquote`,
+                    notCopyToObject = false,
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example.source", "Source"),
+                    mockKSClassDeclaration("me.tbsten.example.target", "Target"),
+                    "copyTo`Target`",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success"),
+                    "copyTo`Success`",
+                ),
+                Triple(
+                    mockKSClassDeclaration("me.tbsten.example", "State"),
+                    mockKSClassDeclaration("me.tbsten.example", "State.Success.MoreLoading"),
+                    "copyTo`Success.MoreLoading`",
+                ),
+            )
+        }
+    })
+
+private fun testCopyFunctionName(
+    options: CreamOptions,
+    vararg triples: Triple<KSClassDeclaration, KSClassDeclaration, String>,
+) {
+    triples.forEach { (source, target, expectedFunName) ->
+        val resultFunName = copyFunctionName(source, target, options).toString()
+
+        resultFunName shouldBe expectedFunName
     }
-
-    @Test
-    fun `under-package, lower-camel-case`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`under-package`,
-                escapeDot = EscapeDot.`lower-camel-case`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyToTarget",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyToStateSuccess",
-            ),
-        )
-
-    @Test
-    fun `diff-parent, lower-camel-case`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`diff`,
-                escapeDot = EscapeDot.`lower-camel-case`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration(
-                    "me.tbsten.example.source",
-                    "Source",
-                ),
-                mockKSClassDeclaration(
-                    "me.tbsten.example.target",
-                    "Target",
-                ),
-                "copyToTargetTarget",
-            ),
-            Triple(
-                mockKSClassDeclaration(
-                    "me.tbsten.example",
-                    "State",
-                ),
-                mockKSClassDeclaration(
-                    "me.tbsten.example",
-                    "State.Success",
-                ),
-                "copyToSuccess",
-            ),
-        )
-
-    @Test
-    fun `simple-name, lower-camel-case`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`simple-name`,
-                escapeDot = EscapeDot.`lower-camel-case`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration(
-                    "me.tbsten.example.source",
-                    "Source",
-                ),
-                mockKSClassDeclaration(
-                    "me.tbsten.example.target",
-                    "Target",
-                ),
-                "copyToTarget",
-            ),
-            Triple(
-                mockKSClassDeclaration(
-                    "me.tbsten.example",
-                    "State",
-                ),
-                mockKSClassDeclaration(
-                    "me.tbsten.example",
-                    "State.Success",
-                ),
-                "copyToSuccess",
-            ),
-        )
-
-    @Test
-    fun `full-name, lower-camel-case`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`full-name`,
-                escapeDot = EscapeDot.`lower-camel-case`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration(
-                    "me.tbsten.example.target",
-                    "Target",
-                ),
-                "copyToMeTbstenExampleTargetTarget",
-            ),
-            Triple(
-                mockKSClassDeclaration(
-                    "me.tbsten.example",
-                    "State",
-                ),
-                mockKSClassDeclaration(
-                    "me.tbsten.example",
-                    "State.Success",
-                ),
-                "copyToMeTbstenExampleStateSuccess",
-            ),
-        )
-
-    @Test
-    fun `inner-name, lower-camel-case`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`inner-name`,
-                escapeDot = EscapeDot.`lower-camel-case`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyToTarget",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyToSuccess",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success.MoreLoading"),
-                "copyToSuccessMoreLoading",
-            ),
-        )
-
-    @Test
-    fun `under-package, replace-to-underscore`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`under-package`,
-                escapeDot = EscapeDot.`replace-to-underscore`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyTo_Target",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyTo_State_Success",
-            ),
-        )
-
-    @Test
-    fun `diff-parent, replace-to-underscore`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`diff`,
-                escapeDot = EscapeDot.`replace-to-underscore`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyTo_target_Target",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyTo_Success",
-            ),
-        )
-
-    @Test
-    fun `simple-name, replace-to-underscore`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`simple-name`,
-                escapeDot = EscapeDot.`replace-to-underscore`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyTo_Target",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyTo_Success",
-            ),
-        )
-
-    @Test
-    fun `full-name, replace-to-underscore`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`full-name`,
-                escapeDot = EscapeDot.`replace-to-underscore`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyTo_me_tbsten_example_target_Target",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyTo_me_tbsten_example_State_Success",
-            ),
-        )
-
-    @Test
-    fun `inner-name, replace-to-underscore`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`inner-name`,
-                escapeDot = EscapeDot.`replace-to-underscore`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyTo_Target",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyTo_Success",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success.MoreLoading"),
-                "copyTo_Success_MoreLoading",
-            ),
-        )
-
-    @Test
-    fun `under-package, backquote`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`under-package`,
-                escapeDot = EscapeDot.`backquote`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyTo`Target`",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyTo`State.Success`",
-            ),
-        )
-
-    @Test
-    fun `diff-parent, backquote`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`diff`,
-                escapeDot = EscapeDot.`backquote`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyTo`target.Target`",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyTo`.Success`",
-            ),
-        )
-
-    @Test
-    fun `simple-name, backquote`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`simple-name`,
-                escapeDot = EscapeDot.`backquote`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyTo`Target`",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyTo`Success`",
-            ),
-        )
-
-    @Test
-    fun `full-name, backquote`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`full-name`,
-                escapeDot = EscapeDot.`backquote`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyTo`me.tbsten.example.target.Target`",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyTo`me.tbsten.example.State.Success`",
-            ),
-        )
-
-    @Test
-    fun `inner-name, backquote`() =
-        testCopyFunctionName(
-            CreamOptions(
-                copyFunNamePrefix = "copyTo",
-                copyFunNamingStrategy = CopyFunNamingStrategy.`inner-name`,
-                escapeDot = EscapeDot.`backquote`,
-                notCopyToObject = false,
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example.source", "Source"),
-                mockKSClassDeclaration("me.tbsten.example.target", "Target"),
-                "copyTo`Target`",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success"),
-                "copyTo`Success`",
-            ),
-            Triple(
-                mockKSClassDeclaration("me.tbsten.example", "State"),
-                mockKSClassDeclaration("me.tbsten.example", "State.Success.MoreLoading"),
-                "copyTo`Success.MoreLoading`",
-            ),
-        )
 }
 
 private fun mockKSClassDeclaration(

--- a/cream-runtime/build.gradle.kts
+++ b/cream-runtime/build.gradle.kts
@@ -63,11 +63,6 @@ kotlin {
                 // put your multiplatform dependencies here
             }
         }
-        val commonTest by getting {
-            dependencies {
-                implementation(libs.kotlinTest)
-            }
-        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,6 @@ kodeview = "0.9.0"
 buildkonfig = "0.17.1"
 
 [libraries]
-kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotest = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotestFrameworkEngine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotestRunnerJunit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "2.2.20"
 android-minSdk = "24"
 android-compileSdk = "36"
 ksp = "2.2.20-2.0.4"
-kotest = "6.0.4"
+kotest = "6.1.11"
 mockk = "1.14.6"
 kctfork = "0.12.1"
 ktlint = "1.7.1"
@@ -23,6 +23,8 @@ buildkonfig = "0.17.1"
 [libraries]
 kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotest = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotestFrameworkEngine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
+kotestRunnerJunit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kspApi = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 kctforkCore = { module = "dev.zacsweers.kctfork:core", version.ref = "kctfork" }
@@ -42,6 +44,7 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kotest = { id = "io.kotest", version.ref = "kotest" }
 ktlintGradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradlePlugin" }
 
 # option builder

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.ksp)
+    // kotest must be applied after ksp: its multiplatform framework wiring is KSP-based.
+    alias(libs.plugins.kotest)
     id("buildLogic.lint")
 }
 
@@ -42,16 +44,31 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotest)
-            implementation(libs.kotlinTest)
+            implementation(libs.kotestFrameworkEngine)
+        }
+        jvmTest.dependencies {
+            implementation(libs.kotestRunnerJunit5)
+        }
+        // Android unit tests run on the JVM via the JUnit Platform too, but androidUnitTest does not
+        // inherit jvmTest, so it needs the kotest JUnit5 runner independently to discover FunSpec.
+        androidUnitTest.dependencies {
+            implementation(libs.kotestRunnerJunit5)
         }
     }
 }
 
+// kotest runs on the JUnit Platform for the JVM and Android unit-test tasks.
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}
+
 dependencies {
+    // cream only processes commonMain annotations (collapsed into kspCommonMainKotlinMetadata by the
+    // workaround below). It is deliberately NOT wired into any *Test KSP configuration so that the
+    // kotest KSP processor owns the test source sets without a second processor running alongside it.
     listOf(
         "kspCommonMainMetadata",
         "kspJvm",
-        "kspJvmTest",
     ).forEach { it(project(":cream-ksp")) }
 }
 
@@ -70,7 +87,12 @@ fun Project.setupKspForMultiplatformWorkaround() {
     tasks.configureEach {
         if (name.startsWith("ksp") && name != "kspCommonMainKotlinMetadata") {
             dependsOn(tasks.named("kspCommonMainKotlinMetadata"))
-            enabled = false
+            // Disable only cream's redundant per-platform *main* generation; keep the *Test KSP tasks
+            // alive so the kotest framework can generate its per-target spec launchers (required for
+            // FunSpec to start on native/Android, and harmless on JVM).
+            if (!name.contains("Test")) {
+                enabled = false
+            }
         }
     }
 }

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/BasicTest.kt
@@ -1,52 +1,51 @@
 package me.tbsten.cream.test.combineFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class BasicTest {
-    @Test
-    fun combineFromTarget() {
-        val sourceA = SourceStateA(propertyA = "sourceA")
-        val sourceB = SourceStateB(propertyB = 42)
+class BasicTest :
+    FunSpec({
+        test("combineFromTarget") {
+            val sourceA = SourceStateA(propertyA = "sourceA")
+            val sourceB = SourceStateB(propertyB = 42)
 
-        val result: TargetState =
-            sourceA.copyToTargetState(
-                sourceStateB = sourceB,
-                propertyC = true,
-            )
+            val result: TargetState =
+                sourceA.copyToTargetState(
+                    sourceStateB = sourceB,
+                    propertyC = true,
+                )
 
-        // Verify
-        val expected =
-            TargetState(
-                propertyA = "sourceA",
-                propertyB = 42,
-                propertyC = true,
-            )
+            // Verify
+            val expected =
+                TargetState(
+                    propertyA = "sourceA",
+                    propertyB = 42,
+                    propertyC = true,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun combineFromTargetWithOverride() {
-        val sourceA = SourceStateA(propertyA = "sourceA")
-        val sourceB = SourceStateB(propertyB = 42)
+        test("combineFromTargetWithOverride") {
+            val sourceA = SourceStateA(propertyA = "sourceA")
+            val sourceB = SourceStateB(propertyB = 42)
 
-        val result: TargetState =
-            sourceA.copyToTargetState(
-                sourceStateB = sourceB,
-                propertyA = "overridden",
-                propertyB = 100,
-                propertyC = true,
-            )
+            val result: TargetState =
+                sourceA.copyToTargetState(
+                    sourceStateB = sourceB,
+                    propertyA = "overridden",
+                    propertyB = 100,
+                    propertyC = true,
+                )
 
-        // Verify
-        val expected =
-            TargetState(
-                propertyA = "overridden",
-                propertyB = 100,
-                propertyC = true,
-            )
+            // Verify
+            val expected =
+                TargetState(
+                    propertyA = "overridden",
+                    propertyB = 100,
+                    propertyC = true,
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/GenericsTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/GenericsTest.kt
@@ -1,54 +1,53 @@
 package me.tbsten.cream.test.combineFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class GenericsTest {
-    @Test
-    fun combineFromWithGenerics() {
-        val sourceA =
-            GenericSourceA(
-                genericProperty = "generic string",
-                normalProperty = "normal",
-            )
-        val sourceB =
-            GenericSourceB(
-                anotherGeneric = 42,
-            )
+class GenericsTest :
+    FunSpec({
+        test("combineFromWithGenerics") {
+            val sourceA =
+                GenericSourceA(
+                    genericProperty = "generic string",
+                    normalProperty = "normal",
+                )
+            val sourceB =
+                GenericSourceB(
+                    anotherGeneric = 42,
+                )
 
-        val result: GenericTarget<String, Int> =
-            sourceA.copyToGenericTarget(
-                genericSourceB = sourceB,
-                extraProperty = 100,
-            )
+            val result: GenericTarget<String, Int> =
+                sourceA.copyToGenericTarget(
+                    genericSourceB = sourceB,
+                    extraProperty = 100,
+                )
 
-        assertEquals("generic string", result.genericProperty)
-        assertEquals("normal", result.normalProperty)
-        assertEquals(42, result.anotherGeneric)
-        assertEquals(100, result.extraProperty)
-    }
+            result.genericProperty shouldBe "generic string"
+            result.normalProperty shouldBe "normal"
+            result.anotherGeneric shouldBe 42
+            result.extraProperty shouldBe 100
+        }
 
-    @Test
-    fun combineFromWithComplexGenerics() {
-        val sourceA =
-            GenericSourceA(
-                genericProperty = listOf("a", "b", "c"),
-                normalProperty = "normal",
-            )
-        val sourceB =
-            GenericSourceB(
-                anotherGeneric = mapOf("key" to "value"),
-            )
+        test("combineFromWithComplexGenerics") {
+            val sourceA =
+                GenericSourceA(
+                    genericProperty = listOf("a", "b", "c"),
+                    normalProperty = "normal",
+                )
+            val sourceB =
+                GenericSourceB(
+                    anotherGeneric = mapOf("key" to "value"),
+                )
 
-        val result: GenericTarget<List<String>, Map<String, String>> =
-            sourceA.copyToGenericTarget(
-                genericSourceB = sourceB,
-                extraProperty = 200,
-            )
+            val result: GenericTarget<List<String>, Map<String, String>> =
+                sourceA.copyToGenericTarget(
+                    genericSourceB = sourceB,
+                    extraProperty = 200,
+                )
 
-        assertEquals(listOf("a", "b", "c"), result.genericProperty)
-        assertEquals("normal", result.normalProperty)
-        assertEquals(mapOf("key" to "value"), result.anotherGeneric)
-        assertEquals(200, result.extraProperty)
-    }
-}
+            result.genericProperty shouldBe listOf("a", "b", "c")
+            result.normalProperty shouldBe "normal"
+            result.anotherGeneric shouldBe mapOf("key" to "value")
+            result.extraProperty shouldBe 200
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/MultiSourceTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/MultiSourceTest.kt
@@ -1,54 +1,53 @@
 package me.tbsten.cream.test.combineFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class MultiSourceTest {
-    @Test
-    fun combineFromFourSources() {
-        val sourceA = MultiSourceA(propertyA = "A")
-        val sourceB = MultiSourceB(propertyB = 42)
-        val sourceC = MultiSourceC(propertyC = true)
-        val sourceD = MultiSourceD(propertyD = 3.14)
+class MultiSourceTest :
+    FunSpec({
+        test("combineFromFourSources") {
+            val sourceA = MultiSourceA(propertyA = "A")
+            val sourceB = MultiSourceB(propertyB = 42)
+            val sourceC = MultiSourceC(propertyC = true)
+            val sourceD = MultiSourceD(propertyD = 3.14)
 
-        val result: MultiSourceTarget =
-            sourceA.copyToMultiSourceTarget(
-                multiSourceB = sourceB,
-                multiSourceC = sourceC,
-                multiSourceD = sourceD,
-                extraProperty = "extra",
-            )
+            val result: MultiSourceTarget =
+                sourceA.copyToMultiSourceTarget(
+                    multiSourceB = sourceB,
+                    multiSourceC = sourceC,
+                    multiSourceD = sourceD,
+                    extraProperty = "extra",
+                )
 
-        assertEquals("A", result.propertyA)
-        assertEquals(42, result.propertyB)
-        assertEquals(true, result.propertyC)
-        assertEquals(3.14, result.propertyD)
-        assertEquals("extra", result.extraProperty)
-    }
+            result.propertyA shouldBe "A"
+            result.propertyB shouldBe 42
+            result.propertyC shouldBe true
+            result.propertyD shouldBe 3.14
+            result.extraProperty shouldBe "extra"
+        }
 
-    @Test
-    fun combineFromFourSourcesWithOverride() {
-        val sourceA = MultiSourceA(propertyA = "A")
-        val sourceB = MultiSourceB(propertyB = 42)
-        val sourceC = MultiSourceC(propertyC = true)
-        val sourceD = MultiSourceD(propertyD = 3.14)
+        test("combineFromFourSourcesWithOverride") {
+            val sourceA = MultiSourceA(propertyA = "A")
+            val sourceB = MultiSourceB(propertyB = 42)
+            val sourceC = MultiSourceC(propertyC = true)
+            val sourceD = MultiSourceD(propertyD = 3.14)
 
-        val result: MultiSourceTarget =
-            sourceA.copyToMultiSourceTarget(
-                multiSourceB = sourceB,
-                multiSourceC = sourceC,
-                multiSourceD = sourceD,
-                propertyA = "Overridden",
-                propertyB = 100,
-                propertyC = false,
-                propertyD = 2.71,
-                extraProperty = "extra",
-            )
+            val result: MultiSourceTarget =
+                sourceA.copyToMultiSourceTarget(
+                    multiSourceB = sourceB,
+                    multiSourceC = sourceC,
+                    multiSourceD = sourceD,
+                    propertyA = "Overridden",
+                    propertyB = 100,
+                    propertyC = false,
+                    propertyD = 2.71,
+                    extraProperty = "extra",
+                )
 
-        assertEquals("Overridden", result.propertyA)
-        assertEquals(100, result.propertyB)
-        assertEquals(false, result.propertyC)
-        assertEquals(2.71, result.propertyD)
-        assertEquals("extra", result.extraProperty)
-    }
-}
+            result.propertyA shouldBe "Overridden"
+            result.propertyB shouldBe 100
+            result.propertyC shouldBe false
+            result.propertyD shouldBe 2.71
+            result.extraProperty shouldBe "extra"
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/NullableTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/NullableTest.kt
@@ -1,49 +1,47 @@
 package me.tbsten.cream.test.combineFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class NullableTest {
-    @Test
-    fun combineFromWithNullableProperties() {
-        val sourceA =
-            NullableSourceA(
-                nullableProperty = "value",
-                nonNullProperty = "required",
-            )
-        val sourceB = NullableSourceB(anotherNullable = 42)
+class NullableTest :
+    FunSpec({
+        test("combineFromWithNullableProperties") {
+            val sourceA =
+                NullableSourceA(
+                    nullableProperty = "value",
+                    nonNullProperty = "required",
+                )
+            val sourceB = NullableSourceB(anotherNullable = 42)
 
-        val result: NullableTarget =
-            sourceA.copyToNullableTarget(
-                nullableSourceB = sourceB,
-                extraProperty = true,
-            )
+            val result: NullableTarget =
+                sourceA.copyToNullableTarget(
+                    nullableSourceB = sourceB,
+                    extraProperty = true,
+                )
 
-        assertEquals("value", result.nullableProperty)
-        assertEquals("required", result.nonNullProperty)
-        assertEquals(42, result.anotherNullable)
-        assertEquals(true, result.extraProperty)
-    }
+            result.nullableProperty shouldBe "value"
+            result.nonNullProperty shouldBe "required"
+            result.anotherNullable shouldBe 42
+            result.extraProperty shouldBe true
+        }
 
-    @Test
-    fun combineFromWithNullValues() {
-        val sourceA =
-            NullableSourceA(
-                nullableProperty = null,
-                nonNullProperty = "required",
-            )
-        val sourceB = NullableSourceB(anotherNullable = null)
+        test("combineFromWithNullValues") {
+            val sourceA =
+                NullableSourceA(
+                    nullableProperty = null,
+                    nonNullProperty = "required",
+                )
+            val sourceB = NullableSourceB(anotherNullable = null)
 
-        val result: NullableTarget =
-            sourceA.copyToNullableTarget(
-                nullableSourceB = sourceB,
-                extraProperty = false,
-            )
+            val result: NullableTarget =
+                sourceA.copyToNullableTarget(
+                    nullableSourceB = sourceB,
+                    extraProperty = false,
+                )
 
-        assertNull(result.nullableProperty)
-        assertEquals("required", result.nonNullProperty)
-        assertNull(result.anotherNullable)
-        assertEquals(false, result.extraProperty)
-    }
-}
+            result.nullableProperty shouldBe null
+            result.nonNullProperty shouldBe "required"
+            result.anotherNullable shouldBe null
+            result.extraProperty shouldBe false
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/ObjectTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/ObjectTargetTest.kt
@@ -1,20 +1,20 @@
 package me.tbsten.cream.test.combineFrom
 
-import kotlin.test.Test
-import kotlin.test.assertSame
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 
-class ObjectTargetTest {
-    @Test
-    fun combineFromToObject() {
-        val sourceA = ObjectSourceA(propertyA = "test")
-        val sourceB = ObjectSourceB(propertyB = 42)
+class ObjectTargetTest :
+    FunSpec({
+        test("combineFromToObject") {
+            val sourceA = ObjectSourceA(propertyA = "test")
+            val sourceB = ObjectSourceB(propertyB = 42)
 
-        val result: TargetObject =
-            sourceA.copyToTargetObject(
-                objectSourceB = sourceB,
-            )
+            val result: TargetObject =
+                sourceA.copyToTargetObject(
+                    objectSourceB = sourceB,
+                )
 
-        // Objects are singletons, so the result should be the same instance
-        assertSame(TargetObject, result)
-    }
-}
+            // Objects are singletons, so the result should be the same instance
+            result shouldBeSameInstanceAs TargetObject
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/OverlapTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/OverlapTest.kt
@@ -1,55 +1,54 @@
 package me.tbsten.cream.test.combineFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class OverlapTest {
-    @Test
-    fun overlappingPropertyPriority() {
-        val sourceA =
-            OverlapSourceA(
-                shared = "from A",
-                uniqueA = "unique A",
-            )
-        val sourceB =
-            OverlapSourceB(
-                shared = "from B",
-                uniqueB = 42,
-            )
+class OverlapTest :
+    FunSpec({
+        test("overlappingPropertyPriority") {
+            val sourceA =
+                OverlapSourceA(
+                    shared = "from A",
+                    uniqueA = "unique A",
+                )
+            val sourceB =
+                OverlapSourceB(
+                    shared = "from B",
+                    uniqueB = 42,
+                )
 
-        val result: OverlapTarget =
-            sourceA.copyToOverlapTarget(
-                overlapSourceB = sourceB,
-            )
+            val result: OverlapTarget =
+                sourceA.copyToOverlapTarget(
+                    overlapSourceB = sourceB,
+                )
 
-        // The last source class (SourceB) should take precedence for 'shared'
-        assertEquals("from B", result.shared)
-        assertEquals("unique A", result.uniqueA)
-        assertEquals(42, result.uniqueB)
-    }
+            // The last source class (SourceB) should take precedence for 'shared'
+            result.shared shouldBe "from B"
+            result.uniqueA shouldBe "unique A"
+            result.uniqueB shouldBe 42
+        }
 
-    @Test
-    fun overlappingPropertyWithExplicitOverride() {
-        val sourceA =
-            OverlapSourceA(
-                shared = "from A",
-                uniqueA = "unique A",
-            )
-        val sourceB =
-            OverlapSourceB(
-                shared = "from B",
-                uniqueB = 42,
-            )
+        test("overlappingPropertyWithExplicitOverride") {
+            val sourceA =
+                OverlapSourceA(
+                    shared = "from A",
+                    uniqueA = "unique A",
+                )
+            val sourceB =
+                OverlapSourceB(
+                    shared = "from B",
+                    uniqueB = 42,
+                )
 
-        val result: OverlapTarget =
-            sourceA.copyToOverlapTarget(
-                overlapSourceB = sourceB,
-                shared = "explicitly set",
-            )
+            val result: OverlapTarget =
+                sourceA.copyToOverlapTarget(
+                    overlapSourceB = sourceB,
+                    shared = "explicitly set",
+                )
 
-        // Explicit parameter should override both sources
-        assertEquals("explicitly set", result.shared)
-        assertEquals("unique A", result.uniqueA)
-        assertEquals(42, result.uniqueB)
-    }
-}
+            // Explicit parameter should override both sources
+            result.shared shouldBe "explicitly set"
+            result.uniqueA shouldBe "unique A"
+            result.uniqueB shouldBe 42
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/PropertyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/PropertyMappingTest.kt
@@ -1,68 +1,65 @@
 package me.tbsten.cream.test.combineFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class PropertyMappingTest {
-    @Test
-    fun simplePropertyNameMapping() {
-        val sourceA = MappingSourceA(sourcePropertyA = "Hello")
-        val sourceB = MappingSourceB(sourcePropertyB = 42)
+class PropertyMappingTest :
+    FunSpec({
+        test("simplePropertyNameMapping") {
+            val sourceA = MappingSourceA(sourcePropertyA = "Hello")
+            val sourceB = MappingSourceB(sourcePropertyB = 42)
 
-        val result: MappedTarget =
-            sourceA.copyToMappedTarget(
-                mappingSourceB = sourceB,
-                normalProperty = "World",
-            )
+            val result: MappedTarget =
+                sourceA.copyToMappedTarget(
+                    mappingSourceB = sourceB,
+                    normalProperty = "World",
+                )
 
-        assertEquals("Hello", result.targetPropertyA)
-        assertEquals(42, result.targetPropertyB)
-        assertEquals("World", result.normalProperty)
-    }
+            result.targetPropertyA shouldBe "Hello"
+            result.targetPropertyB shouldBe 42
+            result.normalProperty shouldBe "World"
+        }
 
-    @Test
-    fun multiplePropertyNamesMapping() {
-        val source = MultiMappingSource(sourceName = "SharedValue")
-        val sourceB = MultiMappingSourceB(otherProp = 100)
+        test("multiplePropertyNamesMapping") {
+            val source = MultiMappingSource(sourceName = "SharedValue")
+            val sourceB = MultiMappingSourceB(otherProp = 100)
 
-        val result: MultiMappedTarget =
-            source.copyToMultiMappedTarget(
-                multiMappingSourceB = sourceB,
-            )
+            val result: MultiMappedTarget =
+                source.copyToMultiMappedTarget(
+                    multiMappingSourceB = sourceB,
+                )
 
-        assertEquals("SharedValue", result.targetName1)
-        assertEquals("SharedValue", result.targetName2)
-        assertEquals(100, result.otherProp)
-    }
+            result.targetName1 shouldBe "SharedValue"
+            result.targetName2 shouldBe "SharedValue"
+            result.otherProp shouldBe 100
+        }
 
-    @Test
-    fun mixedMappingWithDirectMatch() {
-        val sourceA = MixedMappingSourceA(directMatch = "Direct")
-        val sourceB = MixedMappingSourceB(originalProperty = 999)
+        test("mixedMappingWithDirectMatch") {
+            val sourceA = MixedMappingSourceA(directMatch = "Direct")
+            val sourceB = MixedMappingSourceB(originalProperty = 999)
 
-        val result: MixedMappingTarget =
-            sourceA.copyToMixedMappingTarget(
-                mixedMappingSourceB = sourceB,
-                extraProperty = true,
-            )
+            val result: MixedMappingTarget =
+                sourceA.copyToMixedMappingTarget(
+                    mixedMappingSourceB = sourceB,
+                    extraProperty = true,
+                )
 
-        assertEquals("Direct", result.directMatch)
-        assertEquals(999, result.renamedProperty)
-        assertEquals(true, result.extraProperty)
-    }
+            result.directMatch shouldBe "Direct"
+            result.renamedProperty shouldBe 999
+            result.extraProperty shouldBe true
+        }
 
-    @Test
-    fun mergeMappingWithDirectMatch() {
-        val sourceA = MergeMappingSourceA(sourcePropertyA = "SourceA")
-        val sourceB = MergeMappingSourceB(sourcePropertyB = "SourceB")
+        test("mergeMappingWithDirectMatch") {
+            val sourceA = MergeMappingSourceA(sourcePropertyA = "SourceA")
+            val sourceB = MergeMappingSourceB(sourcePropertyB = "SourceB")
 
-        val result: MergeMappingTarget =
-            sourceA.copyToMergeMappingTarget(
-                mergeMappingSourceB = sourceB,
-            )
+            val result: MergeMappingTarget =
+                sourceA.copyToMergeMappingTarget(
+                    mergeMappingSourceB = sourceB,
+                )
 
-        // When both sources map to the same property,
-        // the last source class (SourceB) should take precedence
-        assertEquals("SourceB", result.sourcePropertyA)
-    }
-}
+            // When both sources map to the same property,
+            // the last source class (SourceB) should take precedence
+            result.sourcePropertyA shouldBe "SourceB"
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/TypeAliasTest.kt
@@ -1,47 +1,46 @@
 package me.tbsten.cream.test.combineFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
-class TypeAliasTest {
-    @Test
-    fun testCombineFromWithTypeAliasTarget() {
-        // Create instances using actual class constructors and assign them to variables with typealias types.
-        // Note: Typealiases are just alternative names for the same types.
-        val sourceX: SourceXAlias = SourceX(propX = "x-value")
-        val sourceY: SourceYAlias = SourceY(propY = 99)
+class TypeAliasTest :
+    FunSpec({
+        test("testCombineFromWithTypeAliasTarget") {
+            // Create instances using actual class constructors and assign them to variables with typealias types.
+            // Note: Typealiases are just alternative names for the same types.
+            val sourceX: SourceXAlias = SourceX(propX = "x-value")
+            val sourceY: SourceYAlias = SourceY(propY = 99)
 
-        // Call the generated combine function
-        // Note: Function name and parameter names are based on the actual type (CombinedResult, SourceY), not the alias
-        val result: CombinedResultAlias =
-            sourceX.copyToCombinedResult(
-                sourceY = sourceY,
-                extraProp = "extra",
-            )
+            // Call the generated combine function
+            // Note: Function name and parameter names are based on the actual type (CombinedResult, SourceY), not the alias
+            val result: CombinedResultAlias =
+                sourceX.copyToCombinedResult(
+                    sourceY = sourceY,
+                    extraProp = "extra",
+                )
 
-        // Verify all properties are copied correctly
-        assertEquals("x-value", result.propX)
-        assertEquals(99, result.propY)
-        assertEquals("extra", result.extraProp)
+            // Verify all properties are copied correctly
+            result.propX shouldBe "x-value"
+            result.propY shouldBe 99
+            result.extraProp shouldBe "extra"
 
-        // Verify the result is actually a CombinedResult instance
-        assertIs<CombinedResult>(result)
-    }
+            // Verify the result is actually a CombinedResult instance
+            result.shouldBeInstanceOf<CombinedResult>()
+        }
 
-    @Test
-    fun testCombineFromPreservesAllSourceProperties() {
-        val sourceX: SourceXAlias = SourceX(propX = "test-x")
-        val sourceY: SourceYAlias = SourceY(propY = 200)
+        test("testCombineFromPreservesAllSourceProperties") {
+            val sourceX: SourceXAlias = SourceX(propX = "test-x")
+            val sourceY: SourceYAlias = SourceY(propY = 200)
 
-        val result: CombinedResultAlias =
-            sourceX.copyToCombinedResult(
-                sourceY = sourceY,
-                extraProp = "test-extra",
-            )
+            val result: CombinedResultAlias =
+                sourceX.copyToCombinedResult(
+                    sourceY = sourceY,
+                    extraProp = "test-extra",
+                )
 
-        // Verify that all source properties are preserved in the result
-        assertEquals(sourceX.propX, result.propX)
-        assertEquals(sourceY.propY, result.propY)
-    }
-}
+            // Verify that all source properties are preserved in the result
+            result.propX shouldBe sourceX.propX
+            result.propY shouldBe sourceY.propY
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/VisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/VisibilityTest.kt
@@ -1,17 +1,17 @@
 package me.tbsten.cream.test.combineFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class VisibilityTest {
-    // The generated function being `internal` is verified at compile time: this test
-    // (in the same module) can call it. A `public`-only caller would not compile.
-    @Test
-    fun internalVisibilityCombineFunctionIsCallable() {
-        val source = InternalVisibilityCombineSource(shared = "value")
-        val target: InternalVisibilityCombineTarget =
-            source.copyToInternalVisibilityCombineTarget(extra = 42)
+class VisibilityTest :
+    FunSpec({
+        // The generated function being `internal` is verified at compile time: this test
+        // (in the same module) can call it. A `public`-only caller would not compile.
+        test("internalVisibilityCombineFunctionIsCallable") {
+            val source = InternalVisibilityCombineSource(shared = "value")
+            val target: InternalVisibilityCombineTarget =
+                source.copyToInternalVisibilityCombineTarget(extra = 42)
 
-        assertEquals(InternalVisibilityCombineTarget("value", 42), target)
-    }
-}
+            target shouldBe InternalVisibilityCombineTarget("value", 42)
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/BasicTest.kt
@@ -1,70 +1,69 @@
 package me.tbsten.cream.test.combineMapping
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class BasicTest {
-    @Test
-    fun basicCombineMapping() {
-        val libA =
-            LibAModel(
-                nameA = "NameA",
-                valueA = 100,
-            )
-        val libB =
-            LibBModel(
-                nameB = "NameB",
-                valueB = 3.14,
-            )
+class BasicTest :
+    FunSpec({
+        test("basicCombineMapping") {
+            val libA =
+                LibAModel(
+                    nameA = "NameA",
+                    valueA = 100,
+                )
+            val libB =
+                LibBModel(
+                    nameB = "NameB",
+                    valueB = 3.14,
+                )
 
-        val result: CombinedModel =
-            libA.copyToCombinedModel(
-                libBModel = libB,
-                extraProperty = "Extra",
-            )
+            val result: CombinedModel =
+                libA.copyToCombinedModel(
+                    libBModel = libB,
+                    extraProperty = "Extra",
+                )
 
-        val expected =
-            CombinedModel(
-                nameA = "NameA",
-                valueA = 100,
-                nameB = "NameB",
-                valueB = 3.14,
-                extraProperty = "Extra",
-            )
+            val expected =
+                CombinedModel(
+                    nameA = "NameA",
+                    valueA = 100,
+                    nameB = "NameB",
+                    valueB = 3.14,
+                    extraProperty = "Extra",
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun basicCombineMappingWithOverride() {
-        val libA =
-            LibAModel(
-                nameA = "NameA",
-                valueA = 100,
-            )
-        val libB =
-            LibBModel(
-                nameB = "NameB",
-                valueB = 3.14,
-            )
+        test("basicCombineMappingWithOverride") {
+            val libA =
+                LibAModel(
+                    nameA = "NameA",
+                    valueA = 100,
+                )
+            val libB =
+                LibBModel(
+                    nameB = "NameB",
+                    valueB = 3.14,
+                )
 
-        val result: CombinedModel =
-            libA.copyToCombinedModel(
-                libBModel = libB,
-                nameA = "OverriddenNameA",
-                valueB = 9.99,
-                extraProperty = "Extra",
-            )
+            val result: CombinedModel =
+                libA.copyToCombinedModel(
+                    libBModel = libB,
+                    nameA = "OverriddenNameA",
+                    valueB = 9.99,
+                    extraProperty = "Extra",
+                )
 
-        val expected =
-            CombinedModel(
-                nameA = "OverriddenNameA",
-                valueA = 100,
-                nameB = "NameB",
-                valueB = 9.99,
-                extraProperty = "Extra",
-            )
+            val expected =
+                CombinedModel(
+                    nameA = "OverriddenNameA",
+                    valueA = 100,
+                    nameB = "NameB",
+                    valueB = 9.99,
+                    extraProperty = "Extra",
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/MultiSourceTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/MultiSourceTest.kt
@@ -1,82 +1,81 @@
 package me.tbsten.cream.test.combineMapping
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class MultiSourceTest {
-    @Test
-    fun tripleSourceCombineMapping() {
-        val libA =
-            LibAModel(
-                nameA = "A",
-                valueA = 1,
-            )
-        val libB =
-            LibBModel(
-                nameB = "B",
-                valueB = 2.0,
-            )
-        val libC =
-            LibCModel(
-                nameC = "C",
-                valueC = true,
-            )
+class MultiSourceTest :
+    FunSpec({
+        test("tripleSourceCombineMapping") {
+            val libA =
+                LibAModel(
+                    nameA = "A",
+                    valueA = 1,
+                )
+            val libB =
+                LibBModel(
+                    nameB = "B",
+                    valueB = 2.0,
+                )
+            val libC =
+                LibCModel(
+                    nameC = "C",
+                    valueC = true,
+                )
 
-        val result: TripleCombinedModel =
-            libA.copyToTripleCombinedModel(
-                libBModel = libB,
-                libCModel = libC,
-            )
+            val result: TripleCombinedModel =
+                libA.copyToTripleCombinedModel(
+                    libBModel = libB,
+                    libCModel = libC,
+                )
 
-        val expected =
-            TripleCombinedModel(
-                nameA = "A",
-                valueA = 1,
-                nameB = "B",
-                valueB = 2.0,
-                nameC = "C",
-                valueC = true,
-            )
+            val expected =
+                TripleCombinedModel(
+                    nameA = "A",
+                    valueA = 1,
+                    nameB = "B",
+                    valueB = 2.0,
+                    nameC = "C",
+                    valueC = true,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun tripleSourceCombineMappingWithOverride() {
-        val libA =
-            LibAModel(
-                nameA = "A",
-                valueA = 1,
-            )
-        val libB =
-            LibBModel(
-                nameB = "B",
-                valueB = 2.0,
-            )
-        val libC =
-            LibCModel(
-                nameC = "C",
-                valueC = true,
-            )
+        test("tripleSourceCombineMappingWithOverride") {
+            val libA =
+                LibAModel(
+                    nameA = "A",
+                    valueA = 1,
+                )
+            val libB =
+                LibBModel(
+                    nameB = "B",
+                    valueB = 2.0,
+                )
+            val libC =
+                LibCModel(
+                    nameC = "C",
+                    valueC = true,
+                )
 
-        val result: TripleCombinedModel =
-            libA.copyToTripleCombinedModel(
-                libBModel = libB,
-                libCModel = libC,
-                nameB = "OverriddenB",
-                valueC = false,
-            )
+            val result: TripleCombinedModel =
+                libA.copyToTripleCombinedModel(
+                    libBModel = libB,
+                    libCModel = libC,
+                    nameB = "OverriddenB",
+                    valueC = false,
+                )
 
-        val expected =
-            TripleCombinedModel(
-                nameA = "A",
-                valueA = 1,
-                nameB = "OverriddenB",
-                valueB = 2.0,
-                nameC = "C",
-                valueC = false,
-            )
+            val expected =
+                TripleCombinedModel(
+                    nameA = "A",
+                    valueA = 1,
+                    nameB = "OverriddenB",
+                    valueB = 2.0,
+                    nameC = "C",
+                    valueC = false,
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/OverlapTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/OverlapTest.kt
@@ -1,63 +1,62 @@
 package me.tbsten.cream.test.combineMapping
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class OverlapTest {
-    @Test
-    fun combineMappingWithOverlap() {
-        val libD =
-            LibDModel(
-                sharedName = "FromD",
-                specificD = "ValueD",
-            )
-        val libE =
-            LibEModel(
-                sharedName = "FromE", // This should take precedence
-                specificE = 100,
-            )
+class OverlapTest :
+    FunSpec({
+        test("combineMappingWithOverlap") {
+            val libD =
+                LibDModel(
+                    sharedName = "FromD",
+                    specificD = "ValueD",
+                )
+            val libE =
+                LibEModel(
+                    sharedName = "FromE", // This should take precedence
+                    specificE = 100,
+                )
 
-        val result: OverlapTargetModel =
-            libD.copyToOverlapTargetModel(
-                libEModel = libE,
-            )
+            val result: OverlapTargetModel =
+                libD.copyToOverlapTargetModel(
+                    libEModel = libE,
+                )
 
-        val expected =
-            OverlapTargetModel(
-                sharedName = "FromE", // Last source (LibE) takes precedence
-                valueA = "ValueD", // Mapped from specificD
-                valueB = 100, // Mapped from specificE
-            )
+            val expected =
+                OverlapTargetModel(
+                    sharedName = "FromE", // Last source (LibE) takes precedence
+                    valueA = "ValueD", // Mapped from specificD
+                    valueB = 100, // Mapped from specificE
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun combineMappingWithOverlapAndOverride() {
-        val libD =
-            LibDModel(
-                sharedName = "FromD",
-                specificD = "ValueD",
-            )
-        val libE =
-            LibEModel(
-                sharedName = "FromE",
-                specificE = 100,
-            )
+        test("combineMappingWithOverlapAndOverride") {
+            val libD =
+                LibDModel(
+                    sharedName = "FromD",
+                    specificD = "ValueD",
+                )
+            val libE =
+                LibEModel(
+                    sharedName = "FromE",
+                    specificE = 100,
+                )
 
-        val result: OverlapTargetModel =
-            libD.copyToOverlapTargetModel(
-                libEModel = libE,
-                sharedName = "Overridden",
-            )
+            val result: OverlapTargetModel =
+                libD.copyToOverlapTargetModel(
+                    libEModel = libE,
+                    sharedName = "Overridden",
+                )
 
-        val expected =
-            OverlapTargetModel(
-                sharedName = "Overridden",
-                valueA = "ValueD",
-                valueB = 100,
-            )
+            val expected =
+                OverlapTargetModel(
+                    sharedName = "Overridden",
+                    valueA = "ValueD",
+                    valueB = 100,
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/PropertyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/PropertyMappingTest.kt
@@ -1,70 +1,69 @@
 package me.tbsten.cream.test.combineMapping
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class PropertyMappingTest {
-    @Test
-    fun combineMappingWithPropertyNames() {
-        val libA =
-            LibAModel(
-                nameA = "SourceNameA",
-                valueA = 42,
-            )
-        val libB =
-            LibBModel(
-                nameB = "SourceNameB",
-                valueB = 2.71,
-            )
+class PropertyMappingTest :
+    FunSpec({
+        test("combineMappingWithPropertyNames") {
+            val libA =
+                LibAModel(
+                    nameA = "SourceNameA",
+                    valueA = 42,
+                )
+            val libB =
+                LibBModel(
+                    nameB = "SourceNameB",
+                    valueB = 2.71,
+                )
 
-        val result: RenamedTargetModel =
-            libA.copyToRenamedTargetModel(
-                libBModel = libB,
-                extra = "Extra",
-            )
+            val result: RenamedTargetModel =
+                libA.copyToRenamedTargetModel(
+                    libBModel = libB,
+                    extra = "Extra",
+                )
 
-        val expected =
-            RenamedTargetModel(
-                targetNameA = "SourceNameA",
-                targetValueA = 42,
-                targetNameB = "SourceNameB",
-                targetValueB = 2.71,
-                extra = "Extra",
-            )
+            val expected =
+                RenamedTargetModel(
+                    targetNameA = "SourceNameA",
+                    targetValueA = 42,
+                    targetNameB = "SourceNameB",
+                    targetValueB = 2.71,
+                    extra = "Extra",
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun combineMappingWithPropertyNamesAndOverride() {
-        val libA =
-            LibAModel(
-                nameA = "SourceNameA",
-                valueA = 42,
-            )
-        val libB =
-            LibBModel(
-                nameB = "SourceNameB",
-                valueB = 2.71,
-            )
+        test("combineMappingWithPropertyNamesAndOverride") {
+            val libA =
+                LibAModel(
+                    nameA = "SourceNameA",
+                    valueA = 42,
+                )
+            val libB =
+                LibBModel(
+                    nameB = "SourceNameB",
+                    valueB = 2.71,
+                )
 
-        val result: RenamedTargetModel =
-            libA.copyToRenamedTargetModel(
-                libBModel = libB,
-                targetNameA = "Overridden",
-                targetValueB = 999.0,
-                extra = "Extra",
-            )
+            val result: RenamedTargetModel =
+                libA.copyToRenamedTargetModel(
+                    libBModel = libB,
+                    targetNameA = "Overridden",
+                    targetValueB = 999.0,
+                    extra = "Extra",
+                )
 
-        val expected =
-            RenamedTargetModel(
-                targetNameA = "Overridden",
-                targetValueA = 42,
-                targetNameB = "SourceNameB",
-                targetValueB = 999.0,
-                extra = "Extra",
-            )
+            val expected =
+                RenamedTargetModel(
+                    targetNameA = "Overridden",
+                    targetValueA = 42,
+                    targetNameB = "SourceNameB",
+                    targetValueB = 999.0,
+                    extra = "Extra",
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/BasicTest.kt
@@ -1,52 +1,51 @@
 package me.tbsten.cream.test.combineTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class BasicTest {
-    @Test
-    fun combineToTarget() {
-        val sourceA = SourceStateA(propertyA = "sourceA")
-        val sourceB = SourceStateB(propertyB = 42)
+class BasicTest :
+    FunSpec({
+        test("combineToTarget") {
+            val sourceA = SourceStateA(propertyA = "sourceA")
+            val sourceB = SourceStateB(propertyB = 42)
 
-        val result: TargetState =
-            sourceA.copyToTargetState(
-                sourceStateB = sourceB,
-                propertyC = true,
-            )
+            val result: TargetState =
+                sourceA.copyToTargetState(
+                    sourceStateB = sourceB,
+                    propertyC = true,
+                )
 
-        // Verify
-        val expected =
-            TargetState(
-                propertyA = "sourceA",
-                propertyB = 42,
-                propertyC = true,
-            )
+            // Verify
+            val expected =
+                TargetState(
+                    propertyA = "sourceA",
+                    propertyB = 42,
+                    propertyC = true,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun combineToTargetWithOverride() {
-        val sourceA = SourceStateA(propertyA = "sourceA")
-        val sourceB = SourceStateB(propertyB = 42)
+        test("combineToTargetWithOverride") {
+            val sourceA = SourceStateA(propertyA = "sourceA")
+            val sourceB = SourceStateB(propertyB = 42)
 
-        val result: TargetState =
-            sourceA.copyToTargetState(
-                sourceStateB = sourceB,
-                propertyA = "overridden",
-                propertyB = 100,
-                propertyC = true,
-            )
+            val result: TargetState =
+                sourceA.copyToTargetState(
+                    sourceStateB = sourceB,
+                    propertyA = "overridden",
+                    propertyB = 100,
+                    propertyC = true,
+                )
 
-        // Verify
-        val expected =
-            TargetState(
-                propertyA = "overridden",
-                propertyB = 100,
-                propertyC = true,
-            )
+            // Verify
+            val expected =
+                TargetState(
+                    propertyA = "overridden",
+                    propertyB = 100,
+                    propertyC = true,
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/GenericsTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/GenericsTest.kt
@@ -1,25 +1,25 @@
 package me.tbsten.cream.test.combineTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class GenericsTest {
-    @Test
-    fun combineWithGenerics() {
-        val sourceA = GenericSourceA(genericProperty = 123)
-        val sourceB = GenericSourceB(normalProperty = "normal")
+class GenericsTest :
+    FunSpec({
+        test("combineWithGenerics") {
+            val sourceA = GenericSourceA(genericProperty = 123)
+            val sourceB = GenericSourceB(normalProperty = "normal")
 
-        val result: GenericTarget<Int> =
-            sourceA.copyToGenericTarget(
-                genericSourceB = sourceB,
-            )
+            val result: GenericTarget<Int> =
+                sourceA.copyToGenericTarget(
+                    genericSourceB = sourceB,
+                )
 
-        val expected =
-            GenericTarget(
-                genericProperty = 123,
-                normalProperty = "normal",
-            )
+            val expected =
+                GenericTarget(
+                    genericProperty = 123,
+                    normalProperty = "normal",
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/MultiSourceTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/MultiSourceTest.kt
@@ -1,31 +1,31 @@
 package me.tbsten.cream.test.combineTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class MultiSourceTest {
-    @Test
-    fun combineMultipleSources() {
-        val sourceA = MultiSourceA(propertyA = "A")
-        val sourceB = MultiSourceB(propertyB = 1)
-        val sourceC = MultiSourceC(propertyC = true)
-        val sourceD = MultiSourceD(propertyD = 3.14)
+class MultiSourceTest :
+    FunSpec({
+        test("combineMultipleSources") {
+            val sourceA = MultiSourceA(propertyA = "A")
+            val sourceB = MultiSourceB(propertyB = 1)
+            val sourceC = MultiSourceC(propertyC = true)
+            val sourceD = MultiSourceD(propertyD = 3.14)
 
-        val result =
-            sourceA.copyToMultiSourceTarget(
-                multiSourceB = sourceB,
-                multiSourceC = sourceC,
-                multiSourceD = sourceD,
-            )
+            val result =
+                sourceA.copyToMultiSourceTarget(
+                    multiSourceB = sourceB,
+                    multiSourceC = sourceC,
+                    multiSourceD = sourceD,
+                )
 
-        val expected =
-            MultiSourceTarget(
-                propertyA = "A",
-                propertyB = 1,
-                propertyC = true,
-                propertyD = 3.14,
-            )
+            val expected =
+                MultiSourceTarget(
+                    propertyA = "A",
+                    propertyB = 1,
+                    propertyC = true,
+                    propertyD = 3.14,
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/NullableTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/NullableTest.kt
@@ -1,44 +1,43 @@
 package me.tbsten.cream.test.combineTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class NullableTest {
-    @Test
-    fun combineWithNullableProperties() {
-        val sourceA = NullableSourceA(nullableProperty = "nullable value")
-        val sourceB = NullableSourceB(requiredProperty = "required")
+class NullableTest :
+    FunSpec({
+        test("combineWithNullableProperties") {
+            val sourceA = NullableSourceA(nullableProperty = "nullable value")
+            val sourceB = NullableSourceB(requiredProperty = "required")
 
-        val result: NullableTarget =
-            sourceA.copyToNullableTarget(
-                nullableSourceB = sourceB,
-            )
+            val result: NullableTarget =
+                sourceA.copyToNullableTarget(
+                    nullableSourceB = sourceB,
+                )
 
-        val expected =
-            NullableTarget(
-                nullableProperty = "nullable value",
-                requiredProperty = "required",
-            )
+            val expected =
+                NullableTarget(
+                    nullableProperty = "nullable value",
+                    requiredProperty = "required",
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun combineWithNullableNull() {
-        val sourceA = NullableSourceA(nullableProperty = null)
-        val sourceB = NullableSourceB(requiredProperty = "required")
+        test("combineWithNullableNull") {
+            val sourceA = NullableSourceA(nullableProperty = null)
+            val sourceB = NullableSourceB(requiredProperty = "required")
 
-        val result =
-            sourceA.copyToNullableTarget(
-                nullableSourceB = sourceB,
-            )
+            val result =
+                sourceA.copyToNullableTarget(
+                    nullableSourceB = sourceB,
+                )
 
-        val expected =
-            NullableTarget(
-                nullableProperty = null,
-                requiredProperty = "required",
-            )
+            val expected =
+                NullableTarget(
+                    nullableProperty = null,
+                    requiredProperty = "required",
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/ObjectTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/ObjectTargetTest.kt
@@ -1,20 +1,20 @@
 package me.tbsten.cream.test.combineTo
 
-import kotlin.test.Test
-import kotlin.test.assertSame
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 
-class ObjectTargetTest {
-    @Test
-    fun combineToObject() {
-        val sourceA = ObjectSourceA(propertyA = "test")
-        val sourceB = ObjectSourceB(propertyB = 42)
+class ObjectTargetTest :
+    FunSpec({
+        test("combineToObject") {
+            val sourceA = ObjectSourceA(propertyA = "test")
+            val sourceB = ObjectSourceB(propertyB = 42)
 
-        val result =
-            sourceA.copyToTargetObject(
-                objectSourceB = sourceB,
-            )
+            val result =
+                sourceA.copyToTargetObject(
+                    objectSourceB = sourceB,
+                )
 
-        // Objects are singletons, so the result should be the same instance
-        assertSame(TargetObject, result)
-    }
-}
+            // Objects are singletons, so the result should be the same instance
+            result shouldBeSameInstanceAs TargetObject
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/OverlapTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/OverlapTest.kt
@@ -1,51 +1,50 @@
 package me.tbsten.cream.test.combineTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class OverlapTest {
-    @Test
-    fun combineWithOverlappingProperties() {
-        val sourceA = OverlapSourceA(sharedProperty = "from A", uniqueA = 42)
-        val sourceB = OverlapSourceB(sharedProperty = "from B", uniqueB = true)
+class OverlapTest :
+    FunSpec({
+        test("combineWithOverlappingProperties") {
+            val sourceA = OverlapSourceA(sharedProperty = "from A", uniqueA = 42)
+            val sourceB = OverlapSourceB(sharedProperty = "from B", uniqueB = true)
 
-        // When called from sourceA, sourceB's sharedProperty should be prioritized
-        val result: OverlapTarget =
-            sourceA.copyToOverlapTarget(
-                overlapSourceB = sourceB,
-            )
+            // When called from sourceA, sourceB's sharedProperty should be prioritized
+            val result: OverlapTarget =
+                sourceA.copyToOverlapTarget(
+                    overlapSourceB = sourceB,
+                )
 
-        val expected =
-            OverlapTarget(
-                sharedProperty = "from B", // SourceB is prioritized for overlapping properties
-                uniqueA = 42,
-                uniqueB = true,
-            )
+            val expected =
+                OverlapTarget(
+                    sharedProperty = "from B", // SourceB is prioritized for overlapping properties
+                    uniqueA = 42,
+                    uniqueB = true,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun combineWithOverlappingPropertiesWithOverrides() {
-        val sourceA = OverlapSourceA(sharedProperty = "from A", uniqueA = 42)
-        val sourceB = OverlapSourceB(sharedProperty = "from B", uniqueB = true)
+        test("combineWithOverlappingPropertiesWithOverrides") {
+            val sourceA = OverlapSourceA(sharedProperty = "from A", uniqueA = 42)
+            val sourceB = OverlapSourceB(sharedProperty = "from B", uniqueB = true)
 
-        // When called from sourceA, sourceB's sharedProperty should be prioritized
-        val result =
-            sourceA.copyToOverlapTarget(
-                overlapSourceB = sourceB,
-                sharedProperty = "overridden",
-                uniqueA = 42,
-                uniqueB = true,
-            )
+            // When called from sourceA, sourceB's sharedProperty should be prioritized
+            val result =
+                sourceA.copyToOverlapTarget(
+                    overlapSourceB = sourceB,
+                    sharedProperty = "overridden",
+                    uniqueA = 42,
+                    uniqueB = true,
+                )
 
-        val expected =
-            OverlapTarget(
-                sharedProperty = "overridden", // SourceB is prioritized for overlapping properties
-                uniqueA = 42,
-                uniqueB = true,
-            )
+            val expected =
+                OverlapTarget(
+                    sharedProperty = "overridden", // SourceB is prioritized for overlapping properties
+                    uniqueA = 42,
+                    uniqueB = true,
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/PropertyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/PropertyMappingTest.kt
@@ -1,66 +1,63 @@
 package me.tbsten.cream.test.combineTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class PropertyMappingTest {
-    @Test
-    fun simplePropertyNameMapping() {
-        val sourceA = MappingSourceA(sourcePropertyA = "Hello")
-        val sourceB = MappingSourceB(sourcePropertyB = 42)
+class PropertyMappingTest :
+    FunSpec({
+        test("simplePropertyNameMapping") {
+            val sourceA = MappingSourceA(sourcePropertyA = "Hello")
+            val sourceB = MappingSourceB(sourcePropertyB = 42)
 
-        val result: MappedTarget =
-            sourceA.copyToMappedTarget(
-                mappingSourceB = sourceB,
-                normalProperty = "World",
-            )
+            val result: MappedTarget =
+                sourceA.copyToMappedTarget(
+                    mappingSourceB = sourceB,
+                    normalProperty = "World",
+                )
 
-        assertEquals("Hello", result.targetPropertyA)
-        assertEquals(42, result.targetPropertyB)
-        assertEquals("World", result.normalProperty)
-    }
+            result.targetPropertyA shouldBe "Hello"
+            result.targetPropertyB shouldBe 42
+            result.normalProperty shouldBe "World"
+        }
 
-    @Test
-    fun multiplePropertyNamesMapping() {
-        val source = MultiMappingSource(sourceName = "SharedValue")
-        val sourceB = MultiMappingSourceB(otherProp = 100)
+        test("multiplePropertyNamesMapping") {
+            val source = MultiMappingSource(sourceName = "SharedValue")
+            val sourceB = MultiMappingSourceB(otherProp = 100)
 
-        val result: MultiMappedTarget =
-            source.copyToMultiMappedTarget(
-                multiMappingSourceB = sourceB,
-            )
+            val result: MultiMappedTarget =
+                source.copyToMultiMappedTarget(
+                    multiMappingSourceB = sourceB,
+                )
 
-        assertEquals("SharedValue", result.targetName1)
-        assertEquals("SharedValue", result.targetName2)
-        assertEquals(100, result.otherProp)
-    }
+            result.targetName1 shouldBe "SharedValue"
+            result.targetName2 shouldBe "SharedValue"
+            result.otherProp shouldBe 100
+        }
 
-    @Test
-    fun mixedMappingWithDirectMatch() {
-        val sourceA = MixedMappingSourceA(directMatch = "Direct")
-        val sourceB = MixedMappingSourceB(originalProperty = 999)
+        test("mixedMappingWithDirectMatch") {
+            val sourceA = MixedMappingSourceA(directMatch = "Direct")
+            val sourceB = MixedMappingSourceB(originalProperty = 999)
 
-        val result: MixedMappingTarget =
-            sourceA.copyToMixedMappingTarget(
-                mixedMappingSourceB = sourceB,
-                extraProperty = true,
-            )
+            val result: MixedMappingTarget =
+                sourceA.copyToMixedMappingTarget(
+                    mixedMappingSourceB = sourceB,
+                    extraProperty = true,
+                )
 
-        assertEquals("Direct", result.directMatch)
-        assertEquals(999, result.renamedProperty)
-        assertEquals(true, result.extraProperty)
-    }
+            result.directMatch shouldBe "Direct"
+            result.renamedProperty shouldBe 999
+            result.extraProperty shouldBe true
+        }
 
-    @Test
-    fun mergeMappingWithDirectMatch() {
-        val sourceA = MergeMappingSourceA(sourcePropertyA = "SourceA")
-        val sourceB = MergeMappingSourceB(sourcePropertyB = "SourceB")
+        test("mergeMappingWithDirectMatch") {
+            val sourceA = MergeMappingSourceA(sourcePropertyA = "SourceA")
+            val sourceB = MergeMappingSourceB(sourcePropertyB = "SourceB")
 
-        val result =
-            sourceA.copyToMergeMappingTarget(
-                mergeMappingSourceB = sourceB,
-            )
+            val result =
+                sourceA.copyToMergeMappingTarget(
+                    mergeMappingSourceB = sourceB,
+                )
 
-        assertEquals("SourceB", result.sourcePropertyA)
-    }
-}
+            result.sourcePropertyA shouldBe "SourceB"
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/TypeAliasTest.kt
@@ -1,47 +1,46 @@
 package me.tbsten.cream.test.combineTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
-class TypeAliasTest {
-    @Test
-    fun testCombineToWithTypeAliasSource() {
-        // Create instances using actual class constructors and assign them to variables with typealias types.
-        // Note: Typealiases are just alternative names for the same types.
-        val sourceA: SourceAWithAlias = SourceA(propA = "value-a")
-        val sourceB: SourceBWithAlias = SourceB(propB = 42)
+class TypeAliasTest :
+    FunSpec({
+        test("testCombineToWithTypeAliasSource") {
+            // Create instances using actual class constructors and assign them to variables with typealias types.
+            // Note: Typealiases are just alternative names for the same types.
+            val sourceA: SourceAWithAlias = SourceA(propA = "value-a")
+            val sourceB: SourceBWithAlias = SourceB(propB = 42)
 
-        // Call the generated combine function
-        // Note: Function name and parameter names are based on the actual type (CombinedTarget, SourceB), not the alias
-        val combined: CombinedTargetAlias =
-            sourceA.copyToCombinedTarget(
-                sourceB = sourceB,
-                extra = "extra-value",
-            )
+            // Call the generated combine function
+            // Note: Function name and parameter names are based on the actual type (CombinedTarget, SourceB), not the alias
+            val combined: CombinedTargetAlias =
+                sourceA.copyToCombinedTarget(
+                    sourceB = sourceB,
+                    extra = "extra-value",
+                )
 
-        // Verify all properties are copied correctly
-        assertEquals("value-a", combined.propA)
-        assertEquals(42, combined.propB)
-        assertEquals("extra-value", combined.extra)
+            // Verify all properties are copied correctly
+            combined.propA shouldBe "value-a"
+            combined.propB shouldBe 42
+            combined.extra shouldBe "extra-value"
 
-        // Verify the result is actually a CombinedTarget instance
-        assertIs<CombinedTarget>(combined)
-    }
+            // Verify the result is actually a CombinedTarget instance
+            combined.shouldBeInstanceOf<CombinedTarget>()
+        }
 
-    @Test
-    fun testCombineToPreservesAllProperties() {
-        val sourceA: SourceAWithAlias = SourceA(propA = "test-prop-a")
-        val sourceB: SourceBWithAlias = SourceB(propB = 100)
+        test("testCombineToPreservesAllProperties") {
+            val sourceA: SourceAWithAlias = SourceA(propA = "test-prop-a")
+            val sourceB: SourceBWithAlias = SourceB(propB = 100)
 
-        val combined: CombinedTargetAlias =
-            sourceA.copyToCombinedTarget(
-                sourceB = sourceB,
-                extra = "test-extra",
-            )
+            val combined: CombinedTargetAlias =
+                sourceA.copyToCombinedTarget(
+                    sourceB = sourceB,
+                    extra = "test-extra",
+                )
 
-        // Verify that all source properties are preserved
-        assertEquals(sourceA.propA, combined.propA)
-        assertEquals(sourceB.propB, combined.propB)
-    }
-}
+            // Verify that all source properties are preserved
+            combined.propA shouldBe sourceA.propA
+            combined.propB shouldBe sourceB.propB
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/VisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/VisibilityTest.kt
@@ -1,17 +1,17 @@
 package me.tbsten.cream.test.combineTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class VisibilityTest {
-    // The generated function being `internal` is verified at compile time: this test
-    // (in the same module) can call it. A `public`-only caller would not compile.
-    @Test
-    fun internalVisibilityCombineFunctionIsCallable() {
-        val source = InternalVisibilityCombineSource(shared = "value")
-        val target: InternalVisibilityCombineTarget =
-            source.copyToInternalVisibilityCombineTarget(extra = 42)
+class VisibilityTest :
+    FunSpec({
+        // The generated function being `internal` is verified at compile time: this test
+        // (in the same module) can call it. A `public`-only caller would not compile.
+        test("internalVisibilityCombineFunctionIsCallable") {
+            val source = InternalVisibilityCombineSource(shared = "value")
+            val target: InternalVisibilityCombineTarget =
+                source.copyToInternalVisibilityCombineTarget(extra = 42)
 
-        assertEquals(InternalVisibilityCombineTarget("value", 42), target)
-    }
-}
+            target shouldBe InternalVisibilityCombineTarget("value", 42)
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/BasicTest.kt
@@ -1,44 +1,43 @@
 package me.tbsten.cream.test.copyFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class BasicTest {
-    @Test
-    fun dataLayerModelToDomainLayerModel() {
-        val dataLayerModel: DataLayerModel =
-            DataLayerModel(
-                prop1 = "prop1",
-                prop2 = 42,
-            )
-
-        mapOf(
-            dataLayerModel.copyToDomainLayerModel() to
-                DomainLayerModel(
-                    prop1 = "prop1",
-                    prop2 = 42,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
-        }
-    }
-
-    @Test
-    fun domainLayerModelToDataLayerModel() {
-        val domainLayerModel: DomainLayerModel =
-            DomainLayerModel(
-                prop1 = "prop1",
-                prop2 = 42,
-            )
-
-        mapOf(
-            domainLayerModel.copyToDataLayerModel() to
+class BasicTest :
+    FunSpec({
+        test("dataLayerModelToDomainLayerModel") {
+            val dataLayerModel: DataLayerModel =
                 DataLayerModel(
                     prop1 = "prop1",
                     prop2 = 42,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                )
+
+            mapOf(
+                dataLayerModel.copyToDomainLayerModel() to
+                    DomainLayerModel(
+                        prop1 = "prop1",
+                        prop2 = 42,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
-}
+
+        test("domainLayerModelToDataLayerModel") {
+            val domainLayerModel: DomainLayerModel =
+                DomainLayerModel(
+                    prop1 = "prop1",
+                    prop2 = 42,
+                )
+
+            mapOf(
+                domainLayerModel.copyToDataLayerModel() to
+                    DataLayerModel(
+                        prop1 = "prop1",
+                        prop2 = 42,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/ComplexTypesTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/ComplexTypesTest.kt
@@ -1,50 +1,45 @@
 package me.tbsten.cream.test.copyFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class ComplexTypesTest {
-    @Test
-    fun complexTypes() {
-        val source =
-            ComplexTypeSource(
-                stringList = listOf("a", "b", "c"),
-                intMap = mapOf("one" to 1, "two" to 2),
-                nullableSet = setOf(1.0, 2.0, 3.0),
-            )
+class ComplexTypesTest :
+    FunSpec({
+        test("complexTypes") {
+            val source =
+                ComplexTypeSource(
+                    stringList = listOf("a", "b", "c"),
+                    intMap = mapOf("one" to 1, "two" to 2),
+                    nullableSet = setOf(1.0, 2.0, 3.0),
+                )
 
-        val target: ComplexTypeTarget = source.copyToComplexTypeTarget(newProperty = "new")
+            val target: ComplexTypeTarget = source.copyToComplexTypeTarget(newProperty = "new")
 
-        assertEquals(
-            ComplexTypeTarget(
-                stringList = listOf("a", "b", "c"),
-                intMap = mapOf("one" to 1, "two" to 2),
-                nullableSet = setOf(1.0, 2.0, 3.0),
-                newProperty = "new",
-            ),
-            target,
-        )
-    }
+            target shouldBe
+                ComplexTypeTarget(
+                    stringList = listOf("a", "b", "c"),
+                    intMap = mapOf("one" to 1, "two" to 2),
+                    nullableSet = setOf(1.0, 2.0, 3.0),
+                    newProperty = "new",
+                )
+        }
 
-    @Test
-    fun complexTypesWithNull() {
-        val source =
-            ComplexTypeSource(
-                stringList = listOf("a", "b", "c"),
-                intMap = mapOf("one" to 1, "two" to 2),
-                nullableSet = null,
-            )
+        test("complexTypesWithNull") {
+            val source =
+                ComplexTypeSource(
+                    stringList = listOf("a", "b", "c"),
+                    intMap = mapOf("one" to 1, "two" to 2),
+                    nullableSet = null,
+                )
 
-        val target: ComplexTypeTarget = source.copyToComplexTypeTarget(newProperty = "new")
+            val target: ComplexTypeTarget = source.copyToComplexTypeTarget(newProperty = "new")
 
-        assertEquals(
-            ComplexTypeTarget(
-                stringList = listOf("a", "b", "c"),
-                intMap = mapOf("one" to 1, "two" to 2),
-                nullableSet = null,
-                newProperty = "new",
-            ),
-            target,
-        )
-    }
-}
+            target shouldBe
+                ComplexTypeTarget(
+                    stringList = listOf("a", "b", "c"),
+                    intMap = mapOf("one" to 1, "two" to 2),
+                    nullableSet = null,
+                    newProperty = "new",
+                )
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/NestedTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/NestedTest.kt
@@ -1,15 +1,15 @@
 package me.tbsten.cream.test.copyFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class NestedTest {
-    @Test
-    fun nestedClasses() {
-        val parent = ParentClass("parent", 100)
-        val source = NestedSource(parent)
-        val target: NestedTarget = source.copyToNestedTarget(newProperty = "new")
+class NestedTest :
+    FunSpec({
+        test("nestedClasses") {
+            val parent = ParentClass("parent", 100)
+            val source = NestedSource(parent)
+            val target: NestedTarget = source.copyToNestedTarget(newProperty = "new")
 
-        assertEquals(NestedTarget(parent, "new"), target)
-    }
-}
+            target shouldBe NestedTarget(parent, "new")
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/NullableTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/NullableTest.kt
@@ -1,54 +1,49 @@
 package me.tbsten.cream.test.copyFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class NullableTest {
-    @Test
-    fun nonNullableToNullable() {
-        val source =
-            NonNullableSource(
-                str = "test string",
-                num = 42,
-                bool = true,
-                list = listOf("item1", "item2", "item3"),
-            )
+class NullableTest :
+    FunSpec({
+        test("nonNullableToNullable") {
+            val source =
+                NonNullableSource(
+                    str = "test string",
+                    num = 42,
+                    bool = true,
+                    list = listOf("item1", "item2", "item3"),
+                )
 
-        val target: NullableTarget = source.copyToNullableTarget(newProperty = "new")
+            val target: NullableTarget = source.copyToNullableTarget(newProperty = "new")
 
-        assertEquals(
-            NullableTarget(
-                str = "test string",
-                num = 42,
-                bool = true,
-                list = listOf("item1", "item2", "item3"),
-                newProperty = "new",
-            ),
-            target,
-        )
-    }
+            target shouldBe
+                NullableTarget(
+                    str = "test string",
+                    num = 42,
+                    bool = true,
+                    list = listOf("item1", "item2", "item3"),
+                    newProperty = "new",
+                )
+        }
 
-    @Test
-    fun nonNullableToNullableWithEmptyValues() {
-        val source =
-            NonNullableSource(
-                str = "",
-                num = 0,
-                bool = false,
-                list = emptyList(),
-            )
+        test("nonNullableToNullableWithEmptyValues") {
+            val source =
+                NonNullableSource(
+                    str = "",
+                    num = 0,
+                    bool = false,
+                    list = emptyList(),
+                )
 
-        val target: NullableTarget = source.copyToNullableTarget(newProperty = "new")
+            val target: NullableTarget = source.copyToNullableTarget(newProperty = "new")
 
-        assertEquals(
-            NullableTarget(
-                str = "",
-                num = 0,
-                bool = false,
-                list = emptyList(),
-                newProperty = "new",
-            ),
-            target,
-        )
-    }
-}
+            target shouldBe
+                NullableTarget(
+                    str = "",
+                    num = 0,
+                    bool = false,
+                    list = emptyList(),
+                    newProperty = "new",
+                )
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/ObjectTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/ObjectTargetTest.kt
@@ -1,14 +1,14 @@
 package me.tbsten.cream.test.copyFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class ObjectTargetTest {
-    @Test
-    fun dataObjectToDataObject() {
-        val source = EmptySource
-        val target: EmptyTarget = source.copyToEmptyTarget()
+class ObjectTargetTest :
+    FunSpec({
+        test("dataObjectToDataObject") {
+            val source = EmptySource
+            val target: EmptyTarget = source.copyToEmptyTarget()
 
-        assertEquals(EmptyTarget, target)
-    }
-}
+            target shouldBe EmptyTarget
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/PropertyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/PropertyMappingTest.kt
@@ -1,22 +1,19 @@
 package me.tbsten.cream.test.copyFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class PropertyMappingTest {
-    @Test
-    fun propertyMapping() {
-        val dataModel =
-            DataModel(
-                dataId = "test-id",
-                name = "test-name",
-            )
+class PropertyMappingTest :
+    FunSpec({
+        test("propertyMapping") {
+            val dataModel =
+                DataModel(
+                    dataId = "test-id",
+                    name = "test-name",
+                )
 
-        val domainModel: DomainModel = dataModel.copyToDomainModel()
+            val domainModel: DomainModel = dataModel.copyToDomainModel()
 
-        assertEquals(
-            DomainModel(domainId = "test-id", name = "test-name"),
-            domainModel,
-        )
-    }
-}
+            domainModel shouldBe DomainModel(domainId = "test-id", name = "test-name")
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/TypeAliasTest.kt
@@ -1,33 +1,32 @@
 package me.tbsten.cream.test.copyFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
-class TypeAliasTest {
-    @Test
-    fun testCopyFromTypeAlias() {
-        // Create a SourceModel instance and assign it to a variable typed as SourceModelAlias.
-        // Note: SourceModelAlias is just a type alias for SourceModel.
-        val sourceModel: SourceModelAlias = SourceModel(value = "test-value")
+class TypeAliasTest :
+    FunSpec({
+        test("testCopyFromTypeAlias") {
+            // Create a SourceModel instance and assign it to a variable typed as SourceModelAlias.
+            // Note: SourceModelAlias is just a type alias for SourceModel.
+            val sourceModel: SourceModelAlias = SourceModel(value = "test-value")
 
-        // Call the generated copyToTargetModel function
-        // Note: Function name is based on the actual type (TargetModel), not the alias
-        val targetModel: TargetModelAlias = sourceModel.copyToTargetModel()
+            // Call the generated copyToTargetModel function
+            // Note: Function name is based on the actual type (TargetModel), not the alias
+            val targetModel: TargetModelAlias = sourceModel.copyToTargetModel()
 
-        // Verify the value property is copied correctly
-        assertEquals("test-value", targetModel.value)
+            // Verify the value property is copied correctly
+            targetModel.value shouldBe "test-value"
 
-        // Verify the result is actually a TargetModel instance
-        assertIs<TargetModel>(targetModel)
-    }
+            // Verify the result is actually a TargetModel instance
+            targetModel.shouldBeInstanceOf<TargetModel>()
+        }
 
-    @Test
-    fun testTypeAliasPreservesValue() {
-        val original: SourceModelAlias = SourceModel(value = "original-value")
-        val copied: TargetModelAlias = original.copyToTargetModel()
+        test("testTypeAliasPreservesValue") {
+            val original: SourceModelAlias = SourceModel(value = "original-value")
+            val copied: TargetModelAlias = original.copyToTargetModel()
 
-        // Verify that the copied object has the same property values
-        assertEquals(original.value, copied.value)
-    }
-}
+            // Verify that the copied object has the same property values
+            copied.value shouldBe original.value
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/VisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/VisibilityTest.kt
@@ -1,14 +1,14 @@
 package me.tbsten.cream.test.copyFrom
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class VisibilityTest {
-    @Test
-    fun visibilityProperties() {
-        val source = VisibilitySource("public", 42, true)
-        val target: VisibilityTarget = source.copyToVisibilityTarget(newProperty = "new")
+class VisibilityTest :
+    FunSpec({
+        test("visibilityProperties") {
+            val source = VisibilitySource("public", 42, true)
+            val target: VisibilityTarget = source.copyToVisibilityTarget(newProperty = "new")
 
-        assertEquals(VisibilityTarget("public", "new"), target)
-    }
-}
+            target shouldBe VisibilityTarget("public", "new")
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/CopyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/CopyMappingTest.kt
@@ -1,207 +1,199 @@
 package me.tbsten.cream.test.copyMapping
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class CopyMappingTest {
-    @Test
-    fun libXModelToLibYModel() {
-        val libXModel =
-            LibXModel(
-                shareProp = "shared",
-                xProp = 42,
-            )
+class CopyMappingTest :
+    FunSpec({
+        test("libXModelToLibYModel") {
+            val libXModel =
+                LibXModel(
+                    shareProp = "shared",
+                    xProp = 42,
+                )
 
-        val result =
-            libXModel.copyToLibYModel(
-                yProp = 100,
-            )
+            val result =
+                libXModel.copyToLibYModel(
+                    yProp = 100,
+                )
 
-        val expected =
-            LibYModel(
-                shareProp = "shared",
-                yProp = 100,
-            )
+            val expected =
+                LibYModel(
+                    shareProp = "shared",
+                    yProp = 100,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun libXModelToLibYModelWithOverride() {
-        val libXModel =
-            LibXModel(
-                shareProp = "shared",
-                xProp = 42,
-            )
+        test("libXModelToLibYModelWithOverride") {
+            val libXModel =
+                LibXModel(
+                    shareProp = "shared",
+                    xProp = 42,
+                )
 
-        val result =
-            libXModel.copyToLibYModel(
-                shareProp = "overridden",
-                yProp = 100,
-            )
+            val result =
+                libXModel.copyToLibYModel(
+                    shareProp = "overridden",
+                    yProp = 100,
+                )
 
-        val expected =
-            LibYModel(
-                shareProp = "overridden",
-                yProp = 100,
-            )
+            val expected =
+                LibYModel(
+                    shareProp = "overridden",
+                    yProp = 100,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun libYModelToLibZModel() {
-        val libYModel =
-            LibYModel(
-                shareProp = "shared",
-                yProp = 200,
-            )
+        test("libYModelToLibZModel") {
+            val libYModel =
+                LibYModel(
+                    shareProp = "shared",
+                    yProp = 200,
+                )
 
-        val result =
-            libYModel.copyToLibZModel(
-                zProp = 300,
-            )
+            val result =
+                libYModel.copyToLibZModel(
+                    zProp = 300,
+                )
 
-        val expected =
-            LibZModel(
-                shareProp = "shared",
-                zProp = 300,
-            )
+            val expected =
+                LibZModel(
+                    shareProp = "shared",
+                    zProp = 300,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun libYModelToLibZModelWithOverride() {
-        val libYModel =
-            LibYModel(
-                shareProp = "shared",
-                yProp = 200,
-            )
+        test("libYModelToLibZModelWithOverride") {
+            val libYModel =
+                LibYModel(
+                    shareProp = "shared",
+                    yProp = 200,
+                )
 
-        val result =
-            libYModel.copyToLibZModel(
-                shareProp = "new-shared",
-                zProp = 400,
-            )
+            val result =
+                libYModel.copyToLibZModel(
+                    shareProp = "new-shared",
+                    zProp = 400,
+                )
 
-        val expected =
-            LibZModel(
-                shareProp = "new-shared",
-                zProp = 400,
-            )
+            val expected =
+                LibZModel(
+                    shareProp = "new-shared",
+                    zProp = 400,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun libXModelToLibYModelWithPropertyMapping() {
-        // Test that xProp from LibXModel maps to yProp in LibYModel
-        // via the CopyMapping.Map property mapping
-        val libXModel =
-            LibXModel(
-                shareProp = "shared",
-                xProp = 42,
-            )
+        test("libXModelToLibYModelWithPropertyMapping") {
+            // Test that xProp from LibXModel maps to yProp in LibYModel
+            // via the CopyMapping.Map property mapping
+            val libXModel =
+                LibXModel(
+                    shareProp = "shared",
+                    xProp = 42,
+                )
 
-        val result: LibYModel = libXModel.copyToLibYModel()
+            val result: LibYModel = libXModel.copyToLibYModel()
 
-        val expected =
-            LibYModel(
-                shareProp = "shared",
-                yProp = 42,
-            )
+            val expected =
+                LibYModel(
+                    shareProp = "shared",
+                    yProp = 42,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun libXModelToLibYModelWithPropertyMappingAndOverride() {
-        // Test that property mapping can be overridden
-        val libXModel =
-            LibXModel(
-                shareProp = "shared",
-                xProp = 42,
-            )
+        test("libXModelToLibYModelWithPropertyMappingAndOverride") {
+            // Test that property mapping can be overridden
+            val libXModel =
+                LibXModel(
+                    shareProp = "shared",
+                    xProp = 42,
+                )
 
-        val result =
-            libXModel.copyToLibYModel(
-                yProp = 999,
-            )
+            val result =
+                libXModel.copyToLibYModel(
+                    yProp = 999,
+                )
 
-        val expected =
-            LibYModel(
-                shareProp = "shared",
-                yProp = 999,
-            )
+            val expected =
+                LibYModel(
+                    shareProp = "shared",
+                    yProp = 999,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun libWModelToLibVModelWithCanReverse() {
-        val libWModel =
-            LibWModel(
-                shareProp = "shared",
-                wProp = 3.14,
-            )
+        test("libWModelToLibVModelWithCanReverse") {
+            val libWModel =
+                LibWModel(
+                    shareProp = "shared",
+                    wProp = 3.14,
+                )
 
-        val result =
-            libWModel.copyToLibVModel(
-                vProp = true,
-            )
+            val result =
+                libWModel.copyToLibVModel(
+                    vProp = true,
+                )
 
-        val expected =
-            LibVModel(
-                shareProp = "shared",
-                vProp = true,
-            )
+            val expected =
+                LibVModel(
+                    shareProp = "shared",
+                    vProp = true,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun libVModelToLibWModelWithCanReverse() {
-        val libVModel =
-            LibVModel(
-                shareProp = "shared",
-                vProp = false,
-            )
+        test("libVModelToLibWModelWithCanReverse") {
+            val libVModel =
+                LibVModel(
+                    shareProp = "shared",
+                    vProp = false,
+                )
 
-        val result =
-            libVModel.copyToLibWModel(
-                wProp = 2.71,
-            )
+            val result =
+                libVModel.copyToLibWModel(
+                    wProp = 2.71,
+                )
 
-        val expected =
-            LibWModel(
-                shareProp = "shared",
-                wProp = 2.71,
-            )
+            val expected =
+                LibWModel(
+                    shareProp = "shared",
+                    wProp = 2.71,
+                )
 
-        assertEquals(expected, result)
-    }
+            result shouldBe expected
+        }
 
-    @Test
-    fun libWModelToLibVModelWithCanReverseAndOverride() {
-        val libWModel =
-            LibWModel(
-                shareProp = "shared",
-                wProp = 3.14,
-            )
+        test("libWModelToLibVModelWithCanReverseAndOverride") {
+            val libWModel =
+                LibWModel(
+                    shareProp = "shared",
+                    wProp = 3.14,
+                )
 
-        val result =
-            libWModel.copyToLibVModel(
-                shareProp = "overridden",
-                vProp = true,
-            )
+            val result =
+                libWModel.copyToLibVModel(
+                    shareProp = "overridden",
+                    vProp = true,
+                )
 
-        val expected =
-            LibVModel(
-                shareProp = "overridden",
-                vProp = true,
-            )
+            val expected =
+                LibVModel(
+                    shareProp = "overridden",
+                    vProp = true,
+                )
 
-        assertEquals(expected, result)
-    }
-}
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/BasicTest.kt
@@ -1,187 +1,182 @@
 package me.tbsten.cream.test.copyTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class BasicTest {
-    @Test
-    fun parentToChildren() {
-        val parent: Parent =
-            ChildDataObject
+class BasicTest :
+    FunSpec({
+        test("parentToChildren") {
+            val parent: Parent =
+                ChildDataObject
 
-        mapOf(
-            parent.copyToChildDataObject() to ChildDataObject,
-            parent.copyToChildDataClass(
-                parentOrNull = null,
-                childProp1 = 1.0,
-                childProp2 = 2L,
-                childProp3 = "child",
-            ) to
-                ChildDataClass(
-                    parentProp1 = parent.parentProp1,
-                    parentProp2 = parent.parentProp2,
-                    parentProp3 = parent.parentProp3,
+            mapOf(
+                parent.copyToChildDataObject() to ChildDataObject,
+                parent.copyToChildDataClass(
+                    parentOrNull = null,
                     childProp1 = 1.0,
                     childProp2 = 2L,
                     childProp3 = "child",
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    ChildDataClass(
+                        parentProp1 = parent.parentProp1,
+                        parentProp2 = parent.parentProp2,
+                        parentProp3 = parent.parentProp3,
+                        childProp1 = 1.0,
+                        childProp2 = 2L,
+                        childProp3 = "child",
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun parentToChildrenWithOverrideParentProp() {
-        val parent: Parent =
-            ChildDataObject
+        test("parentToChildrenWithOverrideParentProp") {
+            val parent: Parent =
+                ChildDataObject
 
-        mapOf(
-            parent.copyToChildDataObject() to ChildDataObject,
-            parent.copyToChildDataClass(
-                parentOrNull = null,
-                parentProp1 = "parent",
-                parentProp2 = 123,
-                parentProp3 = false,
-                childProp1 = 1.0,
-                childProp2 = 2L,
-                childProp3 = "child",
-            ) to
-                ChildDataClass(
+            mapOf(
+                parent.copyToChildDataObject() to ChildDataObject,
+                parent.copyToChildDataClass(
+                    parentOrNull = null,
                     parentProp1 = "parent",
                     parentProp2 = 123,
                     parentProp3 = false,
                     childProp1 = 1.0,
                     childProp2 = 2L,
                     childProp3 = "child",
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    ChildDataClass(
+                        parentProp1 = "parent",
+                        parentProp2 = 123,
+                        parentProp3 = false,
+                        childProp1 = 1.0,
+                        childProp2 = 2L,
+                        childProp3 = "child",
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun parentToGrandChildren() {
-        val parent: Parent =
-            ChildDataObject
+        test("parentToGrandChildren") {
+            val parent: Parent =
+                ChildDataObject
 
-        mapOf(
-            parent.copyToGrandChildDataObject() to GrandChildDataObject,
-            parent.copyToGrandChildDataClass(
-                parentOrNull = null,
-                childProp1 = 1.0,
-                childProp2 = 2L,
-                childProp3 = "child",
-                grandChildProp1 = "grandChild",
-                grandChildProp2 = 3,
-                grandChildProp3 = true,
-            ) to
-                GrandChildDataClass(
-                    parentProp1 = parent.parentProp1,
-                    parentProp2 = parent.parentProp2,
-                    parentProp3 = parent.parentProp3,
+            mapOf(
+                parent.copyToGrandChildDataObject() to GrandChildDataObject,
+                parent.copyToGrandChildDataClass(
+                    parentOrNull = null,
                     childProp1 = 1.0,
                     childProp2 = 2L,
                     childProp3 = "child",
                     grandChildProp1 = "grandChild",
                     grandChildProp2 = 3,
                     grandChildProp3 = true,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    GrandChildDataClass(
+                        parentProp1 = parent.parentProp1,
+                        parentProp2 = parent.parentProp2,
+                        parentProp3 = parent.parentProp3,
+                        childProp1 = 1.0,
+                        childProp2 = 2L,
+                        childProp3 = "child",
+                        grandChildProp1 = "grandChild",
+                        grandChildProp2 = 3,
+                        grandChildProp3 = true,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun parentToGrandChildrenWithOverrideParentProp() {
-        val parent: Parent = ChildDataObject
+        test("parentToGrandChildrenWithOverrideParentProp") {
+            val parent: Parent = ChildDataObject
 
-        mapOf(
-            parent.copyToGrandChildDataObject() to GrandChildDataObject,
-            parent.copyToGrandChildDataClass(
-                parentProp1 = "parent",
-                parentProp2 = 123,
-                parentProp3 = false,
-                parentOrNull = null,
-                childProp1 = 1.0,
-                childProp2 = 2L,
-                childProp3 = "child",
-                grandChildProp1 = "grandChild",
-                grandChildProp2 = 3,
-                grandChildProp3 = true,
-            ) to
-                GrandChildDataClass(
+            mapOf(
+                parent.copyToGrandChildDataObject() to GrandChildDataObject,
+                parent.copyToGrandChildDataClass(
                     parentProp1 = "parent",
                     parentProp2 = 123,
                     parentProp3 = false,
+                    parentOrNull = null,
                     childProp1 = 1.0,
                     childProp2 = 2L,
                     childProp3 = "child",
                     grandChildProp1 = "grandChild",
                     grandChildProp2 = 3,
                     grandChildProp3 = true,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    GrandChildDataClass(
+                        parentProp1 = "parent",
+                        parentProp2 = 123,
+                        parentProp3 = false,
+                        childProp1 = 1.0,
+                        childProp2 = 2L,
+                        childProp3 = "child",
+                        grandChildProp1 = "grandChild",
+                        grandChildProp2 = 3,
+                        grandChildProp3 = true,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun childToGrandChildren() {
-        val child: ChildSealedInterface =
-            GrandChildDataObject
+        test("childToGrandChildren") {
+            val child: ChildSealedInterface =
+                GrandChildDataObject
 
-        mapOf(
-            child.copyToGrandChildDataObject() to GrandChildDataObject,
-            child.copyToGrandChildDataClass(
-                parentOrNull = null,
-                grandChildProp1 = "grandChild",
-                grandChildProp2 = 123,
-                grandChildProp3 = true,
-            ) to
-                GrandChildDataClass(
-                    parentProp1 = child.parentProp1,
-                    parentProp2 = child.parentProp2,
-                    parentProp3 = child.parentProp3,
-                    childProp1 = child.childProp1,
-                    childProp2 = child.childProp2,
-                    childProp3 = child.childProp3,
+            mapOf(
+                child.copyToGrandChildDataObject() to GrandChildDataObject,
+                child.copyToGrandChildDataClass(
+                    parentOrNull = null,
                     grandChildProp1 = "grandChild",
                     grandChildProp2 = 123,
                     grandChildProp3 = true,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    GrandChildDataClass(
+                        parentProp1 = child.parentProp1,
+                        parentProp2 = child.parentProp2,
+                        parentProp3 = child.parentProp3,
+                        childProp1 = child.childProp1,
+                        childProp2 = child.childProp2,
+                        childProp3 = child.childProp3,
+                        grandChildProp1 = "grandChild",
+                        grandChildProp2 = 123,
+                        grandChildProp3 = true,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun childToGrandChildrenWithOverrideChildProp() {
-        val child: ChildSealedInterface = GrandChildDataObject
+        test("childToGrandChildrenWithOverrideChildProp") {
+            val child: ChildSealedInterface = GrandChildDataObject
 
-        mapOf(
-            child.copyToGrandChildDataObject() to GrandChildDataObject,
-            child.copyToGrandChildDataClass(
-                parentOrNull = null,
-                childProp1 = 1.0,
-                childProp2 = 2L,
-                childProp3 = "child",
-                grandChildProp1 = "grandChild",
-                grandChildProp2 = 123,
-                grandChildProp3 = true,
-            ) to
-                GrandChildDataClass(
-                    parentProp1 = child.parentProp1,
-                    parentProp2 = child.parentProp2,
-                    parentProp3 = child.parentProp3,
+            mapOf(
+                child.copyToGrandChildDataObject() to GrandChildDataObject,
+                child.copyToGrandChildDataClass(
+                    parentOrNull = null,
                     childProp1 = 1.0,
                     childProp2 = 2L,
                     childProp3 = "child",
                     grandChildProp1 = "grandChild",
                     grandChildProp2 = 123,
                     grandChildProp3 = true,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    GrandChildDataClass(
+                        parentProp1 = child.parentProp1,
+                        parentProp2 = child.parentProp2,
+                        parentProp3 = child.parentProp3,
+                        childProp1 = 1.0,
+                        childProp2 = 2L,
+                        childProp3 = "child",
+                        grandChildProp1 = "grandChild",
+                        grandChildProp2 = 123,
+                        grandChildProp3 = true,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
-}
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/ComplexTypesTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/ComplexTypesTest.kt
@@ -1,50 +1,45 @@
 package me.tbsten.cream.test.copyTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class ComplexTypesTest {
-    @Test
-    fun complexTypes() {
-        val source =
-            ComplexTypeSource(
-                stringList = listOf("a", "b", "c"),
-                intMap = mapOf("one" to 1, "two" to 2),
-                nullableSet = setOf(1.0, 2.0, 3.0),
-            )
+class ComplexTypesTest :
+    FunSpec({
+        test("complexTypes") {
+            val source =
+                ComplexTypeSource(
+                    stringList = listOf("a", "b", "c"),
+                    intMap = mapOf("one" to 1, "two" to 2),
+                    nullableSet = setOf(1.0, 2.0, 3.0),
+                )
 
-        val target: ComplexTypeTarget = source.copyToComplexTypeTarget(newProperty = "new")
+            val target: ComplexTypeTarget = source.copyToComplexTypeTarget(newProperty = "new")
 
-        assertEquals(
-            ComplexTypeTarget(
-                stringList = listOf("a", "b", "c"),
-                intMap = mapOf("one" to 1, "two" to 2),
-                nullableSet = setOf(1.0, 2.0, 3.0),
-                newProperty = "new",
-            ),
-            target,
-        )
-    }
+            target shouldBe
+                ComplexTypeTarget(
+                    stringList = listOf("a", "b", "c"),
+                    intMap = mapOf("one" to 1, "two" to 2),
+                    nullableSet = setOf(1.0, 2.0, 3.0),
+                    newProperty = "new",
+                )
+        }
 
-    @Test
-    fun complexTypesWithNull() {
-        val source =
-            ComplexTypeSource(
-                stringList = listOf("a", "b", "c"),
-                intMap = mapOf("one" to 1, "two" to 2),
-                nullableSet = null,
-            )
+        test("complexTypesWithNull") {
+            val source =
+                ComplexTypeSource(
+                    stringList = listOf("a", "b", "c"),
+                    intMap = mapOf("one" to 1, "two" to 2),
+                    nullableSet = null,
+                )
 
-        val target: ComplexTypeTarget = source.copyToComplexTypeTarget(newProperty = "new")
+            val target: ComplexTypeTarget = source.copyToComplexTypeTarget(newProperty = "new")
 
-        assertEquals(
-            ComplexTypeTarget(
-                stringList = listOf("a", "b", "c"),
-                intMap = mapOf("one" to 1, "two" to 2),
-                nullableSet = null,
-                newProperty = "new",
-            ),
-            target,
-        )
-    }
-}
+            target shouldBe
+                ComplexTypeTarget(
+                    stringList = listOf("a", "b", "c"),
+                    intMap = mapOf("one" to 1, "two" to 2),
+                    nullableSet = null,
+                    newProperty = "new",
+                )
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/CopyVisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/CopyVisibilityTest.kt
@@ -1,16 +1,16 @@
 package me.tbsten.cream.test.copyTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class CopyVisibilityTest {
-    // The generated function being `internal` is verified at compile time: this test
-    // (in the same module) can call it. A `public`-only caller would not compile.
-    @Test
-    fun internalVisibilityCopyFunctionIsCallable() {
-        val source = InternalVisibilitySource(shared = "value")
-        val target: InternalVisibilityTarget = source.copyToInternalVisibilityTarget(extra = 42)
+class CopyVisibilityTest :
+    FunSpec({
+        // The generated function being `internal` is verified at compile time: this test
+        // (in the same module) can call it. A `public`-only caller would not compile.
+        test("internalVisibilityCopyFunctionIsCallable") {
+            val source = InternalVisibilitySource(shared = "value")
+            val target: InternalVisibilityTarget = source.copyToInternalVisibilityTarget(extra = 42)
 
-        assertEquals(InternalVisibilityTarget("value", 42), target)
-    }
-}
+            target shouldBe InternalVisibilityTarget("value", 42)
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/KDocTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/KDocTest.kt
@@ -1,7 +1,7 @@
 package me.tbsten.cream.test.copyTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
 /**
  * Smoke test for the `kdoc = KDoc(...)` parameter on `@CopyTo`.
@@ -10,13 +10,13 @@ import kotlin.test.assertEquals
  * here we just confirm that supplying a [me.tbsten.cream.KDoc] argument does not
  * break code generation or the runtime behavior of the generated copy function.
  */
-class KDocTest {
-    @Test
-    fun copyToKDocTarget_behavesNormally_evenWhenKDocIsProvided() {
-        val source = KDocSource(shared = "value", onlyOnSource = 1)
+class KDocTest :
+    FunSpec({
+        test("copyToKDocTarget_behavesNormally_evenWhenKDocIsProvided") {
+            val source = KDocSource(shared = "value", onlyOnSource = 1)
 
-        val target = source.copyToKDocTarget(extra = 42)
+            val target = source.copyToKDocTarget(extra = 42)
 
-        assertEquals(KDocTarget(shared = "value", extra = 42), target)
-    }
-}
+            target shouldBe KDocTarget(shared = "value", extra = 42)
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/NestedTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/NestedTest.kt
@@ -1,15 +1,15 @@
 package me.tbsten.cream.test.copyTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class NestedTest {
-    @Test
-    fun nestedClasses() {
-        val parent = ParentClass("parent", 100)
-        val source = NestedSource(parent)
-        val target: NestedTarget = source.copyToNestedTarget(newProperty = "new")
+class NestedTest :
+    FunSpec({
+        test("nestedClasses") {
+            val parent = ParentClass("parent", 100)
+            val source = NestedSource(parent)
+            val target: NestedTarget = source.copyToNestedTarget(newProperty = "new")
 
-        assertEquals(NestedTarget(parent, "new"), target)
-    }
-}
+            target shouldBe NestedTarget(parent, "new")
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/NullableTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/NullableTest.kt
@@ -1,54 +1,49 @@
 package me.tbsten.cream.test.copyTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class NullableTest {
-    @Test
-    fun nonNullableToNullable() {
-        val source =
-            NonNullableSource(
-                str = "test string",
-                num = 42,
-                bool = true,
-                list = listOf("item1", "item2", "item3"),
-            )
+class NullableTest :
+    FunSpec({
+        test("nonNullableToNullable") {
+            val source =
+                NonNullableSource(
+                    str = "test string",
+                    num = 42,
+                    bool = true,
+                    list = listOf("item1", "item2", "item3"),
+                )
 
-        val target: NullableTarget = source.copyToNullableTarget(newProperty = "new")
+            val target: NullableTarget = source.copyToNullableTarget(newProperty = "new")
 
-        assertEquals(
-            NullableTarget(
-                str = "test string",
-                num = 42,
-                bool = true,
-                list = listOf("item1", "item2", "item3"),
-                newProperty = "new",
-            ),
-            target,
-        )
-    }
+            target shouldBe
+                NullableTarget(
+                    str = "test string",
+                    num = 42,
+                    bool = true,
+                    list = listOf("item1", "item2", "item3"),
+                    newProperty = "new",
+                )
+        }
 
-    @Test
-    fun nonNullableToNullableWithEmptyValues() {
-        val source =
-            NonNullableSource(
-                str = "",
-                num = 0,
-                bool = false,
-                list = emptyList(),
-            )
+        test("nonNullableToNullableWithEmptyValues") {
+            val source =
+                NonNullableSource(
+                    str = "",
+                    num = 0,
+                    bool = false,
+                    list = emptyList(),
+                )
 
-        val target: NullableTarget = source.copyToNullableTarget(newProperty = "new")
+            val target: NullableTarget = source.copyToNullableTarget(newProperty = "new")
 
-        assertEquals(
-            NullableTarget(
-                str = "",
-                num = 0,
-                bool = false,
-                list = emptyList(),
-                newProperty = "new",
-            ),
-            target,
-        )
-    }
-}
+            target shouldBe
+                NullableTarget(
+                    str = "",
+                    num = 0,
+                    bool = false,
+                    list = emptyList(),
+                    newProperty = "new",
+                )
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/ObjectTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/ObjectTargetTest.kt
@@ -1,14 +1,14 @@
 package me.tbsten.cream.test.copyTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class ObjectTargetTest {
-    @Test
-    fun dataObjectToDataObject() {
-        val source = EmptySource
-        val target: EmptyTarget = source.copyToEmptyTarget()
+class ObjectTargetTest :
+    FunSpec({
+        test("dataObjectToDataObject") {
+            val source = EmptySource
+            val target: EmptyTarget = source.copyToEmptyTarget()
 
-        assertEquals(EmptyTarget, target)
-    }
-}
+            target shouldBe EmptyTarget
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/PropertyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/PropertyMappingTest.kt
@@ -1,22 +1,19 @@
 package me.tbsten.cream.test.copyTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class PropertyMappingTest {
-    @Test
-    fun propertyMapping() {
-        val domainSource =
-            DomainSourceModel(
-                domainId = "test-id",
-                name = "test-name",
-            )
+class PropertyMappingTest :
+    FunSpec({
+        test("propertyMapping") {
+            val domainSource =
+                DomainSourceModel(
+                    domainId = "test-id",
+                    name = "test-name",
+                )
 
-        val dataTarget: DataTargetModel = domainSource.copyToDataTargetModel()
+            val dataTarget: DataTargetModel = domainSource.copyToDataTargetModel()
 
-        assertEquals(
-            DataTargetModel(dataId = "test-id", name = "test-name"),
-            dataTarget,
-        )
-    }
-}
+            dataTarget shouldBe DataTargetModel(dataId = "test-id", name = "test-name")
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/TypeAliasTest.kt
@@ -1,33 +1,32 @@
 package me.tbsten.cream.test.copyTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
-class TypeAliasTest {
-    @Test
-    fun testCopyToTypeAlias() {
-        // Create a DomainModel instance and assign it to a variable typed as DomainModelAlias.
-        // Note: DomainModelAlias is just a type alias for DomainModel.
-        val domainModel: DomainModelAlias = DomainModel(id = "test-id-123")
+class TypeAliasTest :
+    FunSpec({
+        test("testCopyToTypeAlias") {
+            // Create a DomainModel instance and assign it to a variable typed as DomainModelAlias.
+            // Note: DomainModelAlias is just a type alias for DomainModel.
+            val domainModel: DomainModelAlias = DomainModel(id = "test-id-123")
 
-        // Call the generated copyToDataModel function
-        // Note: Function name is based on the actual type (DataModel), not the alias
-        val dataModel: DataModelAlias = domainModel.copyToDataModel()
+            // Call the generated copyToDataModel function
+            // Note: Function name is based on the actual type (DataModel), not the alias
+            val dataModel: DataModelAlias = domainModel.copyToDataModel()
 
-        // Verify the id property is copied correctly
-        assertEquals("test-id-123", dataModel.id)
+            // Verify the id property is copied correctly
+            dataModel.id shouldBe "test-id-123"
 
-        // Verify the result is actually a DataModel instance
-        assertIs<DataModel>(dataModel)
-    }
+            // Verify the result is actually a DataModel instance
+            dataModel.shouldBeInstanceOf<DataModel>()
+        }
 
-    @Test
-    fun testTypeAliasPreservesIdentity() {
-        val original: DomainModelAlias = DomainModel(id = "original-id")
-        val copied: DataModelAlias = original.copyToDataModel()
+        test("testTypeAliasPreservesIdentity") {
+            val original: DomainModelAlias = DomainModel(id = "original-id")
+            val copied: DataModelAlias = original.copyToDataModel()
 
-        // Verify that the copied object has the same property values
-        assertEquals(original.id, copied.id)
-    }
-}
+            // Verify that the copied object has the same property values
+            copied.id shouldBe original.id
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/VisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/VisibilityTest.kt
@@ -1,14 +1,14 @@
 package me.tbsten.cream.test.copyTo
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class VisibilityTest {
-    @Test
-    fun visibilityProperties() {
-        val source = VisibilitySource("public", 42, true)
-        val target: VisibilityTarget = source.copyToVisibilityTarget(newProperty = "new")
+class VisibilityTest :
+    FunSpec({
+        test("visibilityProperties") {
+            val source = VisibilitySource("public", 42, true)
+            val target: VisibilityTarget = source.copyToVisibilityTarget(newProperty = "new")
 
-        assertEquals(VisibilityTarget("public", "new"), target)
-    }
-}
+            target shouldBe VisibilityTarget("public", "new")
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/BasicTest.kt
@@ -1,108 +1,94 @@
 package me.tbsten.cream.test.copyToChildren
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class BasicTest {
-    @Test
-    fun parentToChildren() {
-        val parent: Parent = ChildDataObject
+class BasicTest :
+    FunSpec({
+        test("parentToChildren") {
+            val parent: Parent = ChildDataObject
 
-        mapOf(
-            parent.copyToChildDataObject() to ChildDataObject,
-            parent.copyToChildDataClass(
-                childProp1 = 1.0,
-                childProp2 = 2L,
-                childProp3 = "child",
-            ) to
-                ChildDataClass(
-                    parentProp1 = parent.parentProp1,
-                    parentProp2 = parent.parentProp2,
-                    parentProp3 = parent.parentProp3,
+            mapOf(
+                parent.copyToChildDataObject() to ChildDataObject,
+                parent.copyToChildDataClass(
                     childProp1 = 1.0,
                     childProp2 = 2L,
                     childProp3 = "child",
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    ChildDataClass(
+                        parentProp1 = parent.parentProp1,
+                        parentProp2 = parent.parentProp2,
+                        parentProp3 = parent.parentProp3,
+                        childProp1 = 1.0,
+                        childProp2 = 2L,
+                        childProp3 = "child",
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun parentToChildrenWithOverrideParentProp() {
-        val parent: Parent = ChildDataObject
+        test("parentToChildrenWithOverrideParentProp") {
+            val parent: Parent = ChildDataObject
 
-        mapOf(
-            parent.copyToChildDataObject() to ChildDataObject,
-            parent.copyToChildDataClass(
-                parentProp1 = "parent",
-                parentProp2 = 123,
-                parentProp3 = false,
-                childProp1 = 1.0,
-                childProp2 = 2L,
-                childProp3 = "child",
-            ) to
-                ChildDataClass(
+            mapOf(
+                parent.copyToChildDataObject() to ChildDataObject,
+                parent.copyToChildDataClass(
                     parentProp1 = "parent",
                     parentProp2 = 123,
                     parentProp3 = false,
                     childProp1 = 1.0,
                     childProp2 = 2L,
                     childProp3 = "child",
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    ChildDataClass(
+                        parentProp1 = "parent",
+                        parentProp2 = 123,
+                        parentProp3 = false,
+                        childProp1 = 1.0,
+                        childProp2 = 2L,
+                        childProp3 = "child",
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun parentToGrandChildren() {
-        val parent: Parent = ChildDataObject
+        test("parentToGrandChildren") {
+            val parent: Parent = ChildDataObject
 
-        mapOf(
-            parent.copyToGrandChildDataObject() to GrandChildDataObject,
-            parent.copyToGrandChildDataClass(
-                childProp1 = 1.0,
-                childProp2 = 2L,
-                childProp3 = "child",
-                grandChildProp1 = "grandChild",
-                grandChildProp2 = 3,
-                grandChildProp3 = true,
-            ) to
-                GrandChildDataClass(
-                    parentProp1 = parent.parentProp1,
-                    parentProp2 = parent.parentProp2,
-                    parentProp3 = parent.parentProp3,
+            mapOf(
+                parent.copyToGrandChildDataObject() to GrandChildDataObject,
+                parent.copyToGrandChildDataClass(
                     childProp1 = 1.0,
                     childProp2 = 2L,
                     childProp3 = "child",
                     grandChildProp1 = "grandChild",
                     grandChildProp2 = 3,
                     grandChildProp3 = true,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    GrandChildDataClass(
+                        parentProp1 = parent.parentProp1,
+                        parentProp2 = parent.parentProp2,
+                        parentProp3 = parent.parentProp3,
+                        childProp1 = 1.0,
+                        childProp2 = 2L,
+                        childProp3 = "child",
+                        grandChildProp1 = "grandChild",
+                        grandChildProp2 = 3,
+                        grandChildProp3 = true,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun parentToGrandChildrenWithOverrideParentProp() {
-        val parent: Parent = ChildDataObject
+        test("parentToGrandChildrenWithOverrideParentProp") {
+            val parent: Parent = ChildDataObject
 
-        mapOf(
-            parent.copyToGrandChildDataObject() to GrandChildDataObject,
-            parent.copyToGrandChildDataClass(
-                parentProp1 = "parent",
-                parentProp2 = 123,
-                parentProp3 = false,
-                childProp1 = 1.0,
-                childProp2 = 2L,
-                childProp3 = "child",
-                grandChildProp1 = "grandChild",
-                grandChildProp2 = 3,
-                grandChildProp3 = true,
-            ) to
-                GrandChildDataClass(
+            mapOf(
+                parent.copyToGrandChildDataObject() to GrandChildDataObject,
+                parent.copyToGrandChildDataClass(
                     parentProp1 = "parent",
                     parentProp2 = 123,
                     parentProp3 = false,
@@ -112,66 +98,75 @@ class BasicTest {
                     grandChildProp1 = "grandChild",
                     grandChildProp2 = 3,
                     grandChildProp3 = true,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    GrandChildDataClass(
+                        parentProp1 = "parent",
+                        parentProp2 = 123,
+                        parentProp3 = false,
+                        childProp1 = 1.0,
+                        childProp2 = 2L,
+                        childProp3 = "child",
+                        grandChildProp1 = "grandChild",
+                        grandChildProp2 = 3,
+                        grandChildProp3 = true,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun childToGrandChildren() {
-        val child: ChildSealedInterface = GrandChildDataObject
+        test("childToGrandChildren") {
+            val child: ChildSealedInterface = GrandChildDataObject
 
-        mapOf(
-            child.copyToGrandChildDataObject() to GrandChildDataObject,
-            child.copyToGrandChildDataClass(
-                grandChildProp1 = "grandChild",
-                grandChildProp2 = 123,
-                grandChildProp3 = true,
-            ) to
-                GrandChildDataClass(
-                    parentProp1 = child.parentProp1,
-                    parentProp2 = child.parentProp2,
-                    parentProp3 = child.parentProp3,
-                    childProp1 = child.childProp1,
-                    childProp2 = child.childProp2,
-                    childProp3 = child.childProp3,
+            mapOf(
+                child.copyToGrandChildDataObject() to GrandChildDataObject,
+                child.copyToGrandChildDataClass(
                     grandChildProp1 = "grandChild",
                     grandChildProp2 = 123,
                     grandChildProp3 = true,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    GrandChildDataClass(
+                        parentProp1 = child.parentProp1,
+                        parentProp2 = child.parentProp2,
+                        parentProp3 = child.parentProp3,
+                        childProp1 = child.childProp1,
+                        childProp2 = child.childProp2,
+                        childProp3 = child.childProp3,
+                        grandChildProp1 = "grandChild",
+                        grandChildProp2 = 123,
+                        grandChildProp3 = true,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun childToGrandChildrenWithOverrideChildProp() {
-        val child: ChildSealedInterface = GrandChildDataObject
+        test("childToGrandChildrenWithOverrideChildProp") {
+            val child: ChildSealedInterface = GrandChildDataObject
 
-        mapOf(
-            child.copyToGrandChildDataObject() to GrandChildDataObject,
-            child.copyToGrandChildDataClass(
-                childProp1 = 1.0,
-                childProp2 = 2L,
-                childProp3 = "child",
-                grandChildProp1 = "grandChild",
-                grandChildProp2 = 123,
-                grandChildProp3 = true,
-            ) to
-                GrandChildDataClass(
-                    parentProp1 = child.parentProp1,
-                    parentProp2 = child.parentProp2,
-                    parentProp3 = child.parentProp3,
+            mapOf(
+                child.copyToGrandChildDataObject() to GrandChildDataObject,
+                child.copyToGrandChildDataClass(
                     childProp1 = 1.0,
                     childProp2 = 2L,
                     childProp3 = "child",
                     grandChildProp1 = "grandChild",
                     grandChildProp2 = 123,
                     grandChildProp3 = true,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    GrandChildDataClass(
+                        parentProp1 = child.parentProp1,
+                        parentProp2 = child.parentProp2,
+                        parentProp3 = child.parentProp3,
+                        childProp1 = 1.0,
+                        childProp2 = 2L,
+                        childProp3 = "child",
+                        grandChildProp1 = "grandChild",
+                        grandChildProp2 = 123,
+                        grandChildProp3 = true,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
-}
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/ComplexTypesTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/ComplexTypesTest.kt
@@ -1,68 +1,60 @@
 package me.tbsten.cream.test.copyToChildren
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class ComplexTypesTest {
-    @Test
-    fun complexTypes() {
-        val source =
-            ComplexTypeChild1(
-                stringList = listOf("a", "b", "c"),
-                intMap = mapOf("one" to 1, "two" to 2),
-            )
+class ComplexTypesTest :
+    FunSpec({
+        test("complexTypes") {
+            val source =
+                ComplexTypeChild1(
+                    stringList = listOf("a", "b", "c"),
+                    intMap = mapOf("one" to 1, "two" to 2),
+                )
 
-        val target: ComplexTypeChild2 = source.copyToComplexTypeChild2()
+            val target: ComplexTypeChild2 = source.copyToComplexTypeChild2()
 
-        assertEquals(
-            ComplexTypeChild2(
-                stringList = listOf("a", "b", "c"),
-                intMap = mapOf("one" to 1, "two" to 2),
-            ),
-            target,
-        )
-    }
+            target shouldBe
+                ComplexTypeChild2(
+                    stringList = listOf("a", "b", "c"),
+                    intMap = mapOf("one" to 1, "two" to 2),
+                )
+        }
 
-    @Test
-    fun complexTypesWithNull() {
-        val source =
-            ComplexTypeChild1(
-                stringList = emptyList(),
-                intMap = emptyMap(),
-            )
+        test("complexTypesWithNull") {
+            val source =
+                ComplexTypeChild1(
+                    stringList = emptyList(),
+                    intMap = emptyMap(),
+                )
 
-        val target: ComplexTypeChild2 = source.copyToComplexTypeChild2()
+            val target: ComplexTypeChild2 = source.copyToComplexTypeChild2()
 
-        assertEquals(
-            ComplexTypeChild2(
-                stringList = emptyList(),
-                intMap = emptyMap(),
-            ),
-            target,
-        )
-    }
+            target shouldBe
+                ComplexTypeChild2(
+                    stringList = emptyList(),
+                    intMap = emptyMap(),
+                )
+        }
 
-    @Test
-    fun multipleTransitions() {
-        val source =
-            ComplexTypeChild1(
-                stringList = listOf("a", "b"),
-                intMap = mapOf("x" to 1),
-            )
+        test("multipleTransitions") {
+            val source =
+                ComplexTypeChild1(
+                    stringList = listOf("a", "b"),
+                    intMap = mapOf("x" to 1),
+                )
 
-        val intermediate: ComplexTypeChild2 = source.copyToComplexTypeChild2()
-        val final =
-            intermediate.copyToComplexTypeChild1(
-                stringList = intermediate.stringList!!,
-                intMap = intermediate.intMap!!,
-            )
+            val intermediate: ComplexTypeChild2 = source.copyToComplexTypeChild2()
+            val final =
+                intermediate.copyToComplexTypeChild1(
+                    stringList = intermediate.stringList!!,
+                    intMap = intermediate.intMap!!,
+                )
 
-        assertEquals(
-            ComplexTypeChild1(
-                stringList = listOf("a", "b"),
-                intMap = mapOf("x" to 1),
-            ),
-            final,
-        )
-    }
-}
+            final shouldBe
+                ComplexTypeChild1(
+                    stringList = listOf("a", "b"),
+                    intMap = mapOf("x" to 1),
+                )
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/NestedTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/NestedTest.kt
@@ -1,15 +1,15 @@
 package me.tbsten.cream.test.copyToChildren
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class NestedTest {
-    @Test
-    fun nestedClasses() {
-        val parent = ParentClass("test", 100)
-        val source = NestedChild1(parent, "test name")
-        val target: NestedChild2 = source.copyToNestedChild2(value = 0)
+class NestedTest :
+    FunSpec({
+        test("nestedClasses") {
+            val parent = ParentClass("test", 100)
+            val source = NestedChild1(parent, "test name")
+            val target: NestedChild2 = source.copyToNestedChild2(value = 0)
 
-        assertEquals(NestedChild2(parent, 0), target)
-    }
-}
+            target shouldBe NestedChild2(parent, 0)
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/ObjectTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/ObjectTargetTest.kt
@@ -1,14 +1,14 @@
 package me.tbsten.cream.test.copyToChildren
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class ObjectTargetTest {
-    @Test
-    fun dataObjectToDataObject() {
-        val source = EmptyChild1
-        val target: EmptyChild2 = source.copyToEmptyChild2()
+class ObjectTargetTest :
+    FunSpec({
+        test("dataObjectToDataObject") {
+            val source = EmptyChild1
+            val target: EmptyChild2 = source.copyToEmptyChild2()
 
-        assertEquals(EmptyChild2, target)
-    }
-}
+            target shouldBe EmptyChild2
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/VisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/VisibilityTest.kt
@@ -1,21 +1,19 @@
 package me.tbsten.cream.test.copyToChildren
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class VisibilityTest {
-    @Test
-    fun visibilityProperties() {
-        val source = VisibilityChild1(publicProp = "public", internalProp = "internal")
-        val target: VisibilityChild2 = source.copyToVisibilityChild2(newProperty = "new")
+class VisibilityTest :
+    FunSpec({
+        test("visibilityProperties") {
+            val source = VisibilityChild1(publicProp = "public", internalProp = "internal")
+            val target: VisibilityChild2 = source.copyToVisibilityChild2(newProperty = "new")
 
-        assertEquals(
-            VisibilityChild2(
-                publicProp = "public",
-                internalProp = "internal",
-                newProperty = "new",
-            ),
-            target,
-        )
-    }
-}
+            target shouldBe
+                VisibilityChild2(
+                    publicProp = "public",
+                    internalProp = "internal",
+                    newProperty = "new",
+                )
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/generic/GenericClassTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/generic/GenericClassTest.kt
@@ -1,23 +1,23 @@
 package me.tbsten.cream.test.generic
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 
-class GenericClassTest {
-    @Test
-    fun twoArgToThreeArg() {
-        val source =
-            GenericSourceWithTwoTypeArg(
-                a = "test",
-                b = listOf("a", "b"),
-                d = 123,
-            )
+class GenericClassTest :
+    FunSpec({
+        test("twoArgToThreeArg") {
+            val source =
+                GenericSourceWithTwoTypeArg(
+                    a = "test",
+                    b = listOf("a", "b"),
+                    d = 123,
+                )
 
-        mapOf(
-            // FIXME
-            // https://github.com/TBSten/cream/issues/12
-            // Default value cannot be set correctly in a copy function using type parameters.
-            // KSType.isAssignableFrom(KSType) in FindMatchedProperty.kt does not seem to work.
+            mapOf(
+                // FIXME
+                // https://github.com/TBSten/cream/issues/12
+                // Default value cannot be set correctly in a copy function using type parameters.
+                // KSType.isAssignableFrom(KSType) in FindMatchedProperty.kt does not seem to work.
 //            source.copyToGenericTargetWithThreeTypeArg(
 //                c = "c",
 //            ) to GenericTargetWithThreeTypeArg(
@@ -25,37 +25,36 @@ class GenericClassTest {
 //                b = source.b,
 //                c = "c",
 //            ),
-            source.copyToGenericTargetWithThreeTypeArg(
-                a = "aaa",
-                b = listOf("bbb", "bbb", "bbb"),
-                c = "c",
-                d = 456,
-            ) to
-                GenericTargetWithThreeTypeArg(
+                source.copyToGenericTargetWithThreeTypeArg(
                     a = "aaa",
                     b = listOf("bbb", "bbb", "bbb"),
                     c = "c",
                     d = 456,
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    GenericTargetWithThreeTypeArg(
+                        a = "aaa",
+                        b = listOf("bbb", "bbb", "bbb"),
+                        c = "c",
+                        d = 456,
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun threeArgToTwoArg() {
-        val source =
-            GenericSourceWithThreeTypeArg(
-                a = "test",
-                b = listOf("a", "b"),
-                c = "c",
-            )
+        test("threeArgToTwoArg") {
+            val source =
+                GenericSourceWithThreeTypeArg(
+                    a = "test",
+                    b = listOf("a", "b"),
+                    c = "c",
+                )
 
-        mapOf(
-            // FIXME
-            // https://github.com/TBSten/cream/issues/12
-            // Default value cannot be set correctly in a copy function using type parameters.
-            // KSType.isAssignableFrom(KSType) in FindMatchedProperty.kt does not seem to work.
+            mapOf(
+                // FIXME
+                // https://github.com/TBSten/cream/issues/12
+                // Default value cannot be set correctly in a copy function using type parameters.
+                // KSType.isAssignableFrom(KSType) in FindMatchedProperty.kt does not seem to work.
 //            source.copyToGenericTargetWithTwoTypeArg(
 //                a = source.a,
 //                b = source.b,
@@ -63,32 +62,31 @@ class GenericClassTest {
 //                a = source.a,
 //                b = source.b,
 //            ),
-            source.copyToGenericTargetWithTwoTypeArg(
-                a = "aaa",
-                b = listOf("bbb", "bbb", "bbb"),
-            ) to
-                GenericTargetWithTwoTypeArg(
+                source.copyToGenericTargetWithTwoTypeArg(
                     a = "aaa",
                     b = listOf("bbb", "bbb", "bbb"),
-                ),
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+                ) to
+                    GenericTargetWithTwoTypeArg(
+                        a = "aaa",
+                        b = listOf("bbb", "bbb", "bbb"),
+                    ),
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
 
-    @Test
-    fun threeArgToObject() {
-        val source =
-            GenericSourceWithThreeTypeArg(
-                a = "test",
-                b = listOf("a", "b"),
-                c = "c",
-            )
+        test("threeArgToObject") {
+            val source =
+                GenericSourceWithThreeTypeArg(
+                    a = "test",
+                    b = listOf("a", "b"),
+                    c = "c",
+                )
 
-        mapOf(
-            source.copyToGenericTargetObject() to GenericTargetObject,
-        ).forEach { (actual, expected) ->
-            assertEquals(actual, expected)
+            mapOf(
+                source.copyToGenericTargetObject() to GenericTargetObject,
+            ).forEach { (actual, expected) ->
+                actual shouldBe expected
+            }
         }
-    }
-}
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/sealedCopy/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/sealedCopy/BasicTest.kt
@@ -1,54 +1,55 @@
 package me.tbsten.cream.test.sealedCopy
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 
-class BasicTest {
-    @Test
-    fun copy_preservesSubtype_andUpdatesSharedProperty() {
-        val loading: BasicState = BasicState.Loading(sessionId = "abc", attempt = 1)
-        val updated = loading.copy(attempt = 2)
+class BasicTest :
+    FunSpec({
+        test("copy_preservesSubtype_andUpdatesSharedProperty") {
+            val loading: BasicState = BasicState.Loading(sessionId = "abc", attempt = 1)
+            val updated = loading.copy(attempt = 2)
 
-        assertEquals(BasicState.Loading(sessionId = "abc", attempt = 2), updated)
-    }
+            updated shouldBe BasicState.Loading(sessionId = "abc", attempt = 2)
+        }
 
-    @Test
-    fun copy_withNoArguments_returnsEquivalentInstance() {
-        val success: BasicState =
-            BasicState.Success(sessionId = "abc", attempt = 1, payload = "hi")
+        test("copy_withNoArguments_returnsEquivalentInstance") {
+            val success: BasicState =
+                BasicState.Success(sessionId = "abc", attempt = 1, payload = "hi")
 
-        val updated = success.copy()
+            val updated = success.copy()
 
-        assertEquals(success, updated)
-    }
+            updated shouldBe success
+        }
 
-    @Test
-    fun copy_dispatchesPerSubtype() {
-        val states: List<BasicState> =
-            listOf(
-                BasicState.Loading(sessionId = "a", attempt = 1),
-                BasicState.Success(sessionId = "b", attempt = 2, payload = "x"),
-            )
+        test("copy_dispatchesPerSubtype") {
+            val states: List<BasicState> =
+                listOf(
+                    BasicState.Loading(sessionId = "a", attempt = 1),
+                    BasicState.Success(sessionId = "b", attempt = 2, payload = "x"),
+                )
 
-        val updated = states.map { it.copy(sessionId = "z") }
+            val updated = states.map { it.copy(sessionId = "z") }
 
-        // Each branch must round-trip through *its own* data class .copy(), not
-        // collapse to a single supertype instance.
-        assertEquals("z", (updated[0] as BasicState.Loading).sessionId)
-        assertEquals(1, (updated[0] as BasicState.Loading).attempt)
-        assertEquals("z", (updated[1] as BasicState.Success).sessionId)
-        assertEquals("x", (updated[1] as BasicState.Success).payload)
-    }
+            // Each branch must round-trip through *its own* data class .copy(), not
+            // collapse to a single supertype instance.
+            (updated[0] as BasicState.Loading).sessionId shouldBe "z"
+            (updated[0] as BasicState.Loading).attempt shouldBe 1
+            (updated[1] as BasicState.Success).sessionId shouldBe "z"
+            (updated[1] as BasicState.Success).payload shouldBe "x"
+        }
 
-    @Test
-    fun copy_doesNotShareIdentityWithReceiver() {
-        val loading = BasicState.Loading(sessionId = "abc", attempt = 1)
+        test("copy_doesNotShareIdentityWithReceiver") {
+            val loading = BasicState.Loading(sessionId = "abc", attempt = 1)
 
-        val updated = loading.copy()
+            val updated = loading.copy()
 
-        // data class .copy() always allocates — sanity-check that we're delegating
-        // and not accidentally returning `this`.
-        assertEquals(loading, updated)
-        check(loading !== updated) { "copy() must not return the same instance" }
-    }
-}
+            // data class .copy() always allocates — sanity-check that we're delegating
+            // and not accidentally returning `this`.
+            updated shouldBe loading
+            withClue("copy() must not return the same instance") {
+                loading shouldNotBeSameInstanceAs updated
+            }
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/sealedCopy/MultipleTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/sealedCopy/MultipleTest.kt
@@ -1,58 +1,56 @@
 package me.tbsten.cream.test.sealedCopy
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 
-class MultipleTest {
-    @Test
-    fun withUpdated_andWithUpdatedOrNull_areBothGenerated() {
-        val loading: MultiSealedCopyState =
-            MultiSealedCopyState.Loading(sessionId = "abc")
+class MultipleTest :
+    FunSpec({
+        test("withUpdated_andWithUpdatedOrNull_areBothGenerated") {
+            val loading: MultiSealedCopyState =
+                MultiSealedCopyState.Loading(sessionId = "abc")
 
-        // Both extensions exist independently. Distinct names → distinct
-        // overload-resolution results; no shadowing.
-        val viaAsIs: MultiSealedCopyState = loading.withUpdated(sessionId = "x")
-        val viaNullable: MultiSealedCopyState? = loading.withUpdatedOrNull(sessionId = "y")
+            // Both extensions exist independently. Distinct names → distinct
+            // overload-resolution results; no shadowing.
+            val viaAsIs: MultiSealedCopyState = loading.withUpdated(sessionId = "x")
+            val viaNullable: MultiSealedCopyState? = loading.withUpdatedOrNull(sessionId = "y")
 
-        assertEquals(MultiSealedCopyState.Loading(sessionId = "x"), viaAsIs)
-        assertEquals(MultiSealedCopyState.Loading(sessionId = "y"), viaNullable)
-    }
-
-    @Test
-    fun withUpdated_returnsEmptyAsIs_forObjectBranch() {
-        val empty: MultiSealedCopyState = MultiSealedCopyState.Empty
-
-        val result = empty.withUpdated(sessionId = "ignored")
-
-        // RETURN_AS_IS: object branch collapses to `this`. The supplied sessionId
-        // never reaches the singleton.
-        assertEquals(MultiSealedCopyState.Empty, result)
-        check(result === MultiSealedCopyState.Empty) {
-            "RETURN_AS_IS on an object branch must return the singleton itself"
+            viaAsIs shouldBe MultiSealedCopyState.Loading(sessionId = "x")
+            viaNullable shouldBe MultiSealedCopyState.Loading(sessionId = "y")
         }
-    }
 
-    @Test
-    fun withUpdatedOrNull_returnsNull_forObjectBranch() {
-        val empty: MultiSealedCopyState = MultiSealedCopyState.Empty
+        test("withUpdated_returnsEmptyAsIs_forObjectBranch") {
+            val empty: MultiSealedCopyState = MultiSealedCopyState.Empty
 
-        val result: MultiSealedCopyState? = empty.withUpdatedOrNull(sessionId = "ignored")
+            val result = empty.withUpdated(sessionId = "ignored")
 
-        // RETURN_NULL: object branch collapses to null. Caller must handle it.
-        assertNull(result)
-    }
+            // RETURN_AS_IS: object branch collapses to `this`. The supplied sessionId
+            // never reaches the singleton.
+            result shouldBe MultiSealedCopyState.Empty
+            withClue("RETURN_AS_IS on an object branch must return the singleton itself") {
+                result shouldBeSameInstanceAs MultiSealedCopyState.Empty
+            }
+        }
 
-    @Test
-    fun bothStrategies_delegateToCopy_forDataClassBranch() {
-        val loading: MultiSealedCopyState = MultiSealedCopyState.Loading(sessionId = "abc")
+        test("withUpdatedOrNull_returnsNull_forObjectBranch") {
+            val empty: MultiSealedCopyState = MultiSealedCopyState.Empty
 
-        val viaAsIs = loading.withUpdated(sessionId = "x")
-        val viaNullable = assertNotNull(loading.withUpdatedOrNull(sessionId = "x"))
+            val result: MultiSealedCopyState? = empty.withUpdatedOrNull(sessionId = "ignored")
 
-        // Data class branches behave identically across both strategies — the
-        // strategy only affects how non-copyable branches are emitted.
-        assertEquals(viaAsIs, viaNullable)
-    }
-}
+            // RETURN_NULL: object branch collapses to null. Caller must handle it.
+            result shouldBe null
+        }
+
+        test("bothStrategies_delegateToCopy_forDataClassBranch") {
+            val loading: MultiSealedCopyState = MultiSealedCopyState.Loading(sessionId = "abc")
+
+            val viaAsIs = loading.withUpdated(sessionId = "x")
+            val viaNullable = loading.withUpdatedOrNull(sessionId = "x").shouldNotBeNull()
+
+            // Data class branches behave identically across both strategies — the
+            // strategy only affects how non-copyable branches are emitted.
+            viaNullable shouldBe viaAsIs
+        }
+    })


### PR DESCRIPTION
## What

Migrate the entire test suite from `kotlin.test` (`@Test`) to the kotest **FunSpec** framework, across both test modules.

| Module | Kind | Tests |
|---|---|---|
| `cream-ksp` | JVM (kctfork) | 109 |
| `test/` | KMP commonTest (jvm / android / iosSimulatorArm64) | 104 |

All `@Test` classes become `class X : FunSpec({ test("...") { ... } })`; `assertEquals` / `assertNotEquals` / `assertTrue` / `assertIs` / `assertSame` / `assertNull` / `check` become kotest matchers (`shouldBe`, `shouldNotBe`, `shouldBeInstanceOf`, `shouldBeSameInstanceAs`, `shouldBe null`, `shouldNotBeNull`, …), with failure messages preserved via `withClue`. The `assertMatchesSnapshot` facet DSL is unchanged.

## Build wiring

- **Version catalog**: add `kotest-framework-engine`, `kotest-runner-junit5`, and the `io.kotest` plugin; bump kotest `6.0.4` → `6.1.11`.
- **`cream-ksp` (JVM)**: `kotest-runner-junit5` + `tasks.test { useJUnitPlatform() }` (no KSP / `io.kotest` plugin needed on JVM).
- **`test/` (KMP)**: apply `io.kotest` after `ksp`; `kotest-framework-engine` in `commonTest`; `kotest-runner-junit5` in **both** `jvmTest` and `androidUnitTest` (the latter does not inherit the former); `useJUnitPlatform()` for the JVM/Android test tasks.
- Narrow `setupKspForMultiplatformWorkaround()` to disable only cream's redundant per-platform **main** KSP generation (`!name.contains("Test")`), keeping the `*Test` KSP tasks alive so kotest can generate its native spec launchers; stop wiring cream into `kspJvmTest` so the two KSP processors don't share a task.

## Why the kotest 6.1.11 bump

kotest 6.0.4's native launcher imports specs by simple name, so the many duplicate simple class names across packages (e.g. `BasicTest` in 7 packages) produce `Conflicting import: ... is ambiguous` and break `compileTestKotlinIosSimulatorArm64`. 6.1.x emits aliased imports (`import ...BasicTest as BasicTest0`), fixing native compilation. JVM/Android are unaffected (they discover specs by FQN via the JUnit Platform).

## Verification

- **Test-case parity** vs. the prior `@Test` count: `cream-ksp` **109 / 0 fail**, `test/` `jvmTest` **104 / 0**, `testDebugUnitTest` **104 / 0**, `testReleaseUnitTest` **104 / 0**.
- **Snapshot golden files are byte-identical** (no behavior change).
- `ktlintCheck` passes.
- **False-green guards** on both modules: a corrupted assertion still fails the suite.
- **iosSimulatorArm64**: compiles with all 49 specs registered in the generated launcher. ⚠️ Native test *execution* is left to CI — it needs full Xcode, which is unavailable in the local dev environment (only Command Line Tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
