### PR TITLE
feat(optionBuilder): add runtime English/Japanese language switcher (#82)

### DIFF
--- a/optionBuilder/sharedUI/src/commonMain/composeResources/values-ja/strings.xml
+++ b/optionBuilder/sharedUI/src/commonMain/composeResources/values-ja/strings.xml
@@ -17,6 +17,8 @@
     <string name="class_names_heading">2. コピー元/コピー先のクラス名を設定する (option)</string>
     <string name="class_names_source_sub_heading">コピー元のクラス</string>
     <string name="class_names_target_sub_heading">コピー先のクラス</string>
+    <string name="class_names_package_label">パッケージ:</string>
+    <string name="class_names_class_name_label">クラス名:</string>
     <string name="result_heading">3. Copy 関数名を確認</string>
     <string name="gradle_setting_heading">4. セットアップする</string>
     <string name="show_all">全て表示</string>

--- a/optionBuilder/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/optionBuilder/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="class_names_heading">2. Set Source/Target Class Names (optional)</string>
     <string name="class_names_source_sub_heading">Source Class</string>
     <string name="class_names_target_sub_heading">Target Class</string>
+    <string name="class_names_package_label">package:</string>
+    <string name="class_names_class_name_label">class name:</string>
     <string name="result_heading">3. Check Copy Function Name</string>
     <string name="gradle_setting_heading">4. Setup</string>
     <string name="show_all">Show All</string>

--- a/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/App.kt
+++ b/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/App.kt
@@ -2,6 +2,8 @@ package me.tbsten.cream
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -10,8 +12,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import me.tbsten.cream.i18n.AppEnvironment
+import me.tbsten.cream.i18n.AppLanguage
+import me.tbsten.cream.i18n.LanguageSwitcher
+import me.tbsten.cream.i18n.systemLanguageCode
 import me.tbsten.cream.ksp.options.CreamOptions
 import me.tbsten.cream.sharedui.generated.resources.Res
 import me.tbsten.cream.sharedui.generated.resources.app_title
@@ -25,6 +32,10 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Composable
 fun App() =
     AppTheme {
+        // Hoisted above AppEnvironment so it survives the language-keyed recomposition.
+        var language by rememberShareableState("lang", AppLanguage.serializer()) {
+            AppLanguage.fromLanguageCode(systemLanguageCode())
+        }
         var option by rememberShareableState("option", CreamOptions.serializer()) {
             CreamOptions.default
         }
@@ -41,41 +52,59 @@ fun App() =
             OptionBuilderClassDeclarationInfo("com.myapp", "MyUiState.Success")
         }
 
-        SelectionContainer {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(40.dp),
-                modifier =
-                    Modifier
-                        .verticalScroll(rememberScrollState())
-                        .padding(16.dp),
-            ) {
-                AppTitle()
+        AppEnvironment(language = language) {
+            SelectionContainer {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(40.dp),
+                    modifier =
+                        Modifier
+                            .verticalScroll(rememberScrollState())
+                            .padding(16.dp),
+                ) {
+                    AppHeader(
+                        language = language,
+                        onLanguageChange = { language = it },
+                    )
 
-                InputOptionsSection(
-                    option = option,
-                    onChange = { option = it },
-                )
+                    InputOptionsSection(
+                        option = option,
+                        onChange = { option = it },
+                    )
 
-                InputClassNamesSection(
-                    sourceClass = sourceClass,
-                    onSourceClassChange = { sourceClass = it },
-                    targetClass = targetClass,
-                    onTargetClassChange = { targetClass = it },
-                )
+                    InputClassNamesSection(
+                        sourceClass = sourceClass,
+                        onSourceClassChange = { sourceClass = it },
+                        targetClass = targetClass,
+                        onTargetClassChange = { targetClass = it },
+                    )
 
-                ResultSection(
-                    options = option,
-                    sourceClass = sourceClass,
-                    targetClass = targetClass,
-                )
+                    ResultSection(
+                        options = option,
+                        sourceClass = sourceClass,
+                        targetClass = targetClass,
+                    )
+                }
             }
         }
     }
 
 @Composable
-private fun AppTitle() {
-    Text(
-        text = stringResource(Res.string.app_title),
-        style = AppTextStyles.appTitle,
-    )
+private fun AppHeader(
+    language: AppLanguage,
+    onLanguageChange: (AppLanguage) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = stringResource(Res.string.app_title),
+            style = AppTextStyles.appTitle,
+            modifier = Modifier.weight(1f),
+        )
+        LanguageSwitcher(
+            language = language,
+            onLanguageChange = onLanguageChange,
+        )
+    }
 }

--- a/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/InputClassNamesSection.kt
+++ b/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/InputClassNamesSection.kt
@@ -10,7 +10,9 @@ import androidx.compose.ui.unit.dp
 import me.tbsten.cream.components.CommonInputCard
 import me.tbsten.cream.components.ToggleHeadingText
 import me.tbsten.cream.sharedui.generated.resources.Res
+import me.tbsten.cream.sharedui.generated.resources.class_names_class_name_label
 import me.tbsten.cream.sharedui.generated.resources.class_names_heading
+import me.tbsten.cream.sharedui.generated.resources.class_names_package_label
 import me.tbsten.cream.sharedui.generated.resources.class_names_source_sub_heading
 import me.tbsten.cream.sharedui.generated.resources.class_names_target_sub_heading
 import me.tbsten.cream.sharedui.generated.resources.icon_slab
@@ -66,7 +68,7 @@ private fun ClassInputCard(
         OutlinedTextField(
             value = value.packageName,
             onValueChange = { onValueChange(value.copy(packageName = it)) },
-            label = { Text("package:") },
+            label = { Text(stringResource(Res.string.class_names_package_label)) },
             placeholder = { Text("com.myapp") },
             singleLine = true,
         )
@@ -74,7 +76,7 @@ private fun ClassInputCard(
         OutlinedTextField(
             value = value.underPackageName,
             onValueChange = { onValueChange(value.copy(underPackageName = it)) },
-            label = { Text("class name:") },
+            label = { Text(stringResource(Res.string.class_names_class_name_label)) },
             placeholder = { Text("MyUiState") },
             singleLine = true,
         )

--- a/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/i18n/AppLanguage.kt
+++ b/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/i18n/AppLanguage.kt
@@ -1,0 +1,45 @@
+package me.tbsten.cream.i18n
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Languages the Option Builder UI can be displayed in.
+ *
+ * - [localeTag] drives the runtime platform-locale override (see [LocalAppLocale]).
+ * - [label] is the autonym shown in the language switcher. It is intentionally left untranslated
+ *   so that users can recognise their own language regardless of the currently active one.
+ *
+ * The [SerialName] of each entry pins the serialized form, so the persisted / shareable value
+ * (URL query parameter on web) stays stable even if the Kotlin entry names are later renamed.
+ */
+@Serializable
+enum class AppLanguage(
+    val localeTag: String,
+    val label: String,
+) {
+    @SerialName("en")
+    English("en", "English"),
+
+    @SerialName("ja")
+    Japanese("ja", "日本語"),
+    ;
+
+    companion object {
+        /**
+         * Resolves a language code or BCP-47-ish tag (e.g. `"ja"`, `"en-US"`) to a supported
+         * [AppLanguage], falling back to [English] for anything unsupported.
+         */
+        fun fromLanguageCode(code: String): AppLanguage {
+            val language = code.substringBefore('-')
+            return entries.firstOrNull { it.localeTag.equals(language, ignoreCase = true) } ?: English
+        }
+    }
+}
+
+/**
+ * The current system / browser UI language code (e.g. `"ja"`, `"en"`), used as the initial value
+ * before the user makes an explicit choice. Implemented per platform because reading the system
+ * locale is not part of common Kotlin and must not be a composable call.
+ */
+internal expect fun systemLanguageCode(): String

--- a/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/i18n/LanguageSwitcher.kt
+++ b/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/i18n/LanguageSwitcher.kt
@@ -1,0 +1,51 @@
+package me.tbsten.cream.i18n
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.text.selection.DisableSelection
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+/**
+ * Lets the user pick the UI language. Entries are shown by their autonym (e.g. `日本語`) so they
+ * stay recognisable regardless of the currently active language.
+ *
+ * Wrapped in [DisableSelection] because the whole app lives inside a `SelectionContainer`.
+ */
+@Composable
+fun LanguageSwitcher(
+    language: AppLanguage,
+    onLanguageChange: (AppLanguage) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        OutlinedButton(onClick = { expanded = true }) {
+            Text(text = language.label)
+        }
+        DisableSelection {
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                AppLanguage.entries.forEach { entry ->
+                    DropdownMenuItem(
+                        text = { Text(entry.label) },
+                        onClick = {
+                            onLanguageChange(entry)
+                            expanded = false
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/i18n/LocalAppLocale.kt
+++ b/optionBuilder/sharedUI/src/commonMain/kotlin/me/tbsten/cream/i18n/LocalAppLocale.kt
@@ -1,0 +1,41 @@
+package me.tbsten.cream.i18n
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.runtime.key
+
+/**
+ * Applies [language] to the composition. [key] forces a full recomposition of [content] whenever
+ * the language changes, so every `stringResource` call inside re-resolves against the new locale.
+ *
+ * Note: language-independent state (options, class names, …) must be hoisted *above* this call so
+ * it survives the keyed recomposition.
+ *
+ * Based on the official approach at
+ * https://kotlinlang.org/docs/multiplatform/compose-resource-environment.html — each platform
+ * applies the override differently (the JVM sets the default [java.util.Locale]; the browser swaps
+ * the value read by the `navigator.languages` shim in `index.html`).
+ */
+@Composable
+fun AppEnvironment(
+    language: AppLanguage,
+    content: @Composable () -> Unit,
+) {
+    CompositionLocalProvider(
+        provideAppLocale(language.localeTag),
+    ) {
+        key(language) {
+            content()
+        }
+    }
+}
+
+/**
+ * Platform hook: switches the locale that Compose Resources reads. The actual override is a side
+ * effect performed here *during composition*, so it is applied before children read their strings.
+ * The returned [ProvidedValue] only satisfies [CompositionLocalProvider]; re-resolution of
+ * `stringResource` is driven by [AppEnvironment]'s [key], not by reading this value.
+ */
+@Composable
+internal expect fun provideAppLocale(localeTag: String): ProvidedValue<*>

--- a/optionBuilder/sharedUI/src/commonTest/kotlin/me/tbsten/cream/i18n/AppLanguageTest.kt
+++ b/optionBuilder/sharedUI/src/commonTest/kotlin/me/tbsten/cream/i18n/AppLanguageTest.kt
@@ -1,0 +1,31 @@
+package me.tbsten.cream.i18n
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AppLanguageTest {
+    @Test
+    fun `ja を渡すと Japanese になる`() {
+        assertEquals(AppLanguage.Japanese, AppLanguage.fromLanguageCode("ja"))
+    }
+
+    @Test
+    fun `en を渡すと English になる`() {
+        assertEquals(AppLanguage.English, AppLanguage.fromLanguageCode("en"))
+    }
+
+    @Test
+    fun `地域付きの言語タグでも言語部分で解決する`() {
+        assertEquals(AppLanguage.Japanese, AppLanguage.fromLanguageCode("ja-JP"))
+    }
+
+    @Test
+    fun `大文字小文字を区別せずに解決する`() {
+        assertEquals(AppLanguage.English, AppLanguage.fromLanguageCode("EN"))
+    }
+
+    @Test
+    fun `未対応の言語コードは English にフォールバックする`() {
+        assertEquals(AppLanguage.English, AppLanguage.fromLanguageCode("fr"))
+    }
+}

--- a/optionBuilder/sharedUI/src/jsMain/kotlin/me/tbsten/cream/i18n/LocalAppLocale.js.kt
+++ b/optionBuilder/sharedUI/src/jsMain/kotlin/me/tbsten/cream/i18n/LocalAppLocale.js.kt
@@ -1,0 +1,17 @@
+package me.tbsten.cream.i18n
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import kotlinx.browser.window
+
+private val localeState = staticCompositionLocalOf { systemLanguageCode() }
+
+@Composable
+internal actual fun provideAppLocale(localeTag: String): ProvidedValue<*> {
+    // Read back by the `Navigator.prototype.languages` shim installed in index.html.
+    window.asDynamic().__customLocale = localeTag.replace('_', '-')
+    return localeState.provides(localeTag)
+}
+
+internal actual fun systemLanguageCode(): String = window.navigator.language.substringBefore('-')

--- a/optionBuilder/sharedUI/src/jvmMain/kotlin/me/tbsten/cream/i18n/LocalAppLocale.jvm.kt
+++ b/optionBuilder/sharedUI/src/jvmMain/kotlin/me/tbsten/cream/i18n/LocalAppLocale.jvm.kt
@@ -1,0 +1,18 @@
+package me.tbsten.cream.i18n
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import java.util.Locale
+
+private val localeState = staticCompositionLocalOf { Locale.getDefault().toString() }
+
+@Composable
+internal actual fun provideAppLocale(localeTag: String): ProvidedValue<*> {
+    val locale = Locale.forLanguageTag(localeTag)
+    // Process-global mutation; acceptable for this single-window tool app.
+    Locale.setDefault(locale)
+    return localeState.provides(locale.toString())
+}
+
+internal actual fun systemLanguageCode(): String = Locale.getDefault().language

--- a/optionBuilder/webApp/src/commonMain/resources/index.html
+++ b/optionBuilder/webApp/src/commonMain/resources/index.html
@@ -18,6 +18,22 @@
             overflow: hidden;
         }
     </style>
+    <!--
+      Lets the app override the UI language at runtime (see LocalAppLocale in :sharedUI).
+      Compose Resources reads navigator.languages; this shim returns window.__customLocale
+      (set by the app) when present, otherwise the real browser languages.
+    -->
+    <script>
+        var nativeLanguages = Object.getOwnPropertyDescriptor(Navigator.prototype, "languages");
+        Object.defineProperty(Navigator.prototype, "languages", Object.assign({}, nativeLanguages, {
+            get: function () {
+                if (window.__customLocale) {
+                    return [window.__customLocale];
+                }
+                return nativeLanguages.get.apply(this);
+            }
+        }));
+    </script>
 </head>
 
 <meta content="cream.kt option builder" property="og:title">


### PR DESCRIPTION
## 概要

Option Builder の UI を**実行時に英語 / 日本語へ切り替えられる言語スイッチャー**を追加します。

UI 文言の en/ja リソース自体は既に存在していました（commit `c735994`）が、Compose Resources はシステム / ブラウザのロケールから**自動選択するだけ**で、ユーザーが言語を選ぶ手段がありませんでした。本 PR でその選択 UI を追加し、システムロケールとは独立に言語を選べるようにします。

ヘッダー右上のドロップダウン（各言語の自称表記 `English` / `日本語` を表示）から選択でき、選択結果は `rememberShareableState` で永続化されます（Web では URL クエリパラメータ → 共有可能）。

Closes #82

<details>
<summary><b>仕組み（ランタイムロケール上書き）</b></summary>

JetBrains 公式の手法（[Manage local resource environment](https://kotlinlang.org/docs/multiplatform/compose-resource-environment.html)）に沿っています。

- `AppEnvironment(language) { CompositionLocalProvider(provideAppLocale(tag)) { key(language) { content } } }`
  - `key(language)` が言語変更時に content 全体を再コンポーズさせ、配下の全 `stringResource` が新ロケールで再解決される。
- `expect/actual fun provideAppLocale(tag)`（コンポーズ中に副作用としてロケールを上書き）
  - **JVM/desktop**: `Locale.setDefault(Locale.forLanguageTag(tag))`
  - **JS/browser**: `window.__customLocale = tag` をセット。`index.html` に `Navigator.prototype.languages` を差し替えるシムを追加し、Compose Resources が読む `navigator.languages` が選択ロケールを返すようにする（シムは `webApp.js` より前に実行）。
- 言語に依存しない状態（option / source / target）は `key()` の**外側**に hoist しているため、言語切替でリセットされません。

</details>

<details>
<summary><b>変更ファイル</b></summary>

新規 (`optionBuilder/sharedUI/.../i18n/`):
- `AppLanguage.kt` — `@Serializable enum`（`@SerialName` で直列化名を固定し共有 URL 値の互換性を担保）+ `fromLanguageCode` + `expect fun systemLanguageCode()`
- `LocalAppLocale.kt` — `AppEnvironment` + `expect fun provideAppLocale`
- `LocalAppLocale.jvm.kt` / `LocalAppLocale.js.kt` — 各プラットフォーム actual
- `LanguageSwitcher.kt` — 既存の `OutlinedButton` + `DropdownMenu` イディオムに揃えたスイッチャー
- `commonTest/.../i18n/AppLanguageTest.kt` — `fromLanguageCode` の単体テスト

変更:
- `App.kt` — ヘッダー行にスイッチャーを追加、状態を `AppEnvironment` の外側へ hoist
- `webApp/.../index.html` — `navigator.languages` シム
- `InputClassNamesSection.kt` + `values/strings.xml`・`values-ja/strings.xml` — 残っていたハードコード文言 `package:` / `class name:` をリソース化（別コミット）

</details>

<details>
<summary><b>設計上の判断</b></summary>

- **言語スイッチャーのラベルは自称表記**（`English` / `日本語`）で固定し、翻訳しない（現在の UI 言語に関わらず自分の言語を見つけられるように、言語選択 UI の定石）。
- **初期言語はシステムロケールから解決**（`systemLanguageCode()`）。従来の自動判定挙動を維持しつつ、明示選択も可能。
- **`expect/actual object` ではなく `fun` を採用**。expect/actual class/object は `KT-61573` の Beta 警告を出すため、関数にして警告を回避。
- **desktop の `Window` タイトルはプロダクト名のまま**（`Cream Option Builder`）据え置き（デプロイ対象は Web。ネイティブタイトルの動的化はスコープ外）。

</details>

<details>
<summary><b>動作確認</b></summary>

- `./gradlew :optionBuilder:sharedUI:compileKotlinJvm :optionBuilder:sharedUI:compileKotlinJs` — 成功（**JS は PR CI でビルドされない**ため特にローカル確認）
- `./gradlew :optionBuilder:sharedUI:ktlintCheck` — 成功
- `./gradlew :optionBuilder:sharedUI:jvmTest` — `AppLanguageTest` 5 ケース成功
- Web 実機確認（`:optionBuilder:webApp:jsBrowserDevelopmentExecutableDistribution` を配信しブラウザ操作）:
  - `navigator.languages` シムが `window.__customLocale` を反映することを確認
  - 同一ブラウザ（system=ja）で、デフォルトは**日本語表示**、`?lang="en"` 上書き時は**英語表示**に切り替わることを確認 → ロケール上書き〜Compose Resources 解決まで一気通貫で動作

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
