### PR TITLE
fix(ksp): escape keyword identifiers & propagate @Deprecated in generated code

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Class.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Class.kt
@@ -11,6 +11,7 @@ import me.tbsten.cream.ksp.UnknownCreamException
 import me.tbsten.cream.ksp.options.CreamOptions
 import me.tbsten.cream.ksp.reportToGithub
 import me.tbsten.cream.ksp.util.asString
+import me.tbsten.cream.ksp.util.escapeKotlinIdentifier
 import me.tbsten.cream.ksp.util.fullName
 import me.tbsten.cream.ksp.util.isCountMoreThan
 import me.tbsten.cream.ksp.util.lines
@@ -137,7 +138,7 @@ internal fun BufferedWriter.appendCopyToClassFunction(
                         },
                     )
             val modifiers = if (parameter.isVararg) "vararg " else ""
-            append("    $modifiers$paramName: $paramType")
+            append("    $modifiers${paramName.escapeKotlinIdentifier()}: $paramType")
 
             val matchedProperty = parameter.findMatchedProperty(source, generateSourceAnnotation)
             if (logger != null) {
@@ -146,7 +147,7 @@ internal fun BufferedWriter.appendCopyToClassFunction(
             if (matchedProperty != null &&
                 !parameter.isExcludedFromCopy(matchedProperty, source, generateSourceAnnotation)
             ) {
-                append(" = this.${matchedProperty.simpleName.asString()}")
+                append(" = this.${matchedProperty.simpleName.asString().escapeKotlinIdentifier()}")
             }
             append(",\n")
         }
@@ -200,7 +201,8 @@ internal fun BufferedWriter.appendCopyToClassFunction(
         appendLine()
 
         constructor.parameters.forEach { param ->
-            appendLine("    ${param.name!!.asString()} = ${param.name!!.asString()},")
+            val escaped = param.name!!.asString().escapeKotlinIdentifier()
+            appendLine("    $escaped = $escaped,")
         }
 
         appendLine(")")

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Class.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Class.kt
@@ -56,6 +56,8 @@ internal fun BufferedWriter.appendCopyToClassFunction(
 
         appendCopyToClassKDoc(source, targetClass, generateSourceAnnotation, funName, requiredParamNames)
 
+        deprecatedAnnotationLine(listOf(source))?.let { appendLine(it) }
+
         append("${visibility.toModifierString(targetClass)} fun ")
         if (typeParameters.isNotEmpty()) {
             append("<")

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CombineToClass.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CombineToClass.kt
@@ -11,6 +11,7 @@ import me.tbsten.cream.ksp.UnknownCreamException
 import me.tbsten.cream.ksp.options.CreamOptions
 import me.tbsten.cream.ksp.reportToGithub
 import me.tbsten.cream.ksp.util.asString
+import me.tbsten.cream.ksp.util.escapeKotlinIdentifier
 import me.tbsten.cream.ksp.util.fullName
 import me.tbsten.cream.ksp.util.isCountMoreThan
 import me.tbsten.cream.ksp.util.lines
@@ -179,7 +180,7 @@ internal fun BufferedWriter.appendCombineToClassFunction(
                         },
                     )
             val modifiers = if (parameter.isVararg) "vararg " else ""
-            append("    $modifiers$paramName: $paramType")
+            append("    $modifiers${paramName.escapeKotlinIdentifier()}: $paramType")
 
             // Try to find matching property in any of the source classes
             // Use asReversed() to prioritize later source classes when properties overlap
@@ -207,10 +208,10 @@ internal fun BufferedWriter.appendCombineToClassFunction(
                 val (matchedSource, matchedProperty) = matchedSourceAndProperty
                 if (!excluded) {
                     if (matchedSource == primarySource) {
-                        append(" = this.${matchedProperty.simpleName.asString()}")
+                        append(" = this.${matchedProperty.simpleName.asString().escapeKotlinIdentifier()}")
                     } else {
                         val sourceParamName = matchedSource.simpleName.asString().replaceFirstChar { it.lowercase() }
-                        append(" = $sourceParamName.${matchedProperty.simpleName.asString()}")
+                        append(" = $sourceParamName.${matchedProperty.simpleName.asString().escapeKotlinIdentifier()}")
                     }
                 }
             } else if (logger != null) {
@@ -269,7 +270,8 @@ internal fun BufferedWriter.appendCombineToClassFunction(
         appendLine()
 
         constructor.parameters.forEach { param ->
-            appendLine("    ${param.name!!.asString()} = ${param.name!!.asString()},")
+            val escaped = param.name!!.asString().escapeKotlinIdentifier()
+            appendLine("    $escaped = $escaped,")
         }
 
         appendLine(")")

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CombineToClass.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CombineToClass.kt
@@ -70,6 +70,8 @@ internal fun BufferedWriter.appendCombineToClassFunction(
 
         appendCombineToClassKDoc(allSources, targetClass, generateSourceAnnotation, funName, requiredCtorParamNames)
 
+        deprecatedAnnotationLine(allSources)?.let { appendLine(it) }
+
         append("${visibility.toModifierString(targetClass)} fun ")
         if (typeParameters.isNotEmpty()) {
             append("<")

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/DeprecatedPropagation.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/DeprecatedPropagation.kt
@@ -15,9 +15,12 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
  * the annotation onto the generated function moves those references inside a deprecated declaration,
  * which suppresses the warnings (issue #103).
  *
- * The first deprecation found wins, in this precedence: each source class (in [sources] order),
- * then the properties of each source class. message and level are preserved; level is only rendered
- * when it differs from the default [DeprecationLevel.WARNING] to keep output minimal.
+ * The first deprecation found wins, scanning [sources] in order and, within each source, checking
+ * its class-level `@Deprecated` before that same source's properties before moving to the next
+ * source. So a class-level deprecation wins over its own properties, yet an earlier source's
+ * deprecated property still wins over a later source's deprecated class. message and level are
+ * preserved; level is only rendered when it differs from the default [DeprecationLevel.WARNING] to
+ * keep output minimal.
  */
 internal fun deprecatedAnnotationLine(sources: List<KSClassDeclaration>): String? {
     val deprecated = sources.firstDeprecation() ?: return null
@@ -33,15 +36,16 @@ internal fun deprecatedAnnotationLine(sources: List<KSClassDeclaration>): String
 }
 
 /**
- * The first `@Deprecated` among these source classes, preferring a deprecation on the class itself
- * over one on a property, so a class-level message/level wins when both are present.
+ * The first `@Deprecated` among these source classes, evaluated per source in declaration order:
+ * each source is fully checked (its class-level annotation, then its own properties) before moving
+ * on to the next source. So a class-level deprecation wins over that same source's properties, but
+ * an earlier source's property deprecation still wins over a later source's class deprecation.
  */
-private fun List<KSClassDeclaration>.firstDeprecation(): Deprecated? {
-    firstNotNullOfOrNull { it.deprecatedAnnotation() }?.let { return it }
-    return firstNotNullOfOrNull { source ->
-        source.getAllProperties().firstNotNullOfOrNull { it.deprecatedAnnotation() }
+private fun List<KSClassDeclaration>.firstDeprecation(): Deprecated? =
+    firstNotNullOfOrNull { source ->
+        source.deprecatedAnnotation()
+            ?: source.getAllProperties().firstNotNullOfOrNull { it.deprecatedAnnotation() }
     }
-}
 
 private fun KSAnnotated.deprecatedAnnotation(): Deprecated? = getAnnotationsByType(Deprecated::class).firstOrNull()
 

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/DeprecatedPropagation.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/DeprecatedPropagation.kt
@@ -1,0 +1,67 @@
+package me.tbsten.cream.ksp.transform
+
+import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+/**
+ * Build the `@Deprecated(...)` line to propagate onto a generated copy function, or `null` when no
+ * contributing source is deprecated.
+ *
+ * A generated copy function references its source class (as the receiver) and the source properties
+ * it reads via `this.<name>` / `source.<name>`. When any of those symbols is `@Deprecated`, the
+ * generated code would otherwise emit deprecation warnings (and fail under `-Werror`); a
+ * `DeprecationLevel.ERROR` source even makes the generated code fail to compile outright. Copying
+ * the annotation onto the generated function moves those references inside a deprecated declaration,
+ * which suppresses the warnings (issue #103).
+ *
+ * The first deprecation found wins, in this precedence: each source class (in [sources] order),
+ * then the properties of each source class. message and level are preserved; level is only rendered
+ * when it differs from the default [DeprecationLevel.WARNING] to keep output minimal.
+ */
+internal fun deprecatedAnnotationLine(sources: List<KSClassDeclaration>): String? {
+    val deprecated = sources.firstDeprecation() ?: return null
+    return buildString {
+        append("@Deprecated(")
+        append(deprecated.message.toKotlinStringLiteral())
+        if (deprecated.level != DeprecationLevel.WARNING) {
+            append(", level = DeprecationLevel.")
+            append(deprecated.level.name)
+        }
+        append(")")
+    }
+}
+
+/**
+ * The first `@Deprecated` among these source classes, preferring a deprecation on the class itself
+ * over one on a property, so a class-level message/level wins when both are present.
+ */
+private fun List<KSClassDeclaration>.firstDeprecation(): Deprecated? {
+    firstNotNullOfOrNull { it.deprecatedAnnotation() }?.let { return it }
+    return firstNotNullOfOrNull { source ->
+        source.getAllProperties().firstNotNullOfOrNull { it.deprecatedAnnotation() }
+    }
+}
+
+private fun KSAnnotated.deprecatedAnnotation(): Deprecated? = getAnnotationsByType(Deprecated::class).firstOrNull()
+
+/**
+ * Render this string as a Kotlin double-quoted string literal, escaping the characters that would
+ * otherwise terminate the literal or be interpreted (`\`, `"`, `$`) and common control characters.
+ */
+private fun String.toKotlinStringLiteral(): String =
+    buildString {
+        append('"')
+        this@toKotlinStringLiteral.forEach { char ->
+            when (char) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '$' -> append("\\$")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> append(char)
+            }
+        }
+        append('"')
+    }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/EscapeIdentifier.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/EscapeIdentifier.kt
@@ -4,10 +4,14 @@ package me.tbsten.cream.ksp.util
  * Kotlin hard keywords. These can never be used as a bare identifier and must be backquoted
  * when they appear as a property / parameter name in generated code.
  *
+ * This is the complete set of hard keywords from the Kotlin reference:
+ * https://kotlinlang.org/docs/reference/keyword-reference.html ("Hard keywords"). The
+ * operator-spelled variants listed there (`as?`, `!in`, `!is`) are omitted because they are not
+ * identifier strings a property / parameter could be named, so they never reach this check.
+ *
  * Soft / modifier keywords (e.g. `data`, `out`, `sealed`) are intentionally NOT listed: they are
  * valid bare identifiers in identifier position, so backquoting them is unnecessary (a redundant
- * backquote would also be valid, but we keep output minimal). The list mirrors the "Hard keywords"
- * section of the Kotlin grammar.
+ * backquote would also be valid, but we keep output minimal).
  */
 private val kotlinHardKeywords =
     setOf(

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/EscapeIdentifier.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/EscapeIdentifier.kt
@@ -1,0 +1,73 @@
+package me.tbsten.cream.ksp.util
+
+/**
+ * Kotlin hard keywords. These can never be used as a bare identifier and must be backquoted
+ * when they appear as a property / parameter name in generated code.
+ *
+ * Soft / modifier keywords (e.g. `data`, `out`, `sealed`) are intentionally NOT listed: they are
+ * valid bare identifiers in identifier position, so backquoting them is unnecessary (a redundant
+ * backquote would also be valid, but we keep output minimal). The list mirrors the "Hard keywords"
+ * section of the Kotlin grammar.
+ */
+private val kotlinHardKeywords =
+    setOf(
+        "as",
+        "break",
+        "class",
+        "continue",
+        "do",
+        "else",
+        "false",
+        "for",
+        "fun",
+        "if",
+        "in",
+        "interface",
+        "is",
+        "null",
+        "object",
+        "package",
+        "return",
+        "super",
+        "this",
+        "throw",
+        "true",
+        "try",
+        "typealias",
+        "typeof",
+        "val",
+        "var",
+        "when",
+        "while",
+    )
+
+/**
+ * A name is a valid bare (unescaped) identifier when it is non-empty, starts with a Unicode letter
+ * or underscore, and otherwise contains only Unicode letters, decimal digits, and underscores. The
+ * Unicode-aware classes matter: Kotlin allows non-ASCII identifiers (e.g. Japanese `税込金額`), so an
+ * ASCII-only check would wrongly backquote them and drift the generated output.
+ *
+ * This deliberately ignores characters that are illegal even inside backquotes (`. ; [ ] / < > : \`
+ * and friends): such names cannot be represented in Kotlin at all, so cream cannot rescue them by
+ * escaping — they are out of scope (see issue #94). For the names cream can rescue (keywords and
+ * whitespace-containing names), [escapeKotlinIdentifier] wraps them in backquotes.
+ */
+private val bareIdentifierRegex = Regex("[\\p{L}_][\\p{L}\\p{Nd}_]*")
+
+/**
+ * Wrap this identifier in backquotes when it cannot appear as a bare Kotlin identifier — i.e. it is
+ * a [hard keyword][kotlinHardKeywords] or is not a [bare identifier][bareIdentifierRegex] (for
+ * example it contains a space). Already-valid bare identifiers are returned unchanged so generated
+ * code stays readable.
+ *
+ * Used at every site where cream interpolates a source property / target constructor-parameter name
+ * into generated code (parameter declarations, `this.<name>` defaults, and `name = name` named
+ * arguments). Without it, a property named after a keyword (e.g. `in`) or with a space produces a
+ * syntax error in the generated source.
+ */
+internal fun String.escapeKotlinIdentifier(): String =
+    if (this in kotlinHardKeywords || !bareIdentifierRegex.matches(this)) {
+        "`$this`"
+    } else {
+        this
+    }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/DeprecatedSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/DeprecatedSnapshotTest.kt
@@ -1,6 +1,7 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -42,7 +43,7 @@ internal class DeprecatedSnapshotTest :
             return generated
         }
 
-        test("Deprecated な source クラスから生成された copy 関数に @Deprecated が付与される") {
+        test("propagates @Deprecated onto the copy function generated from a deprecated source class") {
             val generated =
                 runSnapshot(
                     "DeprecatedSnapshotTest.deprecatedSourceClass",
@@ -61,7 +62,7 @@ internal class DeprecatedSnapshotTest :
             generated shouldContain "@Deprecated(\"source is deprecated\")"
         }
 
-        test("Deprecated な source プロパティから生成された copy 関数に @Deprecated が付与される") {
+        test("propagates @Deprecated onto the copy function generated from a deprecated source property") {
             val generated =
                 runSnapshot(
                     "DeprecatedSnapshotTest.deprecatedSourceProperty",
@@ -84,7 +85,7 @@ internal class DeprecatedSnapshotTest :
         // is a hard error at every use site even inside another @Deprecated declaration. So this
         // case pins only that the propagated annotation PRESERVES the level, without requiring the
         // generated code to compile.
-        test("DeprecationLevel ERROR の source は level を保持して @Deprecated が付与される") {
+        test("preserves DeprecationLevel.ERROR when propagating @Deprecated from the source") {
             val source =
                 """
                 package snap.deprecated.levelerror
@@ -98,14 +99,16 @@ internal class DeprecatedSnapshotTest :
                 data class DpT(val old: Int)
                 """.trimIndent()
             val generated = compileWithCream(source).generatedSourceText()
-            generated shouldContain "@Deprecated(\"gone\", level = DeprecationLevel.ERROR)"
-            assertMatchesSnapshot("DeprecatedSnapshotTest.deprecatedLevelError") {
-                "Generated" facetOf generated
-                "Input" facetOf source
+            assertSoftly {
+                generated shouldContain "@Deprecated(\"gone\", level = DeprecationLevel.ERROR)"
+                assertMatchesSnapshot("DeprecatedSnapshotTest.deprecatedLevelError") {
+                    "Generated" facetOf generated
+                    "Input" facetOf source
+                }
             }
         }
 
-        test("Deprecated でない source からは @Deprecated が付与されない") {
+        test("does not propagate @Deprecated from a non-deprecated source") {
             val generated =
                 runSnapshot(
                     "DeprecatedSnapshotTest.notDeprecated",
@@ -123,7 +126,7 @@ internal class DeprecatedSnapshotTest :
             generated shouldNotContain "@Deprecated"
         }
 
-        test("Deprecated な primary source から生成された combineTo の copy 関数に @Deprecated が付与される") {
+        test("propagates @Deprecated onto a @CombineTo copy function generated from a deprecated primary source") {
             val generated =
                 runSnapshot(
                     "DeprecatedSnapshotTest.deprecatedCombineToSource",
@@ -152,7 +155,7 @@ internal class DeprecatedSnapshotTest :
         // function on the `First` receiver must therefore carry the property's message, not the
         // later class's message — otherwise a later class-level deprecation would shadow an earlier
         // property-level one.
-        test("前の source の Deprecated プロパティが後の source の Deprecated クラスより優先される") {
+        test("prefers an earlier source's deprecated property over a later source's deprecated class") {
             val generated =
                 runSnapshot(
                     "DeprecatedSnapshotTest.combineToPropertyBeforeLaterClass",

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/DeprecatedSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/DeprecatedSnapshotTest.kt
@@ -143,4 +143,36 @@ internal class DeprecatedSnapshotTest :
                 )
             generated shouldContain "@Deprecated(\"primary is deprecated\")"
         }
+
+        // Precedence is evaluated per source in declaration order: for each source, its class-level
+        // @Deprecated is checked before that same source's property-level @Deprecated. With multiple
+        // @CombineTo sources, the receiver source comes first, so an earlier source's deprecated
+        // PROPERTY must win over a later source's deprecated CLASS. The earlier (`First`) receiver
+        // has only a deprecated property; the later (`Second`) source is class-deprecated. The
+        // function on the `First` receiver must therefore carry the property's message, not the
+        // later class's message — otherwise a later class-level deprecation would shadow an earlier
+        // property-level one.
+        test("前の source の Deprecated プロパティが後の source の Deprecated クラスより優先される") {
+            val generated =
+                runSnapshot(
+                    "DeprecatedSnapshotTest.combineToPropertyBeforeLaterClass",
+                    """
+                    package snap.deprecated.combinetoorder
+
+                    import me.tbsten.cream.CombineTo
+
+                    @CombineTo(Target::class)
+                    data class First(@Deprecated("first property gone") val id: Int)
+
+                    @Deprecated("second class gone")
+                    @CombineTo(Target::class)
+                    data class Second(val extra: String)
+
+                    data class Target(val id: Int, val extra: String)
+                    """.trimIndent(),
+                )
+            // Buggy precedence (all classes first) would attach "second class gone" to the `First`
+            // receiver and never emit "first property gone"; the per-source order makes it appear.
+            generated shouldContain "@Deprecated(\"first property gone\")"
+        }
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/DeprecatedSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/DeprecatedSnapshotTest.kt
@@ -1,0 +1,146 @@
+package me.tbsten.cream.ksp.snapshot
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
+
+/**
+ * Snapshot tests covering `@Deprecated` propagation onto generated copy functions (issue #103).
+ *
+ * When the source class or one of the source properties referenced by the generated function is
+ * `@Deprecated`, the generated copy function references deprecated symbols and would otherwise emit
+ * deprecation warnings (failing under `-Werror`). cream propagates `@Deprecated` onto the generated
+ * function so those references live inside a deprecated declaration and stop warning.
+ *
+ * The propagated annotation reproduces the original message and level (a non-default level such as
+ * `DeprecationLevel.ERROR` must be preserved). `exitCode == OK` confirms the generated source still
+ * compiles with the propagated annotation.
+ */
+internal class DeprecatedSnapshotTest :
+    FunSpec({
+        fun runSnapshot(
+            snapshotName: String,
+            source: String,
+        ): String {
+            val result = compileWithCream(source)
+
+            withClue("Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            assertMatchesSnapshot(snapshotName) {
+                "Generated" facetOf generated
+                "Input" facetOf source
+            }
+            return generated
+        }
+
+        test("Deprecated な source クラスから生成された copy 関数に @Deprecated が付与される") {
+            val generated =
+                runSnapshot(
+                    "DeprecatedSnapshotTest.deprecatedSourceClass",
+                    """
+                    package snap.deprecated.sourceclass
+
+                    import me.tbsten.cream.CopyTo
+
+                    @Deprecated("source is deprecated")
+                    @CopyTo(DpT::class)
+                    data class DpS(val old: Int)
+
+                    data class DpT(val old: Int)
+                    """.trimIndent(),
+                )
+            generated shouldContain "@Deprecated(\"source is deprecated\")"
+        }
+
+        test("Deprecated な source プロパティから生成された copy 関数に @Deprecated が付与される") {
+            val generated =
+                runSnapshot(
+                    "DeprecatedSnapshotTest.deprecatedSourceProperty",
+                    """
+                    package snap.deprecated.sourceproperty
+
+                    import me.tbsten.cream.CopyTo
+
+                    @CopyTo(DpT::class)
+                    data class DpS(@Deprecated("prop is deprecated") val old: Int)
+
+                    data class DpT(val old: Int)
+                    """.trimIndent(),
+                )
+            generated shouldContain "@Deprecated(\"prop is deprecated\")"
+        }
+
+        // A DeprecationLevel.ERROR source cannot yield compiling generated code: the generated
+        // function references the source (as receiver / via this.x), and an ERROR-level deprecation
+        // is a hard error at every use site even inside another @Deprecated declaration. So this
+        // case pins only that the propagated annotation PRESERVES the level, without requiring the
+        // generated code to compile.
+        test("DeprecationLevel ERROR の source は level を保持して @Deprecated が付与される") {
+            val source =
+                """
+                package snap.deprecated.levelerror
+
+                import me.tbsten.cream.CopyTo
+
+                @Deprecated("gone", level = DeprecationLevel.ERROR)
+                @CopyTo(DpT::class)
+                data class DpS(val old: Int)
+
+                data class DpT(val old: Int)
+                """.trimIndent()
+            val generated = compileWithCream(source).generatedSourceText()
+            generated shouldContain "@Deprecated(\"gone\", level = DeprecationLevel.ERROR)"
+            assertMatchesSnapshot("DeprecatedSnapshotTest.deprecatedLevelError") {
+                "Generated" facetOf generated
+                "Input" facetOf source
+            }
+        }
+
+        test("Deprecated でない source からは @Deprecated が付与されない") {
+            val generated =
+                runSnapshot(
+                    "DeprecatedSnapshotTest.notDeprecated",
+                    """
+                    package snap.deprecated.none
+
+                    import me.tbsten.cream.CopyTo
+
+                    @CopyTo(DpT::class)
+                    data class DpS(val old: Int)
+
+                    data class DpT(val old: Int)
+                    """.trimIndent(),
+                )
+            generated shouldNotContain "@Deprecated"
+        }
+
+        test("Deprecated な primary source から生成された combineTo の copy 関数に @Deprecated が付与される") {
+            val generated =
+                runSnapshot(
+                    "DeprecatedSnapshotTest.deprecatedCombineToSource",
+                    """
+                    package snap.deprecated.combineto
+
+                    import me.tbsten.cream.CombineTo
+
+                    @Deprecated("primary is deprecated")
+                    @CombineTo(Target::class)
+                    data class Primary(val id: Int)
+
+                    data class Other(val extra: String)
+
+                    data class Target(val id: Int, val extra: String)
+                    """.trimIndent(),
+                )
+            generated shouldContain "@Deprecated(\"primary is deprecated\")"
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/IdentifierEscapingSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/IdentifierEscapingSnapshotTest.kt
@@ -1,0 +1,147 @@
+package me.tbsten.cream.ksp.snapshot
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
+
+/**
+ * Snapshot tests covering backquote-escaping of generated identifiers (issue #94).
+ *
+ * When a property / constructor-parameter name is a Kotlin keyword (`in`, `is`, …) or
+ * contains characters that are only legal inside backquotes (e.g. a space), the generated
+ * copy function must wrap that identifier in backquotes at every interpolation site —
+ * parameter declaration, `this.<name>` default, and the `name = name` named argument —
+ * otherwise the generated code does not compile.
+ *
+ * Note: the generated function NAME is intentionally not escaped by cream (left to the
+ * compiler, see CopyFunctionNameExt). These tests pin the escaping of property/parameter
+ * identifiers only, and assert the generated code actually compiles (exitCode == OK proves
+ * the emitted source is valid Kotlin).
+ */
+internal class IdentifierEscapingSnapshotTest :
+    FunSpec({
+        fun runSnapshot(
+            snapshotName: String,
+            source: String,
+        ): String {
+            val result = compileWithCream(source)
+
+            withClue("Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}") {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            assertMatchesSnapshot(snapshotName) {
+                "Generated" facetOf generated
+                "Input" facetOf source
+            }
+            return generated
+        }
+
+        test("keyword 名のプロパティを持つ copyTo が backquote で escape して compile できるコードを生成する") {
+            val generated =
+                runSnapshot(
+                    "IdentifierEscapingSnapshotTest.copyToKeyword",
+                    """
+                    package snap.escape.copyto
+
+                    import me.tbsten.cream.CopyTo
+
+                    @CopyTo(KwTarget::class)
+                    data class KwSource(val `in`: Int, val `is`: Boolean)
+
+                    data class KwTarget(val `in`: Int, val `is`: Boolean)
+                    """.trimIndent(),
+                )
+            generated shouldContain "`in`: Int = this.`in`"
+            generated shouldContain "`is`: Boolean = this.`is`"
+            generated shouldContain "`in` = `in`"
+            generated shouldContain "`is` = `is`"
+        }
+
+        test("空白入り名のプロパティを持つ copyTo が backquote で escape して compile できるコードを生成する") {
+            val generated =
+                runSnapshot(
+                    "IdentifierEscapingSnapshotTest.copyToSpaceName",
+                    """
+                    package snap.escape.space
+
+                    import me.tbsten.cream.CopyTo
+
+                    @CopyTo(SpTarget::class)
+                    data class SpSource(val `my prop`: Int)
+
+                    data class SpTarget(val `my prop`: Int)
+                    """.trimIndent(),
+                )
+            generated shouldContain "`my prop`: Int = this.`my prop`"
+            generated shouldContain "`my prop` = `my prop`"
+        }
+
+        test("keyword 名のプロパティを持つ copyFrom が backquote で escape して compile できるコードを生成する") {
+            val generated =
+                runSnapshot(
+                    "IdentifierEscapingSnapshotTest.copyFromKeyword",
+                    """
+                    package snap.escape.copyfrom
+
+                    import me.tbsten.cream.CopyFrom
+
+                    data class KwSource(val `object`: String)
+
+                    @CopyFrom(KwSource::class)
+                    data class KwTarget(val `object`: String)
+                    """.trimIndent(),
+                )
+            generated shouldContain "`object`: String = this.`object`"
+            generated shouldContain "`object` = `object`"
+        }
+
+        test("keyword 名のプロパティを持つ combineTo が backquote で escape して compile できるコードを生成する") {
+            val generated =
+                runSnapshot(
+                    "IdentifierEscapingSnapshotTest.combineToKeyword",
+                    """
+                    package snap.escape.combineto
+
+                    import me.tbsten.cream.CombineTo
+
+                    @CombineTo(KwTarget::class)
+                    data class Primary(val `in`: Int)
+
+                    data class Other(val `return`: String)
+
+                    data class KwTarget(val `in`: Int, val `return`: String)
+                    """.trimIndent(),
+                )
+            // primary source contributes `this.` reference, other source contributes a param + ref
+            generated shouldContain "`in`: Int = this.`in`"
+            generated shouldContain "`in` = `in`"
+            generated shouldContain "`return` = `return`"
+        }
+
+        test("非 ASCII の正当な identifier は backquote で escape されない") {
+            val generated =
+                runSnapshot(
+                    "IdentifierEscapingSnapshotTest.nonAsciiIdentifier",
+                    """
+                    package snap.escape.nonascii
+
+                    import me.tbsten.cream.CopyTo
+
+                    @CopyTo(注文::class)
+                    data class 注文Entity(val 税込金額: Int)
+
+                    data class 注文(val 税込金額: Int)
+                    """.trimIndent(),
+                )
+            generated shouldContain "税込金額: Int = this.税込金額"
+            generated shouldNotContain "`税込金額`"
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/IdentifierEscapingSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/IdentifierEscapingSnapshotTest.kt
@@ -1,6 +1,7 @@
 package me.tbsten.cream.ksp.snapshot
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -44,7 +45,7 @@ internal class IdentifierEscapingSnapshotTest :
             return generated
         }
 
-        test("keyword 名のプロパティを持つ copyTo が backquote で escape して compile できるコードを生成する") {
+        test("escapes keyword-named properties of a @CopyTo source so the generated code compiles") {
             val generated =
                 runSnapshot(
                     "IdentifierEscapingSnapshotTest.copyToKeyword",
@@ -59,13 +60,15 @@ internal class IdentifierEscapingSnapshotTest :
                     data class KwTarget(val `in`: Int, val `is`: Boolean)
                     """.trimIndent(),
                 )
-            generated shouldContain "`in`: Int = this.`in`"
-            generated shouldContain "`is`: Boolean = this.`is`"
-            generated shouldContain "`in` = `in`"
-            generated shouldContain "`is` = `is`"
+            assertSoftly {
+                generated shouldContain "`in`: Int = this.`in`"
+                generated shouldContain "`is`: Boolean = this.`is`"
+                generated shouldContain "`in` = `in`"
+                generated shouldContain "`is` = `is`"
+            }
         }
 
-        test("空白入り名のプロパティを持つ copyTo が backquote で escape して compile できるコードを生成する") {
+        test("escapes space-containing property names of a @CopyTo source so the generated code compiles") {
             val generated =
                 runSnapshot(
                     "IdentifierEscapingSnapshotTest.copyToSpaceName",
@@ -80,11 +83,13 @@ internal class IdentifierEscapingSnapshotTest :
                     data class SpTarget(val `my prop`: Int)
                     """.trimIndent(),
                 )
-            generated shouldContain "`my prop`: Int = this.`my prop`"
-            generated shouldContain "`my prop` = `my prop`"
+            assertSoftly {
+                generated shouldContain "`my prop`: Int = this.`my prop`"
+                generated shouldContain "`my prop` = `my prop`"
+            }
         }
 
-        test("keyword 名のプロパティを持つ copyFrom が backquote で escape して compile できるコードを生成する") {
+        test("escapes keyword-named properties of a @CopyFrom source so the generated code compiles") {
             val generated =
                 runSnapshot(
                     "IdentifierEscapingSnapshotTest.copyFromKeyword",
@@ -99,11 +104,13 @@ internal class IdentifierEscapingSnapshotTest :
                     data class KwTarget(val `object`: String)
                     """.trimIndent(),
                 )
-            generated shouldContain "`object`: String = this.`object`"
-            generated shouldContain "`object` = `object`"
+            assertSoftly {
+                generated shouldContain "`object`: String = this.`object`"
+                generated shouldContain "`object` = `object`"
+            }
         }
 
-        test("keyword 名のプロパティを持つ combineTo が backquote で escape して compile できるコードを生成する") {
+        test("escapes keyword-named properties of @CombineTo sources so the generated code compiles") {
             val generated =
                 runSnapshot(
                     "IdentifierEscapingSnapshotTest.combineToKeyword",
@@ -120,13 +127,15 @@ internal class IdentifierEscapingSnapshotTest :
                     data class KwTarget(val `in`: Int, val `return`: String)
                     """.trimIndent(),
                 )
-            // primary source contributes `this.` reference, other source contributes a param + ref
-            generated shouldContain "`in`: Int = this.`in`"
-            generated shouldContain "`in` = `in`"
-            generated shouldContain "`return` = `return`"
+            assertSoftly {
+                // primary source contributes `this.` reference, other source contributes a param + ref
+                generated shouldContain "`in`: Int = this.`in`"
+                generated shouldContain "`in` = `in`"
+                generated shouldContain "`return` = `return`"
+            }
         }
 
-        test("非 ASCII の正当な identifier は backquote で escape されない") {
+        test("does not escape a valid non-ASCII identifier") {
             val generated =
                 runSnapshot(
                     "IdentifierEscapingSnapshotTest.nonAsciiIdentifier",
@@ -141,7 +150,9 @@ internal class IdentifierEscapingSnapshotTest :
                     data class 注文(val 税込金額: Int)
                     """.trimIndent(),
                 )
-            generated shouldContain "税込金額: Int = this.税込金額"
-            generated shouldNotContain "`税込金額`"
+            assertSoftly {
+                generated shouldContain "税込金額: Int = this.税込金額"
+                generated shouldNotContain "`税込金額`"
+            }
         }
     })

--- a/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/combineToPropertyBeforeLaterClass.md
+++ b/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/combineToPropertyBeforeLaterClass.md
@@ -1,0 +1,104 @@
+## Generated
+
+````kt
+// file: CombineTo__First__Target.kt
+package snap.deprecated.combinetoorder
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CombineTo] annotation of [First])
+ * 
+ * [First] + [Second] -> [Target] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val first = First(...)
+ * val second = Second(...)
+ * val target = first.copyToTarget(second = Second(...))
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val first = First(...)
+ * val second = Second(...)
+ * val target = first.copyToTarget(second = Second(...), property = value)
+ * ```
+ * 
+ * 
+ * @see First
+ * @see Second
+ * @see Target
+ */
+@Deprecated("first property gone")
+public fun  snap.deprecated.combinetoorder.First.copyToTarget(
+    second: snap.deprecated.combinetoorder.Second,
+    id: Int = this.id,
+    extra: String = second.extra,
+) : snap.deprecated.combinetoorder.Target = snap.deprecated.combinetoorder.Target(
+    id = id,
+    extra = extra,
+)
+
+// ----- next file -----
+
+// file: CombineTo__Second__Target.kt
+package snap.deprecated.combinetoorder
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CombineTo] annotation of [Second])
+ * 
+ * [Second] + [First] -> [Target] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val second = Second(...)
+ * val first = First(...)
+ * val target = second.copyToTarget(first = First(...))
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val second = Second(...)
+ * val first = First(...)
+ * val target = second.copyToTarget(first = First(...), property = value)
+ * ```
+ * 
+ * 
+ * @see Second
+ * @see First
+ * @see Target
+ */
+@Deprecated("second class gone")
+public fun  snap.deprecated.combinetoorder.Second.copyToTarget(
+    first: snap.deprecated.combinetoorder.First,
+    id: Int = first.id,
+    extra: String = this.extra,
+) : snap.deprecated.combinetoorder.Target = snap.deprecated.combinetoorder.Target(
+    id = id,
+    extra = extra,
+)
+````
+
+## Input
+
+```kt
+package snap.deprecated.combinetoorder
+
+import me.tbsten.cream.CombineTo
+
+@CombineTo(Target::class)
+data class First(@Deprecated("first property gone") val id: Int)
+
+@Deprecated("second class gone")
+@CombineTo(Target::class)
+data class Second(val extra: String)
+
+data class Target(val id: Int, val extra: String)
+```

--- a/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/deprecatedCombineToSource.md
+++ b/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/deprecatedCombineToSource.md
@@ -1,0 +1,56 @@
+## Generated
+
+````kt
+// file: CombineTo__Primary__Target.kt
+package snap.deprecated.combineto
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CombineTo] annotation of [Primary])
+ * 
+ * [Primary] -> [Target] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val primary = Primary(...)
+ * val target = primary.copyToTarget(extra = extra)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val primary = Primary(...)
+ * val target = primary.copyToTarget(extra = extra, property = value)
+ * ```
+ * 
+ * 
+ * @see Primary
+ * @see Target
+ */
+@Deprecated("primary is deprecated")
+public fun  snap.deprecated.combineto.Primary.copyToTarget(
+    id: Int = this.id,
+    extra: String,
+) : snap.deprecated.combineto.Target = snap.deprecated.combineto.Target(
+    id = id,
+    extra = extra,
+)
+````
+
+## Input
+
+```kt
+package snap.deprecated.combineto
+
+import me.tbsten.cream.CombineTo
+
+@Deprecated("primary is deprecated")
+@CombineTo(Target::class)
+data class Primary(val id: Int)
+
+data class Other(val extra: String)
+
+data class Target(val id: Int, val extra: String)
+```

--- a/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/deprecatedLevelError.md
+++ b/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/deprecatedLevelError.md
@@ -1,0 +1,52 @@
+## Generated
+
+````kt
+// file: CopyTo__DpS.kt
+package snap.deprecated.levelerror
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [DpS])
+ * 
+ * DpS -> DpT copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = DpS(...)
+ * val target = source.copyToDpT()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = DpS(...)
+ * val target = source.copyToDpT(property = value)
+ * ```
+ * 
+ * 
+ * @see DpS
+ * @see DpT
+ */
+@Deprecated("gone", level = DeprecationLevel.ERROR)
+public fun  snap.deprecated.levelerror.DpS.copyToDpT(
+    old: Int = this.old,
+) : snap.deprecated.levelerror.DpT = snap.deprecated.levelerror.DpT(
+    old = old,
+)
+````
+
+## Input
+
+```kt
+package snap.deprecated.levelerror
+
+import me.tbsten.cream.CopyTo
+
+@Deprecated("gone", level = DeprecationLevel.ERROR)
+@CopyTo(DpT::class)
+data class DpS(val old: Int)
+
+data class DpT(val old: Int)
+```

--- a/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/deprecatedSourceClass.md
+++ b/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/deprecatedSourceClass.md
@@ -1,0 +1,52 @@
+## Generated
+
+````kt
+// file: CopyTo__DpS.kt
+package snap.deprecated.sourceclass
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [DpS])
+ * 
+ * DpS -> DpT copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = DpS(...)
+ * val target = source.copyToDpT()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = DpS(...)
+ * val target = source.copyToDpT(property = value)
+ * ```
+ * 
+ * 
+ * @see DpS
+ * @see DpT
+ */
+@Deprecated("source is deprecated")
+public fun  snap.deprecated.sourceclass.DpS.copyToDpT(
+    old: Int = this.old,
+) : snap.deprecated.sourceclass.DpT = snap.deprecated.sourceclass.DpT(
+    old = old,
+)
+````
+
+## Input
+
+```kt
+package snap.deprecated.sourceclass
+
+import me.tbsten.cream.CopyTo
+
+@Deprecated("source is deprecated")
+@CopyTo(DpT::class)
+data class DpS(val old: Int)
+
+data class DpT(val old: Int)
+```

--- a/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/deprecatedSourceProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/deprecatedSourceProperty.md
@@ -1,0 +1,51 @@
+## Generated
+
+````kt
+// file: CopyTo__DpS.kt
+package snap.deprecated.sourceproperty
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [DpS])
+ * 
+ * DpS -> DpT copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = DpS(...)
+ * val target = source.copyToDpT()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = DpS(...)
+ * val target = source.copyToDpT(property = value)
+ * ```
+ * 
+ * 
+ * @see DpS
+ * @see DpT
+ */
+@Deprecated("prop is deprecated")
+public fun  snap.deprecated.sourceproperty.DpS.copyToDpT(
+    old: Int = this.old,
+) : snap.deprecated.sourceproperty.DpT = snap.deprecated.sourceproperty.DpT(
+    old = old,
+)
+````
+
+## Input
+
+```kt
+package snap.deprecated.sourceproperty
+
+import me.tbsten.cream.CopyTo
+
+@CopyTo(DpT::class)
+data class DpS(@Deprecated("prop is deprecated") val old: Int)
+
+data class DpT(val old: Int)
+```

--- a/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/notDeprecated.md
+++ b/cream-ksp/src/test/resources/snapshots/DeprecatedSnapshotTest/notDeprecated.md
@@ -1,0 +1,50 @@
+## Generated
+
+````kt
+// file: CopyTo__DpS.kt
+package snap.deprecated.none
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [DpS])
+ * 
+ * DpS -> DpT copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = DpS(...)
+ * val target = source.copyToDpT()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = DpS(...)
+ * val target = source.copyToDpT(property = value)
+ * ```
+ * 
+ * 
+ * @see DpS
+ * @see DpT
+ */
+public fun  snap.deprecated.none.DpS.copyToDpT(
+    old: Int = this.old,
+) : snap.deprecated.none.DpT = snap.deprecated.none.DpT(
+    old = old,
+)
+````
+
+## Input
+
+```kt
+package snap.deprecated.none
+
+import me.tbsten.cream.CopyTo
+
+@CopyTo(DpT::class)
+data class DpS(val old: Int)
+
+data class DpT(val old: Int)
+```

--- a/cream-ksp/src/test/resources/snapshots/IdentifierEscapingSnapshotTest/combineToKeyword.md
+++ b/cream-ksp/src/test/resources/snapshots/IdentifierEscapingSnapshotTest/combineToKeyword.md
@@ -1,0 +1,54 @@
+## Generated
+
+````kt
+// file: CombineTo__Primary__KwTarget.kt
+package snap.escape.combineto
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CombineTo] annotation of [Primary])
+ * 
+ * [Primary] -> [KwTarget] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val primary = Primary(...)
+ * val target = primary.copyToKwTarget(return = return)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val primary = Primary(...)
+ * val target = primary.copyToKwTarget(return = return, property = value)
+ * ```
+ * 
+ * 
+ * @see Primary
+ * @see KwTarget
+ */
+public fun  snap.escape.combineto.Primary.copyToKwTarget(
+    `in`: Int = this.`in`,
+    `return`: String,
+) : snap.escape.combineto.KwTarget = snap.escape.combineto.KwTarget(
+    `in` = `in`,
+    `return` = `return`,
+)
+````
+
+## Input
+
+```kt
+package snap.escape.combineto
+
+import me.tbsten.cream.CombineTo
+
+@CombineTo(KwTarget::class)
+data class Primary(val `in`: Int)
+
+data class Other(val `return`: String)
+
+data class KwTarget(val `in`: Int, val `return`: String)
+```

--- a/cream-ksp/src/test/resources/snapshots/IdentifierEscapingSnapshotTest/copyFromKeyword.md
+++ b/cream-ksp/src/test/resources/snapshots/IdentifierEscapingSnapshotTest/copyFromKeyword.md
@@ -1,0 +1,50 @@
+## Generated
+
+````kt
+// file: CopyFrom__KwTarget.kt
+package snap.escape.copyfrom
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyFrom] annotation of [KwTarget])
+ * 
+ * KwSource -> KwTarget copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = KwSource(...)
+ * val target = source.copyToKwTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = KwSource(...)
+ * val target = source.copyToKwTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see KwSource
+ * @see KwTarget
+ */
+public fun  snap.escape.copyfrom.KwSource.copyToKwTarget(
+    `object`: String = this.`object`,
+) : snap.escape.copyfrom.KwTarget = snap.escape.copyfrom.KwTarget(
+    `object` = `object`,
+)
+````
+
+## Input
+
+```kt
+package snap.escape.copyfrom
+
+import me.tbsten.cream.CopyFrom
+
+data class KwSource(val `object`: String)
+
+@CopyFrom(KwSource::class)
+data class KwTarget(val `object`: String)
+```

--- a/cream-ksp/src/test/resources/snapshots/IdentifierEscapingSnapshotTest/copyToKeyword.md
+++ b/cream-ksp/src/test/resources/snapshots/IdentifierEscapingSnapshotTest/copyToKeyword.md
@@ -1,0 +1,52 @@
+## Generated
+
+````kt
+// file: CopyTo__KwSource.kt
+package snap.escape.copyto
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [KwSource])
+ * 
+ * KwSource -> KwTarget copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = KwSource(...)
+ * val target = source.copyToKwTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = KwSource(...)
+ * val target = source.copyToKwTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see KwSource
+ * @see KwTarget
+ */
+public fun  snap.escape.copyto.KwSource.copyToKwTarget(
+    `in`: Int = this.`in`,
+    `is`: Boolean = this.`is`,
+) : snap.escape.copyto.KwTarget = snap.escape.copyto.KwTarget(
+    `in` = `in`,
+    `is` = `is`,
+)
+````
+
+## Input
+
+```kt
+package snap.escape.copyto
+
+import me.tbsten.cream.CopyTo
+
+@CopyTo(KwTarget::class)
+data class KwSource(val `in`: Int, val `is`: Boolean)
+
+data class KwTarget(val `in`: Int, val `is`: Boolean)
+```

--- a/cream-ksp/src/test/resources/snapshots/IdentifierEscapingSnapshotTest/copyToSpaceName.md
+++ b/cream-ksp/src/test/resources/snapshots/IdentifierEscapingSnapshotTest/copyToSpaceName.md
@@ -1,0 +1,50 @@
+## Generated
+
+````kt
+// file: CopyTo__SpSource.kt
+package snap.escape.space
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [SpSource])
+ * 
+ * SpSource -> SpTarget copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = SpSource(...)
+ * val target = source.copyToSpTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = SpSource(...)
+ * val target = source.copyToSpTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see SpSource
+ * @see SpTarget
+ */
+public fun  snap.escape.space.SpSource.copyToSpTarget(
+    `my prop`: Int = this.`my prop`,
+) : snap.escape.space.SpTarget = snap.escape.space.SpTarget(
+    `my prop` = `my prop`,
+)
+````
+
+## Input
+
+```kt
+package snap.escape.space
+
+import me.tbsten.cream.CopyTo
+
+@CopyTo(SpTarget::class)
+data class SpSource(val `my prop`: Int)
+
+data class SpTarget(val `my prop`: Int)
+```

--- a/cream-ksp/src/test/resources/snapshots/IdentifierEscapingSnapshotTest/nonAsciiIdentifier.md
+++ b/cream-ksp/src/test/resources/snapshots/IdentifierEscapingSnapshotTest/nonAsciiIdentifier.md
@@ -1,0 +1,50 @@
+## Generated
+
+````kt
+// file: CopyTo__注文Entity.kt
+package snap.escape.nonascii
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [注文Entity])
+ * 
+ * 注文Entity -> 注文 copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = 注文Entity(...)
+ * val target = source.copyTo注文()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = 注文Entity(...)
+ * val target = source.copyTo注文(property = value)
+ * ```
+ * 
+ * 
+ * @see 注文Entity
+ * @see 注文
+ */
+public fun  snap.escape.nonascii.注文Entity.copyTo注文(
+    税込金額: Int = this.税込金額,
+) : snap.escape.nonascii.注文 = snap.escape.nonascii.注文(
+    税込金額 = 税込金額,
+)
+````
+
+## Input
+
+```kt
+package snap.escape.nonascii
+
+import me.tbsten.cream.CopyTo
+
+@CopyTo(注文::class)
+data class 注文Entity(val 税込金額: Int)
+
+data class 注文(val 税込金額: Int)
+```


### PR DESCRIPTION
## Summary

Fixes two codegen correctness bugs found via exploratory verification.

Closes #94, #103

> [!NOTE]
> **Stacked on #109 (`fix/issue-49-vararg`).** Review/merge that PR first; this PR's base is `fix/issue-49-vararg`, so its diff here is only these two commits. It builds on (and keeps green) the vararg work without touching it.

### #94 — backquote-escape generated identifiers

Generated copy functions interpolated source-property / target-constructor-parameter names raw, so a name that is a Kotlin keyword (`in`, `is`, `object`, ...) or contains a space produced non-compiling generated code (e.g. `in: Int = this.in`). Now such identifiers are backquoted at every interpolation site, e.g.:

```kotlin
public fun KwSource.copyToKwTarget(
    `in`: Int = this.`in`,
    `is`: Boolean = this.`is`,
) : KwTarget = KwTarget(`in` = `in`, `is` = `is`)
```

### #103 — propagate `@Deprecated` onto generated functions

A generated copy function references its source class (as receiver) and the source properties it reads, so a `@Deprecated` source/property made the generated code emit deprecation warnings (failing under `-Werror`). Now `@Deprecated` is propagated onto the generated function, preserving message and (non-default) level:

```kotlin
@Deprecated("source is deprecated")
public fun DpS.copyToDpT(old: Int = this.old): DpT = DpT(old = old)
```

## Changes

- `util/EscapeIdentifier.kt` (new): `String.escapeKotlinIdentifier()` backquotes hard keywords / non-bare identifiers. Valid bare identifiers — including non-ASCII ones like Japanese, which are legal Kotlin identifiers — are left unchanged. Characters illegal even inside backquotes (`. ; [ ] / < > : \`) are out of scope.
- `transform/DeprecatedPropagation.kt` (new): `deprecatedAnnotationLine(sources)` renders the `@Deprecated(...)` line (class-level deprecation wins over property-level; level rendered only when non-`WARNING`). Reads the annotation via KSP `getAnnotationsByType(Deprecated::class)` (type-safe, no casts).
- `transform/Class.kt`, `transform/CombineToClass.kt`: apply escaping at all identifier interpolation sites; emit the `@Deprecated` line before the function signature.

The generated function NAME and `DeprecationLevel.ERROR` references are intentionally left to the compiler (an ERROR-deprecated source receiver cannot yield compiling code regardless of propagation).

## Test plan

New JVM kctfork snapshot tests (golden = generated source; `exitCode == OK` proves the generated code actually compiles):

- `IdentifierEscapingSnapshotTest` (5): keyword names (copyTo / copyFrom / combineTo), space-in-name, and a non-ASCII-identifier guard ensuring legal Unicode names are **not** escaped.
- `DeprecatedSnapshotTest` (5): deprecated source class / source property, level preservation, combineTo primary, and a negative control (no `@Deprecated` when source isn't deprecated).

Results: both new classes green; full `:cream-ksp:test` green (178 tests, 0 failures), including the stacked vararg `VarargSnapshotTest`. `:cream-ksp:ktlintCheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)