### PR TITLE
fix(ksp): skip empty package+import file when no copy function is generated

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineFromProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineFromProcessor.kt
@@ -120,9 +120,6 @@ internal fun CreamSymbolProcessor.processCombineFrom(resolver: Resolver): List<K
                 packageName = targetClass.packageName,
                 fileName = "CombineFrom__${primarySource.underPackageName}__${targetClass.underPackageName}",
             ) {
-                it.appendLine("import me.tbsten.cream.*")
-                it.appendLine()
-
                 // Generate combine function with multiple sources
                 it.appendCombineToFunction(
                     primarySource = primarySource,

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
@@ -153,9 +153,6 @@ internal fun CreamSymbolProcessor.processCombineMapping(resolver: Resolver): Lis
                     packageName = packageName,
                     fileName = "CombineMapping__${annotatedDeclaration.underPackageName}",
                 ) {
-                    it.appendLine("import me.tbsten.cream.*")
-                    it.appendLine()
-
                     mappings.forEach { mapping ->
                         val primarySource = mapping.sourceClasses.first()
                         val otherSources = mapping.sourceClasses.drop(1)

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineToProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineToProcessor.kt
@@ -152,9 +152,6 @@ internal fun CreamSymbolProcessor.processCombineTo(resolver: Resolver): List<KSA
                     packageName = sourceClass.packageName,
                     fileName = "CombineTo__${sourceClass.underPackageName}__${targetClass.underPackageName}",
                 ) {
-                    it.appendLine("import me.tbsten.cream.*")
-                    it.appendLine()
-
                     // Generate combine function with multiple sources
                     it.appendCombineToFunction(
                         primarySource = sourceClass,

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyFromProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyFromProcessor.kt
@@ -84,9 +84,6 @@ internal fun CreamSymbolProcessor.processCopyFrom(resolver: Resolver): List<KSAn
                 packageName = targetClass.packageName,
                 fileName = "CopyFrom__${targetClass.underPackageName}",
             ) {
-                it.appendLine("import me.tbsten.cream.*")
-                it.appendLine()
-
                 sourceClasses.forEach { sourceClass ->
                     it.appendCopyFunction(
                         source = sourceClass,

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
@@ -149,9 +149,6 @@ internal fun CreamSymbolProcessor.processCopyMapping(resolver: Resolver): List<K
                     packageName = packageName,
                     fileName = "CopyMapping__${annotatedDeclaration.underPackageName}",
                 ) {
-                    it.appendLine("import me.tbsten.cream.*")
-                    it.appendLine()
-
                     mappings.forEach { mapping ->
                         it.appendCopyFunction(
                             source = mapping.sourceClass,

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToChildrenProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToChildrenProcessor.kt
@@ -114,9 +114,6 @@ internal fun CreamSymbolProcessor.processCopyToChildren(resolver: Resolver): Lis
                 packageName = sourceSealedClass.packageName,
                 fileName = "CopyToChildren__${sourceSealedClass.underPackageName}",
             ) {
-                it.appendLine("import me.tbsten.cream.*")
-                it.appendLine()
-
                 targetClasses.forEach { targetClass ->
                     // generate sourceClass to sourceClass copy function
                     it.appendCopyFunction(

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToProcessor.kt
@@ -111,9 +111,6 @@ internal fun CreamSymbolProcessor.processCopyTo(resolver: Resolver): List<KSAnno
                 packageName = sourceClass.packageName,
                 fileName = "CopyTo__${sourceClass.underPackageName}",
             ) {
-                it.appendLine("import me.tbsten.cream.*")
-                it.appendLine()
-
                 targetClasses.forEach { targetClass ->
                     // generate sourceClass to sourceClass copy function
                     it.appendCopyFunction(

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/SealedCopyProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/SealedCopyProcessor.kt
@@ -124,9 +124,6 @@ internal fun CreamSymbolProcessor.processSealedCopy(resolver: Resolver): List<KS
                 packageName = annotated.packageName,
                 fileName = "SealedCopy__${annotated.underPackageName}",
             ) {
-                it.appendLine("import me.tbsten.cream.*")
-                it.appendLine()
-
                 annotationsWithFunName.forEach { (sealedAnnotation, funName) ->
                     val nonCopyableStrategy =
                         sealedAnnotation.arguments

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/CodeGeneratorExt.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/CodeGeneratorExt.kt
@@ -4,20 +4,40 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.symbol.KSName
 import java.io.BufferedWriter
+import java.io.StringWriter
 
+/**
+ * Write a generated Kotlin file, but only when [block] actually produces declarations.
+ *
+ * [block] is run first against an in-memory buffer and must write **only declarations** — the
+ * `package` line and the `import me.tbsten.cream.*` boilerplate are owned here so every caller
+ * shares one source of truth. If [block] writes nothing (every target was skipped, e.g.
+ * `notCopyToObject` object-skips), no file is opened: cream emits no empty `package` + `import`
+ * file (issue #113). Otherwise the real file is created and the boilerplate + buffered
+ * declarations are flushed to it.
+ */
 internal fun CodeGenerator.createNewKotlinFile(
     dependencies: Dependencies,
     packageName: KSName,
     fileName: String,
     block: (BufferedWriter) -> Unit,
-) = createNewFile(
-    dependencies = dependencies,
-    packageName = packageName.asString(),
-    fileName = fileName,
-).bufferedWriter()
-    .use {
-        it.appendLine("package ${packageName.asString()}")
-        it.appendLine()
+) {
+    val buffer = StringWriter()
+    BufferedWriter(buffer).use(block)
+    val body = buffer.toString()
 
-        block(it)
-    }
+    if (body.isEmpty()) return
+
+    createNewFile(
+        dependencies = dependencies,
+        packageName = packageName.asString(),
+        fileName = fileName,
+    ).bufferedWriter()
+        .use {
+            it.appendLine("package ${packageName.asString()}")
+            it.appendLine()
+            it.appendLine("import me.tbsten.cream.*")
+            it.appendLine()
+            it.append(body)
+        }
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/EmptyFileGenerationTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/EmptyFileGenerationTest.kt
@@ -1,0 +1,70 @@
+package me.tbsten.cream.ksp
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+
+/**
+ * #113: when a generation unit produces zero copy functions (all targets skipped),
+ * cream must write NO file at all — not a file containing only `package` + `import`.
+ */
+internal class EmptyFileGenerationTest :
+    FunSpec({
+        test("copyToChildren over all-object subclasses with notCopyToObject writes no file") {
+            // Every direct subclass is an object, so notCopyToObject=true skips them all and the
+            // generation unit produces zero functions.
+            val source =
+                """
+                package empty.allobject
+
+                import me.tbsten.cream.CopyToChildren
+
+                @CopyToChildren(notCopyToObject = true)
+                sealed interface State {
+                    data object Loading : State
+                    data object Empty : State
+                }
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            assertSoftly {
+                withClue(result.messages) {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+                }
+                withClue("No file should be generated when every target is skipped. Generated:\n${result.generatedSourceText()}") {
+                    result.generatedSources().shouldBeEmpty()
+                }
+            }
+        }
+
+        test("copyToChildren that generates functions still writes its file") {
+            // Regression: a unit that produces at least one function keeps emitting its file.
+            val source =
+                """
+                package empty.generates
+
+                import me.tbsten.cream.CopyToChildren
+
+                @CopyToChildren(notCopyToObject = true)
+                sealed interface State {
+                    data class Loaded(val value: String) : State
+                    data object Loading : State
+                }
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            assertSoftly {
+                withClue(result.messages) {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+                }
+                withClue("A unit with a real declaration should still produce one file. Generated:\n${result.generatedSourceText()}") {
+                    result.generatedSources().size shouldBe 1
+                }
+            }
+        }
+    })

--- a/cream-ksp/src/test/resources/snapshots/ObjectTargetSnapshotTest/combineToObject.notCopyToObject.md
+++ b/cream-ksp/src/test/resources/snapshots/ObjectTargetSnapshotTest/combineToObject.notCopyToObject.md
@@ -1,10 +1,7 @@
 ## Generated
 
 ```kt
-// file: CombineTo__Source__Singleton.kt
-package snap.objtarget
 
-import me.tbsten.cream.*
 ```
 
 ## Input


### PR DESCRIPTION
## Why

PR #112 のフォローアップ。生成ユニットがコピー関数を **1 つも生成しない**（全 target が skip された）場合でも、cream は `package …` + `import me.tbsten.cream.*` だけの空の `.kt` ファイルを生成していた。`createNewKotlinFile` がファイルを先に開き、`block` がインポート + 関数本体を書く構造のため、`block` が 0 件ループでもボイラープレートだけのファイルが残っていた。

該当する空本体パス: `notCopyToObject` による object skip（`@CombineTo` / `@CombineFrom` の単一 object target、`@CopyToChildren(notCopyToObject = true)` の全 object 子クラス）と `generateTargetToSealedSubclasses=false` の no-op。

`Closes #113`

## What

`createNewKotlinFile`（`util/CodeGeneratorExt.kt`）を **writer 側で transactional 化**（SSoT — 各呼び出し側にガードを足さない）:

- `block` の出力をまず in-memory バッファ（`StringWriter`）に書き出す。
- バッファが空（宣言ゼロ）なら **ファイルを開かない** → 空ファイルは生成されない。
- 非空なら実ファイルを開き、`package` + `import me.tbsten.cream.*` + バッファ内容を flush。
- `import me.tbsten.cream.*` のボイラープレートを writer に集約。8 つの processor 呼び出し側（CopyTo / CopyFrom / CopyToChildren / SealedCopy / CombineTo / CombineFrom / CopyMapping / CombineMapping）から重複していた import 行を削除（SSoT win）。

有効な sibling 関数を持つユニットは従来どおりファイルを生成する（部分拒否ケースも valid sibling を捨てない）。非空ファイルのバイト出力は変更なし。

## Test

- 新規 `EmptyFileGenerationTest`:
  - 全 object 子クラスの sealed interface + `@CopyToChildren(notCopyToObject = true)` → 生成ファイル 0 件（空ファイルでないことを `generatedSources().shouldBeEmpty()` で検証）。
  - data class 子クラスを持つ sealed interface → 従来どおり 1 ファイル生成（回帰）。
- `ObjectTargetSnapshotTest` の `combineToObject.notCopyToObject` golden を再生成。差分は **空ファイルの削除のみ**（下記）。
- `:cream-ksp:test` / `:test:jvmTest` / `:cream-ksp:ktlintCheck` すべて green。

<details>
<summary>golden 差分（空ファイルの削除のみ）</summary>

```diff
 ## Generated

 ```kt
-// file: CombineTo__Source__Singleton.kt
-package snap.objtarget

-import me.tbsten.cream.*
 ```
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
