### PR TITLE
fix(runtime): specify @Target for annotations that were missing one (closes #85)

### DIFF
--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CombineMapping.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CombineMapping.kt
@@ -126,6 +126,7 @@ annotation class CombineMapping(
      * )
      * ```
      */
+    @Target()
     annotation class Map(
         val source: String,
         val target: String,

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyMapping.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyMapping.kt
@@ -126,6 +126,7 @@ annotation class CopyMapping(
      * @param target The property name in the target class
      * ```
      */
+    @Target()
     annotation class Map(
         val source: String,
         val target: String,

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/InternalCreamApi.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/InternalCreamApi.kt
@@ -1,4 +1,5 @@
 package me.tbsten.cream
 
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @RequiresOptIn(message = "This API is used internally within cream.kt. Direct use is not recommended.")
 annotation class InternalCreamApi


### PR DESCRIPTION
## Summary

Closes #85.

Three annotation declarations in `cream-runtime` had no `@Target`, so they implicitly permitted *every* annotation site. This specifies an explicit `@Target` for each, matching how it is actually used.

| Annotation | Before | After | Rationale |
|---|---|---|---|
| `CombineMapping.Map` | (none) | `@Target()` | only used as a value inside `@CombineMapping(properties = [...])` |
| `CopyMapping.Map` | (none) | `@Target()` | only used as a value inside `@CopyMapping(properties = [...])` |
| `InternalCreamApi` | (none) | `@Target(CLASS, FUNCTION)` | opt-in marker, applied only to classes and functions |

This is a source-only hardening change: it constrains where each annotation may be written. **No generated code changes** — every existing snapshot golden is byte-identical.

<details>
<summary><b>Why these targets</b></summary>

**`CombineMapping.Map` / `CopyMapping.Map` → empty `@Target()`**

Unlike the other `.Map` annotations (`@CopyTo.Map`, `@CombineFrom.Map`, …) which are applied directly to a constructor parameter or property, these two are never applied to a declaration: the mapped classes live in libraries you cannot annotate, so a `Map` is only ever passed as a value inside the parent annotation's `properties = [...]` argument. An empty `@Target()` is exactly the right tool — it forbids applying the annotation to any declaration while keeping the array-value usage valid. This mirrors `KDoc`, the existing "argument-value-only" annotation in cream-runtime, which already uses `@Target()`.

**`InternalCreamApi` → `@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)`**

`@InternalCreamApi` is a `@RequiresOptIn` marker applied across cream-ksp-shared to classes (enum / interface / data / abstract / open / regular) and to top-level / extension functions — nothing else. Constraining it to `CLASS, FUNCTION` lets the compiler reject misplacement. `PROPERTY` is intentionally omitted: nothing marks a property today, and cream prefers expressing the actual surface in the type system over leaving speculative room.

</details>

<details>
<summary><b>Verification</b></summary>

- `./gradlew :cream-runtime:compileKotlinJvm` — empty `@Target()` accepted
- `./gradlew :cream-ksp:shared:compileKotlinJvm` — all `@InternalCreamApi` sites compile under the new target
- `./gradlew :cream-ksp:test` — kctfork snapshot/diagnostic tests pass with goldens unchanged (no `-Dcream.snapshot.update`)
- `./gradlew :test:jvmTest` — integration tests exercising `@CopyMapping` / `@CombineMapping` `properties = [...Map(...)]` pass
- `./gradlew :cream-runtime:ktlintCheck` — clean
- `git status` after the run shows only the 3 edited `.kt` files; no golden `*.md` changed

No new tests added: `@Target` is enforced by the Kotlin compiler, so testing that it rejects misplacement would be testing the compiler. The existing suite (which uses all of these annotations correctly) passing unchanged is the regression guard.

</details>

<details>
<summary><b>Out of scope: <code>@Retention</code></b></summary>

While auditing `@Target`, I noticed several cream annotations also lack an explicit `@Retention` (defaulting to `RUNTIME`), e.g. `CopyTo` / `CopyFrom` / `CombineTo` / `CombineFrom` and the newly-targeted `.Map` pair, and `@InternalCreamApi` (where `@RequiresOptIn` markers conventionally use `BINARY`). That is a separate hygiene concern and outside the scope of #85 (which is specifically about `AnnotationTarget`). Happy to follow up in a dedicated issue/PR if desired.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
