### PR TITLE
ci: run gradle build matrix on PRs targeting any base branch

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   workflow_call:
 
 permissions:


### PR DESCRIPTION
## Why

Stacked PRs (base ≠ `main`) currently skip the gradle `build` / `ktlint` matrix, because the `pull_request` trigger in `.github/workflows/gradle.yml` is filtered to `branches: [ "main" ]`. (Only `claude-code-review.yml`, which has no branch filter, runs on them.)

## What

Remove the `pull_request.branches: [ "main" ]` filter so PRs based on **any** branch run the full matrix. `push.branches: [ "main" ]` and `workflow_call:` are unchanged.

```diff
   pull_request:
-    branches: [ "main" ]
   workflow_call:
```

## Verification

Subsequent stacked PRs (base = a feature branch) should now trigger the `build` matrix + `ktlint` job in Actions. (Trade-off: every PR to any base now runs the iOS matrix → more CI minutes.)

<details>
<summary>Context: first of a stacked series</summary>

This is the first PR (PR-0) of a planned series addressing issues #98, #101, #106, #108, #113, #114, #115. Several of those are stacked PRs (base ≠ `main`); this change ensures they receive full CI rather than only the review workflow.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
