### PR TITLE
docs: clarify @CombineTo same-name precedence is argument-source-wins (#108)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -394,7 +394,9 @@ val successState: SuccessState = loadingState.copyToSuccessState(
 )
 ```
 
-複数のソースクラスに同じプロパティ名がある場合、**後に宣言されたソースクラス** の値が優先されます。
+複数のソースクラスに同じプロパティ名がある場合、**(receiver ではなく) 引数として渡したソースクラスの値が
+優先** されます。生成される関数は primary source を receiver とする拡張関数で、他のソースは引数として渡される
+ため、重複するプロパティでは receiver よりも後に並ぶ引数側のソースが優先されます。
 
 ### CombineFrom
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,10 @@ val successState: SuccessState = loadingState.copyToSuccessState(
 )
 ```
 
-When multiple source classes have the same property name, **the last declared source class** takes precedence.
+When multiple source classes have the same property name, **the argument (non-receiver) source wins** —
+that is, the value comes from a source passed as an argument rather than from the receiver. Because the
+generated function is an extension on the primary source (the receiver) with the other sources passed as
+arguments, the last-listed argument source takes precedence over the receiver for the overlapping property.
 
 ### CombineFrom
 


### PR DESCRIPTION
## Why

The docs said: "When multiple source classes have the same property name, **the last declared source class** takes precedence." That is technically true but misleading. In `@CombineTo`, the generated function is an extension on the primary source (the **receiver**), and the other sources are passed as **arguments**. The implementation (`cream-ksp/.../transform/CombineToClass.kt`) resolves the value with `allSources.asReversed().firstNotNullOfOrNull { ... }` where `allSources = listOf(primarySource) + otherSources`, so the **last source = a non-receiver (argument) source** always wins over the receiver for an overlapping property name. "Last declared" obscures that the winner is specifically an argument source, not the receiver.

## What

Docs-only. No code changed.

- `README.md` — reworded the precedence sentence to state the **argument (non-receiver) source wins** (the value comes from a source passed as an argument, not the receiver), and explained why (extension on the receiver + other sources as arguments).
- `README.ja.md` — same clarification: 「(receiver ではなく) 引数として渡したソースクラスの値が優先」. en/ja kept in sync.

Stacked on #119 (#106). 

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)