### PR TITLE
fix(ksp): show token names in funName diagnostics (follow-up to #77)

### DIFF
--- a/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/transform/FunctionNameTemplate.kt
+++ b/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/transform/FunctionNameTemplate.kt
@@ -55,6 +55,15 @@ fun containsAnyCopyFunNameToken(template: String): Boolean =
         copyTargetTokenExpanders.any { (placeholder, _) -> template.contains(placeholder) }
 
 /**
+ * Render [template] for display in diagnostics: replace each internal token placeholder
+ * `{{cream:X}}` with its public token const name `X`, so an error shows the tokens the user
+ * referenced (e.g. `bad-CopyTargetSimpleName`) rather than cream's internal wrapper
+ * (`bad-{{cream:CopyTargetSimpleName}}`).
+ */
+@InternalCreamApi
+fun displayFunNameTemplate(template: String): String = template.replace(Regex("\\{\\{cream:([^}]*)}}"), "$1")
+
+/**
  * Whether [name] is usable as the simple name of the top-level function cream generates:
  * a plain identifier (`toSuccess`) or a backtick-quoted identifier (`` `to success` ``).
  * Rejects the empty string and any name containing a character illegal in a Kotlin

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CopyFunctionNameExt.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CopyFunctionNameExt.kt
@@ -64,7 +64,7 @@ internal fun resolveValidatedFunName(
             message =
                 lines(
                     "@$annotationName on $annotatedName produced an invalid function name \"$name\".",
-                    "  funName template : \"$funNameTemplate\"",
+                    "  funName template : \"${displayFunNameTemplate(funNameTemplate)}\"",
                     "  target           : ${target.fullName}",
                 ),
             solution = invalidFunNameSolution(name, funNameTemplate),
@@ -128,7 +128,7 @@ internal fun resolveValidatedSealedCopyFunName(
             message =
                 lines(
                     "@SealedCopy on ${sealedClass.fullName} produced an invalid function name \"$name\".",
-                    "  funName template : \"$funNameTemplate\"",
+                    "  funName template : \"${displayFunNameTemplate(funNameTemplate)}\"",
                 ),
             solution = invalidFunNameSolution(name, funNameTemplate),
         )

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/defaultPlusSuffixBackquote.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/defaultPlusSuffixBackquote.output.md
@@ -2,7 +2,7 @@
 
 ```text
 Invalid cream usage: @CopyTo on diag.Source produced an invalid function name "copyTo`Target`OrNull".
-  funName template : "{{cream:DefaultCopyFunctionName}}OrNull"
+  funName template : "DefaultCopyFunctionNameOrNull"
   target           : diag.Target
 
 Solution: 
@@ -12,7 +12,7 @@ Solution:
   Note: when cream.escapeDot=backquote, DefaultCopyFunctionName is itself a backtick-quoted name and cannot take a prefix/suffix — use a CopyTarget* token instead.
 
 me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyTo on diag.Source produced an invalid function name "copyTo`Target`OrNull".
-  funName template : "{{cream:DefaultCopyFunctionName}}OrNull"
+  funName template : "DefaultCopyFunctionNameOrNull"
   target           : diag.Target
 
 Solution: 

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/invalidViaToken.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/invalidViaToken.output.md
@@ -2,7 +2,7 @@
 
 ```text
 Invalid cream usage: @CopyTo on diag.Source produced an invalid function name "bad-Target".
-  funName template : "bad-{{cream:CopyTargetSimpleName}}"
+  funName template : "bad-CopyTargetSimpleName"
   target           : diag.Target
 
 Solution: 
@@ -11,7 +11,7 @@ Solution:
   Adjust funName, or the tokens it expands to, so it produces one.
 
 me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyTo on diag.Source produced an invalid function name "bad-Target".
-  funName template : "bad-{{cream:CopyTargetSimpleName}}"
+  funName template : "bad-CopyTargetSimpleName"
   target           : diag.Target
 
 Solution: 


### PR DESCRIPTION
Stacked on #77 (base: `feature/issue-60-funName`). Follow-up — cosmetic diagnostics polish.

### Problem
An invalid-`funName` error printed the **internal** template form, leaking cream's `{{cream:…}}` wrapper:

```text
  funName template : "bad-{{cream:CopyTargetSimpleName}}"
```

### Fix
`displayFunNameTemplate` renders the public token const names instead, so the message reflects the tokens the user referenced:

```text
  funName template : "bad-CopyTargetSimpleName"
```

Only the two diagnostic goldens that contain a token in the template line change (`invalidViaToken`, `defaultPlusSuffixBackquote`); the resolved name and everything else are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
