### PR TITLE
fix(ksp): reject escapeDot=backquote's invalid default name (follow-up to #77)

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CopyFunctionNameExt.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CopyFunctionNameExt.kt
@@ -34,10 +34,13 @@ internal fun copyFunctionName(
  * Resolve [funNameTemplate] into the concrete name for the function generated from
  * [source] to [target], then validate it.
  *
- * A bare [DefaultCopyFunctionName] (the value when `funName` is omitted) is cream's own
- * derived name and is emitted as-is, preserving behaviour for every naming option. Any
- * other template is something the user composed, so its result is validated and an invalid
- * name fails the build with an [InvalidCreamUsageException].
+ * The resolved name is always validated. A user-composed name that is not a valid Kotlin
+ * function name fails the build with an [InvalidCreamUsageException]. When `funName` was
+ * omitted, every supported option (`lower-camel-case` / `replace-to-underscore`) yields a
+ * valid name and the derived name is emitted unchanged; the one exception is
+ * `escapeDot=backquote` with a non-empty prefix, which produces an invalid name (e.g.
+ * `` copyTo`Target` ``) and is now reported against the naming option rather than silently
+ * emitted as broken code.
  */
 internal fun resolveValidatedFunName(
     funNameTemplate: String,
@@ -53,24 +56,44 @@ internal fun resolveValidatedFunName(
             target = target.toClassDeclarationInfo(),
             options = options,
         )
-    if (funNameTemplate != DefaultCopyFunctionName && !isValidGeneratedFunctionName(name)) {
-        val annotationName = generateSourceAnnotation.annotationClass.simpleName ?: "cream annotation"
-        // Name the *annotated* declaration, not `source`: for @CopyMapping / @CombineMapping the
-        // source is a mapped (often un-owned) class with no annotation, and for @CopyFrom it is the
-        // copied-from class. The annotation actually lives on annotationTarget.
-        val annotatedName =
-            generateSourceAnnotation.annotationTarget.let { it.qualifiedName?.asString() ?: it.simpleName.asString() }
+    if (isValidGeneratedFunctionName(name)) return name
+
+    val annotationName = generateSourceAnnotation.annotationClass.simpleName ?: "cream annotation"
+    // Name the *annotated* declaration, not `source`: for @CopyMapping / @CombineMapping the
+    // source is a mapped (often un-owned) class with no annotation, and for @CopyFrom it is the
+    // copied-from class. The annotation actually lives on annotationTarget.
+    val annotatedName =
+        generateSourceAnnotation.annotationTarget.let { it.qualifiedName?.asString() ?: it.simpleName.asString() }
+
+    if (funNameTemplate == DefaultCopyFunctionName) {
+        // funName was omitted, yet cream's derived name is not a valid Kotlin function name. A
+        // project naming option produced it — in practice cream.escapeDot=backquote together with a
+        // non-empty cream.copyFunNamePrefix (e.g. "copyTo`Target`"). Report it against the option,
+        // which the user actually set, rather than funName, which they did not.
         throw InvalidCreamUsageException(
             message =
                 lines(
-                    "@$annotationName on $annotatedName produced an invalid function name \"$name\".",
-                    "  funName template : \"$funNameTemplate\"",
-                    "  target           : ${target.fullName}",
+                    "cream's derived name \"$name\" for ${target.fullName} (from @$annotationName on $annotatedName)",
+                    "is not a valid Kotlin function name. A project naming option produced it — most likely",
+                    "cream.escapeDot=backquote together with a non-empty cream.copyFunNamePrefix.",
                 ),
-            solution = invalidFunNameSolution(name, funNameTemplate),
+            solution =
+                lines(
+                    "Use cream.escapeDot=lower-camel-case or replace-to-underscore, set cream.copyFunNamePrefix",
+                    "to \"\", or set funName explicitly on the declaration.",
+                ),
         )
     }
-    return name
+
+    throw InvalidCreamUsageException(
+        message =
+            lines(
+                "@$annotationName on $annotatedName produced an invalid function name \"$name\".",
+                "  funName template : \"$funNameTemplate\"",
+                "  target           : ${target.fullName}",
+            ),
+        solution = invalidFunNameSolution(name, funNameTemplate),
+    )
 }
 
 /**

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/EscapeDotOptionTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/EscapeDotOptionTest.kt
@@ -4,9 +4,11 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.generatedSourceText
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
 
 internal class EscapeDotOptionTest :
     FunSpec({
@@ -59,11 +61,11 @@ internal class EscapeDotOptionTest :
             }
         }
 
-        test("backquote wraps the target name in backticks in generated source") {
-            // backquote produces the literal substring `copyTo\`Target\`` in the generated function
-            // name. Note that Kotlin currently cannot parse a function declaration whose name has
-            // a non-quoted prefix followed by a backquote-wrapped suffix, so downstream compilation
-            // would fail — this test only verifies the KSP code-generation behavior of the option.
+        test("backquote with a non-empty prefix is rejected with a clear error") {
+            // escapeDot=backquote + the default "copyTo" prefix yields the literal `copyTo`Target``
+            // — not a valid Kotlin function name (a non-quoted prefix followed by a backtick-wrapped
+            // suffix). cream now rejects it with a clear message pointed at the naming option,
+            // instead of emitting code that fails downstream at the user's compiler.
             val result =
                 compileWithCream(
                     fullNameSource,
@@ -73,13 +75,11 @@ internal class EscapeDotOptionTest :
                             "cream.escapeDot" to "backquote",
                         ),
                 )
-            // simple-name -> "Target"
-            // backquote -> "`Target`"
-            // first char `\`` non-letter -> no capitalize change
-            // -> "copyTo`Target`" (matches CopyFunctionNameTest unit-test expectations)
-            val generated = result.generatedSourceText()
-            withClue("Expected 'copyTo`Target`' in generated source. Actual:\n$generated") {
-                generated shouldContain "copyTo`Target`"
+            withClue("Expected compilation failure. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            withClue(result.normalizedCompilerOutput()) {
+                result.normalizedCompilerOutput() shouldContain "cream.escapeDot=backquote"
             }
         }
     })


### PR DESCRIPTION
Stacked on #77 (base: `feature/issue-60-funName`). Follow-up to the funName work — fixes a pre-existing footgun that the new funName validator made closeable.

### Problem
`cream.escapeDot=backquote` with a non-empty `cream.copyFunNamePrefix` (the default `copyTo`) derives an invalid Kotlin name — `` copyTo`Target` `` — a non-quoted prefix followed by a backtick-wrapped suffix. cream emitted it verbatim, so the build failed **downstream at the user's compiler** with cryptic syntax errors and no cream message. (`EscapeDotOptionTest` previously documented this as known-broken without asserting compilation.)

### Fix
`resolveValidatedFunName` now validates the derived (omitted-`funName`) name too. When it is invalid, cream fails with a clear `InvalidCreamUsageException` pointed at the naming option:

```text
cream's derived name "copyTo`Target`" for ... is not a valid Kotlin function name.
A project naming option produced it — most likely cream.escapeDot=backquote together
with a non-empty cream.copyFunNamePrefix.

Solution:
  Use cream.escapeDot=lower-camel-case or replace-to-underscore, set cream.copyFunNamePrefix
  to "", or set funName explicitly on the declaration.
```

### Compatibility
Valid configs are unaffected and emit the same name as before: `lower-camel-case`, `replace-to-underscore`, and `backquote` **with an empty prefix** (which yields a fully backtick-quoted, valid name). Existing snapshots are byte-identical. `EscapeDotOptionTest`'s backquote case now asserts the clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
