### PR TITLE
fix(ksp): reject duplicate @CopyMapping/@CombineMapping functions (follow-up to #77)

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
@@ -18,6 +18,9 @@ import me.tbsten.cream.ksp.GenerateSourceAnnotation
 import me.tbsten.cream.ksp.InvalidCreamUsageException
 import me.tbsten.cream.ksp.transform.appendCombineToFunction
 import me.tbsten.cream.ksp.transform.appendCopyFunction
+import me.tbsten.cream.ksp.transform.requireNoDuplicateGeneratedFunctions
+import me.tbsten.cream.ksp.transform.resolveFunNameTemplate
+import me.tbsten.cream.ksp.transform.toClassDeclarationInfo
 import me.tbsten.cream.ksp.util.annotationsOf
 import me.tbsten.cream.ksp.util.classListArgument
 import me.tbsten.cream.ksp.util.copyVisibilityArgument
@@ -147,6 +150,29 @@ internal fun CreamSymbolProcessor.processCombineMapping(resolver: Resolver): Lis
                         .first()
                         .containingFile
                         ?: annotatedDeclaration.containingFile!!
+
+                // Reject stacked @CombineMapping occurrences written more than once (same
+                // primary-source receiver + name + the same combined source/target classes) — the
+                // copy-paste duplicate. This is intentionally not a full overload-collision check:
+                // distinct class sets that emit the same signature are left to the compiler (cream
+                // does not replicate Kotlin's overload-resolution rules).
+                requireNoDuplicateGeneratedFunctions(
+                    functions =
+                        mappings.map { mapping ->
+                            val primarySource = mapping.sourceClasses.first()
+                            val name =
+                                resolveFunNameTemplate(
+                                    mapping.funNameTemplate,
+                                    primarySource.toClassDeclarationInfo(),
+                                    mapping.targetClass.toClassDeclarationInfo(),
+                                    options,
+                                )
+                            val classes = mapping.sourceClasses.joinToString(",") { it.fullName } + "->" + mapping.targetClass.fullName
+                            "${primarySource.fullName}|$name|$classes" to "${primarySource.fullName}.$name"
+                        },
+                    annotationSimpleName = CombineMapping::class.simpleName!!,
+                    declarationFullName = annotatedDeclaration.fullName,
+                )
 
                 codeGenerator.createNewKotlinFile(
                     dependencies = Dependencies(aggregating = true, sourceFile),

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
@@ -18,6 +18,9 @@ import me.tbsten.cream.ksp.InvalidCreamUsageException
 import me.tbsten.cream.ksp.transform.appendCombineToFunction
 import me.tbsten.cream.ksp.transform.appendCopyFunction
 import me.tbsten.cream.ksp.transform.requireFunNameSupportsFanout
+import me.tbsten.cream.ksp.transform.requireNoDuplicateGeneratedFunctions
+import me.tbsten.cream.ksp.transform.resolveFunNameTemplate
+import me.tbsten.cream.ksp.transform.toClassDeclarationInfo
 import me.tbsten.cream.ksp.util.annotationsOf
 import me.tbsten.cream.ksp.util.classListArgument
 import me.tbsten.cream.ksp.util.createNewKotlinFile
@@ -143,6 +146,45 @@ internal fun CreamSymbolProcessor.processCopyMapping(resolver: Resolver): List<K
                 val sourceFile =
                     mappings.first().sourceClass.containingFile
                         ?: annotatedDeclaration.containingFile!!
+
+                // Reject stacked @CopyMapping occurrences written more than once (same receiver +
+                // name + mapped classes) — the copy-paste duplicate. This is intentionally not a
+                // full overload-collision check: distinct targets that emit the same signature are
+                // left to the compiler (see requireNoDuplicateGeneratedFunctions — cream does not
+                // replicate Kotlin's overload-resolution rules).
+                requireNoDuplicateGeneratedFunctions(
+                    functions =
+                        buildList {
+                            mappings.forEach { mapping ->
+                                val fwd =
+                                    resolveFunNameTemplate(
+                                        mapping.funNameTemplate,
+                                        mapping.sourceClass.toClassDeclarationInfo(),
+                                        mapping.targetClass.toClassDeclarationInfo(),
+                                        options,
+                                    )
+                                add(
+                                    "${mapping.sourceClass.fullName}|$fwd|${mapping.targetClass.fullName}" to
+                                        "${mapping.sourceClass.fullName}.$fwd",
+                                )
+                                if (mapping.canReverse) {
+                                    val rev =
+                                        resolveFunNameTemplate(
+                                            mapping.funNameTemplate,
+                                            mapping.targetClass.toClassDeclarationInfo(),
+                                            mapping.sourceClass.toClassDeclarationInfo(),
+                                            options,
+                                        )
+                                    add(
+                                        "${mapping.targetClass.fullName}|$rev|${mapping.sourceClass.fullName}" to
+                                            "${mapping.targetClass.fullName}.$rev",
+                                    )
+                                }
+                            }
+                        },
+                    annotationSimpleName = CopyMapping::class.simpleName!!,
+                    declarationFullName = annotatedDeclaration.fullName,
+                )
 
                 codeGenerator.createNewKotlinFile(
                     dependencies = Dependencies(aggregating = true, sourceFile),

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CopyFunctionNameExt.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CopyFunctionNameExt.kt
@@ -96,3 +96,39 @@ internal fun requireFunNameSupportsFanout(
             ),
     )
 }
+
+/**
+ * Fail when two of the [functions] share an identity key — i.e. the same mapping written more than
+ * once. Each entry is `identityKey to displayName`; the caller builds the key from the receiver,
+ * name, and mapped classes. This catches the common copy-paste duplicate with a clear cream error
+ * instead of a redeclaration at the user's compiler. Used by the repeatable mapping annotations,
+ * where stacked occurrences land in one file.
+ *
+ * It is deliberately not a full overload-collision check: two entries with *different* mapped
+ * classes get distinct keys and pass here even if they would emit the same Kotlin signature
+ * (Kotlin ignores the return type in overload resolution). Detecting that precisely would mean
+ * replicating Kotlin's signature rules, so cream leaves it to the compiler's "Conflicting
+ * overloads" instead — see the funName note: cream does not pre-validate what the compiler enforces.
+ */
+internal fun requireNoDuplicateGeneratedFunctions(
+    functions: List<Pair<String, String>>,
+    annotationSimpleName: String,
+    declarationFullName: String,
+) {
+    val seen = HashSet<String>()
+    for ((key, display) in functions) {
+        if (!seen.add(key)) {
+            throw InvalidCreamUsageException(
+                message =
+                    lines(
+                        "@$annotationSimpleName on $declarationFullName generates the function $display more than once.",
+                        "Stacked occurrences resolve to the same receiver and name (an identical signature), which collide.",
+                    ),
+                solution =
+                    lines(
+                        "Remove the duplicate occurrence, or give the occurrences distinct funName values.",
+                    ),
+            )
+        }
+    }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/FunNameDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/FunNameDiagnosticTest.kt
@@ -195,4 +195,58 @@ internal class FunNameDiagnosticTest :
                 "Input" facetOf source
             }
         }
+
+        // Stacked @CopyMapping occurrences that resolve to an identical function (same source +
+        // target + name) collide; cream rejects them. (Different targets = overloads are allowed —
+        // see the snapshot test.)
+        test("duplicate @CopyMapping occurrences fail compilation") {
+            val source =
+                """
+                package diag
+
+                import me.tbsten.cream.CopyMapping
+
+                data class A(val shared: String)
+                data class B(val shared: String, val extra: Int)
+
+                @CopyMapping(A::class, B::class, funName = "conv")
+                @CopyMapping(A::class, B::class, funName = "conv")
+                object Mapping
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("FunNameDiagnosticTest.copyMappingDuplicate.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
+        }
+
+        test("duplicate @CombineMapping occurrences fail compilation") {
+            val source =
+                """
+                package diag
+
+                import me.tbsten.cream.CombineMapping
+
+                data class A(val a: String)
+                data class B(val b: Int)
+                data class C(val a: String, val b: Int, val extra: Long)
+
+                @CombineMapping(sources = [A::class, B::class], target = C::class, funName = "combine")
+                @CombineMapping(sources = [A::class, B::class], target = C::class, funName = "combine")
+                object Mapping
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            }
+            assertMatchesSnapshot("FunNameDiagnosticTest.combineMappingDuplicate.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
+        }
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/FunNameSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/FunNameSnapshotTest.kt
@@ -462,4 +462,38 @@ internal class FunNameSnapshotTest :
                 "Input" facetOf source
             }
         }
+
+        // The duplicate-name guard must NOT reject legitimate overloads: the same funName to
+        // different targets (with different signatures) is two valid overloaded functions.
+        test("@CopyMapping reuses a funName across different targets as overloads") {
+            val source =
+                """
+                package snap.funname
+
+                import me.tbsten.cream.CopyMapping
+
+                data class A(val shared: String)
+                data class B(val shared: String, val extra: Int)
+                data class C(val shared: String, val flag: Boolean)
+
+                @CopyMapping(A::class, B::class, funName = "conv")
+                @CopyMapping(A::class, C::class, funName = "conv")
+                object Mapping
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue(generated) {
+                generated shouldContain ".conv("
+                generated shouldContain ": snap.funname.B"
+                generated shouldContain ": snap.funname.C"
+            }
+            assertMatchesSnapshot("FunNameSnapshotTest.edgeCase/copyMappingOverloads") {
+                "Generated" facetOf generated
+                "Input" facetOf source
+            }
+        }
     })

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/combineMappingDuplicate.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/combineMappingDuplicate.output.md
@@ -1,0 +1,33 @@
+## Compiler output
+
+```text
+Invalid cream usage: @CombineMapping on diag.Mapping generates the function diag.A.combine more than once.
+Stacked occurrences resolve to the same receiver and name (an identical signature), which collide.
+
+Solution: 
+  Remove the duplicate occurrence, or give the occurrences distinct funName values.
+
+me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CombineMapping on diag.Mapping generates the function diag.A.combine more than once.
+Stacked occurrences resolve to the same receiver and name (an identical signature), which collide.
+
+Solution: 
+  Remove the duplicate occurrence, or give the occurrences distinct funName values.
+
+	<stack trace omitted>
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CombineMapping
+
+data class A(val a: String)
+data class B(val b: Int)
+data class C(val a: String, val b: Int, val extra: Long)
+
+@CombineMapping(sources = [A::class, B::class], target = C::class, funName = "combine")
+@CombineMapping(sources = [A::class, B::class], target = C::class, funName = "combine")
+object Mapping
+```

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/copyMappingDuplicate.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/copyMappingDuplicate.output.md
@@ -1,0 +1,32 @@
+## Compiler output
+
+```text
+Invalid cream usage: @CopyMapping on diag.Mapping generates the function diag.A.conv more than once.
+Stacked occurrences resolve to the same receiver and name (an identical signature), which collide.
+
+Solution: 
+  Remove the duplicate occurrence, or give the occurrences distinct funName values.
+
+me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyMapping on diag.Mapping generates the function diag.A.conv more than once.
+Stacked occurrences resolve to the same receiver and name (an identical signature), which collide.
+
+Solution: 
+  Remove the duplicate occurrence, or give the occurrences distinct funName values.
+
+	<stack trace omitted>
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CopyMapping
+
+data class A(val shared: String)
+data class B(val shared: String, val extra: Int)
+
+@CopyMapping(A::class, B::class, funName = "conv")
+@CopyMapping(A::class, B::class, funName = "conv")
+object Mapping
+```

--- a/cream-ksp/src/test/resources/snapshots/FunNameSnapshotTest/edgeCase/copyMappingOverloads.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameSnapshotTest/edgeCase/copyMappingOverloads.md
@@ -1,0 +1,86 @@
+## Generated
+
+````kt
+// file: CopyMapping__Mapping.kt
+package snap.funname
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * A -> B copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = A(...)
+ * val target = source.conv()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = A(...)
+ * val target = source.conv(property = value)
+ * ```
+ * 
+ * 
+ * @see A
+ * @see B
+ */
+public fun  snap.funname.A.conv(
+    shared: String = this.shared,
+    extra: Int,
+) : snap.funname.B = snap.funname.B(
+    shared = shared,
+    extra = extra,
+)
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * A -> C copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = A(...)
+ * val target = source.conv()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = A(...)
+ * val target = source.conv(property = value)
+ * ```
+ * 
+ * 
+ * @see A
+ * @see C
+ */
+public fun  snap.funname.A.conv(
+    shared: String = this.shared,
+    flag: Boolean,
+) : snap.funname.C = snap.funname.C(
+    shared = shared,
+    flag = flag,
+)
+````
+
+## Input
+
+```kt
+package snap.funname
+
+import me.tbsten.cream.CopyMapping
+
+data class A(val shared: String)
+data class B(val shared: String, val extra: Int)
+data class C(val shared: String, val flag: Boolean)
+
+@CopyMapping(A::class, B::class, funName = "conv")
+@CopyMapping(A::class, C::class, funName = "conv")
+object Mapping
+```


### PR DESCRIPTION
Stacked on #77 (base: `feature/issue-60-funName`). Follow-up — completes duplicate-name guarding for the `@Repeatable` mapping annotations.

### Problem
`@CopyMapping` / `@CombineMapping` are `@Repeatable`, and all occurrences on one declaration are generated into a single file. Two occurrences resolving to an **identical** function (same receiver + name + mapped classes) collide, and previously failed only at the user's compiler with a cryptic "Conflicting overloads" / redeclaration error — no cream message. (#77 added the analogous guard for `@CombineFrom` and `@SealedCopy`.)

### Fix
`requireNoDuplicateGeneratedFunctions` rejects exact-duplicate generated functions with a clear cream error:

```text
@CopyMapping on diag.Mapping generates the function diag.A.conv more than once.
Stacked occurrences resolve to the same receiver and name (an identical signature), which collide.

Solution:
  Remove the duplicate occurrence, or give the occurrences distinct funName values.
```

### Safety (no false positives)
The identity key includes the mapped classes, so **legitimate overloads stay allowed**: the same `funName` to different targets with different signatures generates two valid overloaded functions (covered by a snapshot test — `edgeCase/copyMappingOverloads`). Only true redeclarations are flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
