### PR TITLE
fix(ksp): handle duplicate @CombineTo/@CombineFrom target (reject vs dedupe)

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineFromProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineFromProcessor.kt
@@ -51,6 +51,11 @@ internal fun CreamSymbolProcessor.processCombineFrom(resolver: Resolver): List<K
 
         val combineFromAnnotations = target.annotationsOf(CombineFrom::class)
 
+        // @CombineFrom is @Repeatable; the sources of every occurrence are flattened into one
+        // merged copy function. Stacking it twice with the same source set (or simply repeating a
+        // class across occurrences) is an idempotent re-declaration, so dedupe the collected
+        // sources: keeping a duplicate would emit a function with two identically named parameters
+        // ("Conflicting declarations") and re-list the same source in KDoc (issue #101).
         val sourceClasses =
             combineFromAnnotations
                 .classListArgument("sources")
@@ -60,7 +65,8 @@ internal fun CreamSymbolProcessor.processCombineFrom(resolver: Resolver): List<K
                         annotationName = CombineFrom::class.simpleName!!,
                         context = "Specified in @${CombineFrom::class.simpleName}.sources of ${target.fullName}",
                     )
-                }.toList()
+                }.distinct()
+                .toList()
 
         // Need at least one source class
         if (sourceClasses.isEmpty()) {

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
@@ -171,6 +171,7 @@ internal fun CreamSymbolProcessor.processCombineMapping(resolver: Resolver): Lis
                                 ),
                             visibility = mapping.visibility,
                             funNameTemplate = mapping.funNameTemplate,
+                            logger = logger,
                         )
                     }
                 }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
@@ -92,7 +92,7 @@ internal fun CreamSymbolProcessor.processCombineMapping(resolver: Resolver): Lis
 
                     val sourceClasses =
                         sourcesTypes.mapNotNull { sourceType ->
-                            (sourceType as? KSType)?.declaration as? KSClassDeclaration
+                            (sourceType as? KSType)?.declaration?.resolveToClassDeclaration()
                         }
 
                     if (sourceClasses.size < 2) {
@@ -114,11 +114,10 @@ internal fun CreamSymbolProcessor.processCombineMapping(resolver: Resolver): Lis
                     }
 
                     val targetClass =
-                        targetType.declaration as? KSClassDeclaration
-                            ?: throw InvalidCreamUsageException(
-                                message = "${targetType.declaration.fullName} (Specified in @${CombineMapping::class.simpleName}.target) must be a class.",
-                                solution = "Specify a class in @${CombineMapping::class.simpleName}.target",
-                            )
+                        targetType.declaration.requireClassDeclaration(
+                            annotationName = CombineMapping::class.simpleName!!,
+                            context = "Specified in @${CombineMapping::class.simpleName}.target",
+                        )
 
                     val (kdocDescription, kdocExamples) = annotation.extractKDoc()
 

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineToProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineToProcessor.kt
@@ -83,6 +83,31 @@ internal fun CreamSymbolProcessor.processCombineTo(resolver: Resolver): List<KSA
                     )
                 }.toList()
 
+        // @CombineTo is NOT @Repeatable: it lists its targets in a single `vararg targets`. Listing
+        // the same target twice (`@CombineTo(Foo::class, Foo::class)`) is an unambiguous user
+        // mistake — cream would write the same generated file twice and crash with a
+        // FileAlreadyExistsException (a KSP INTERNAL_ERROR). Reject it up front with a clean
+        // positioned diagnostic and skip generating for this source so no partial file is left
+        // behind (issue #101). The source declaration carries the file/line for IDE navigation.
+        val duplicateTargets =
+            targetClasses
+                .groupingBy { it }
+                .eachCount()
+                .filterValues { it > 1 }
+                .keys
+        if (duplicateTargets.isNotEmpty()) {
+            val duplicateNames = duplicateTargets.joinToString(", ") { it.fullName }
+            logger.error(
+                InvalidCreamUsageException(
+                    message =
+                        "Duplicate target $duplicateNames in @${CombineTo::class.simpleName} of ${sourceClass.fullName}.",
+                    solution = "Remove the duplicate target from @${CombineTo::class.simpleName} (list each target at most once).",
+                ).message.orEmpty(),
+                sourceDeclaration,
+            )
+            return@forEach
+        }
+
         val (kdocDescription, kdocExamples) =
             combineToAnnotations.firstOrNull()?.extractKDoc() ?: ("" to emptyList())
 

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
@@ -27,7 +27,6 @@ import me.tbsten.cream.ksp.util.fullName
 import me.tbsten.cream.ksp.util.funNameTemplate
 import me.tbsten.cream.ksp.util.isSealed
 import me.tbsten.cream.ksp.util.requireClassDeclaration
-import me.tbsten.cream.ksp.util.resolveToClassDeclaration
 import me.tbsten.cream.ksp.util.underPackageName
 
 /**
@@ -97,18 +96,16 @@ internal fun CreamSymbolProcessor.processCopyMapping(resolver: Resolver): List<K
                     val propertyMaps = annotation.extractPropertyMappings()
 
                     val sourceClass =
-                        sourceType.declaration as? KSClassDeclaration
-                            ?: throw InvalidCreamUsageException(
-                                message = "${sourceType.declaration.fullName} (Specified in @${CopyMapping::class.simpleName}.source) must be a class.",
-                                solution = "Specify a class in @${CopyMapping::class.simpleName}.source",
-                            )
+                        sourceType.declaration.requireClassDeclaration(
+                            annotationName = CopyMapping::class.simpleName!!,
+                            context = "Specified in @${CopyMapping::class.simpleName}.source",
+                        )
 
                     val targetClass =
-                        targetType.declaration as? KSClassDeclaration
-                            ?: throw InvalidCreamUsageException(
-                                message = "${targetType.declaration.fullName} (Specified in @${CopyMapping::class.simpleName}.target) must be a class.",
-                                solution = "Specify a class in @${CopyMapping::class.simpleName}.target",
-                            )
+                        targetType.declaration.requireClassDeclaration(
+                            annotationName = CopyMapping::class.simpleName!!,
+                            context = "Specified in @${CopyMapping::class.simpleName}.target",
+                        )
 
                     val (kdocDescription, kdocExamples) = annotation.extractKDoc()
 

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
@@ -161,6 +161,7 @@ internal fun CreamSymbolProcessor.processCopyMapping(resolver: Resolver): List<K
                                 ),
                             notCopyToObject = false,
                             funNameTemplate = mapping.funNameTemplate,
+                            logger = logger,
                         )
 
                         if (mapping.canReverse) {
@@ -182,6 +183,7 @@ internal fun CreamSymbolProcessor.processCopyMapping(resolver: Resolver): List<K
                                     ),
                                 notCopyToObject = false,
                                 funNameTemplate = mapping.funNameTemplate,
+                                logger = logger,
                             )
                         }
                     }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Transform.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Transform.kt
@@ -22,11 +22,12 @@ import java.io.BufferedWriter
  * file), with the offending [target] attached as the [com.google.devtools.ksp.symbol.KSNode]
  * so the diagnostic carries the file/line location and IDE navigation works.
  *
- * When no logger is provided (the `@CopyMapping` / `@CombineMapping` paths do not yet thread one
- * through) the rejection is *fail-closed* by throwing [InvalidCreamUsageException]: it surfaces
- * as an `INTERNAL_ERROR` rather than the cleaner `COMPILATION_ERROR`, but an invalid target is
- * never silently dropped. Threading a logger into the mapping processors so they too get a clean
- * diagnostic is a follow-up.
+ * Every caller of [appendCopyFunction] now threads the processor's logger through — including the
+ * `@CopyMapping` path, which previously omitted it — so a rejected target reliably yields the clean
+ * `COMPILATION_ERROR`. The `null` branch remains as a *fail-closed* fallback: if a future caller
+ * forgets the logger, the rejection still throws [InvalidCreamUsageException] (surfacing as an
+ * `INTERNAL_ERROR`) instead of being silently dropped, which would generate nothing and leave the
+ * user wondering why.
  */
 private fun KSPLogger?.reportRejection(
     rejection: CopyTargetRejection,

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CombineToDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CombineToDiagnosticTest.kt
@@ -1,0 +1,54 @@
+package me.tbsten.cream.ksp.diagnostic
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
+
+/**
+ * `@CombineTo` is NOT `@Repeatable`; it lists its targets in a single `vararg targets`. Listing
+ * the same target twice (`@CombineTo(Foo::class, Foo::class)`) is an unambiguous user mistake: cream
+ * would otherwise write the same generated file twice and crash with a `FileAlreadyExistsException`
+ * (a KSP `INTERNAL_ERROR`). It is rejected up front with a clean positioned `COMPILATION_ERROR`
+ * instead, and no partial file is emitted (issue #101).
+ */
+internal class CombineToDiagnosticTest :
+    FunSpec({
+        test("@CombineTo listing the same target twice fails compilation cleanly without crashing") {
+            val source =
+                """
+                package diag
+
+                import me.tbsten.cream.CombineTo
+
+                data class Foo(val id: String, val extra: Int)
+
+                @CombineTo(Foo::class, Foo::class)
+                data class Source(val id: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    // A clean COMPILATION_ERROR, not the INTERNAL_ERROR a FileAlreadyExistsException crash produces.
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                // The diagnostic names the duplicated target so the user can find the mistake.
+                result.messages shouldContain "Foo"
+                result.messages shouldContain "duplicate"
+                // No partial / empty generated file is left behind.
+                withClue("No file should be generated for a rejected @CombineTo.") {
+                    result.generatedSources() shouldBe emptyList()
+                }
+            }
+            assertMatchesSnapshot("CombineToDiagnosticTest.duplicateTarget.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyMappingTargetKindDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyMappingTargetKindDiagnosticTest.kt
@@ -4,22 +4,25 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
 
 /**
- * `@CopyMapping` / `@CombineMapping` do not thread a [com.google.devtools.ksp.processing.KSPLogger]
- * into the target dispatcher yet, so a non-constructable target cannot be reported as the clean
- * `COMPILATION_ERROR` that the `@CopyTo` path produces. It must still *fail closed*: the rejection
- * throws so the invalid target reliably aborts compilation instead of being silently dropped
- * (which would generate nothing and leave the user wondering why). Threading a logger through the
- * mapping processors for a clean diagnostic is a follow-up.
+ * `@CopyMapping` reuses the same target dispatcher ([me.tbsten.cream.ksp.transform.appendCopyFunction])
+ * as `@CopyTo` / `@CopyFrom`, so a non-constructable target (sealed / abstract / enum class, plain
+ * interface, …) must be rejected with the same clean, positioned `COMPILATION_ERROR` rather than an
+ * `INTERNAL_ERROR` crash. The processor threads its [com.google.devtools.ksp.processing.KSPLogger]
+ * into the dispatcher, so the #112 target-kind rejection (`reportRejection` → `logger.error`) fires
+ * for the mapping path too. The rejection also fails closed: nothing is generated for the invalid
+ * mapping.
  */
 internal class CopyMappingTargetKindDiagnosticTest :
     FunSpec({
-        test("fails compilation instead of silently skipping a sealed class target") {
+        test("rejects a sealed class target with a clean diagnostic and generates nothing") {
             val source =
                 """
                 package diag
@@ -37,10 +40,16 @@ internal class CopyMappingTargetKindDiagnosticTest :
 
             assertSoftly {
                 withClue("Output:\n${result.normalizedCompilerOutput()}") {
-                    result.exitCode shouldBe KotlinCompilation.ExitCode.INTERNAL_ERROR
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
                 }
-                // The rejection reason still reaches the user instead of being swallowed.
-                result.messages shouldContain "Unsupported target sealed class"
+                result.messages shouldContain "sealed class"
+                result.messages shouldContain "concrete subclasses"
+                // A rejected target must not leave a half-written generated file behind.
+                result.generatedSources().shouldBeEmpty()
+            }
+            assertMatchesSnapshot("CopyMappingTargetKindDiagnosticTest.sealedClass.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
             }
         }
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/CombineDuplicateSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/snapshot/CombineDuplicateSnapshotTest.kt
@@ -1,0 +1,111 @@
+package me.tbsten.cream.ksp.snapshot
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.generatedSourceText
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
+
+/**
+ * `@CombineFrom` IS `@Repeatable`. Stacking it twice with the same source set is an idempotent
+ * re-declaration, not an error: cream dedupes the collected sources so exactly one copy function is
+ * generated (issue #101). A regular non-duplicate stack keeps merging distinct sources as before.
+ */
+internal class CombineDuplicateSnapshotTest :
+    FunSpec({
+        test("repeated @CombineFrom with the same source is deduped to one generated function") {
+            val source =
+                """
+                package snap.combinefrom.dup
+
+                import me.tbsten.cream.CombineFrom
+
+                data class A(val a: String)
+
+                @CombineFrom(A::class)
+                @CombineFrom(A::class)
+                data class Target(val a: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            assertSoftly {
+                withClue("Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+                }
+                // The idempotent re-declaration collapses to a single generated file.
+                withClue("Generated files: ${result.generatedSources().map { it.name }}") {
+                    result.generatedSources().size shouldBe 1
+                }
+            }
+            assertMatchesSnapshot("CombineDuplicateSnapshotTest.combineFromDuplicate") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
+        }
+
+        test("repeated @CombineFrom with distinct sources still merges into one function") {
+            val source =
+                """
+                package snap.combinefrom.distinct
+
+                import me.tbsten.cream.CombineFrom
+
+                data class Alpha(val id: String)
+                data class Beta(val count: Int)
+
+                @CombineFrom(Alpha::class)
+                @CombineFrom(Beta::class)
+                data class Target(val id: String, val count: Int)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            assertSoftly {
+                withClue("Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+                }
+                withClue("Generated files: ${result.generatedSources().map { it.name }}") {
+                    result.generatedSources().size shouldBe 1
+                }
+            }
+            assertMatchesSnapshot("CombineDuplicateSnapshotTest.combineFromDistinct") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
+        }
+
+        test("@CombineTo with distinct targets still generates one function per target") {
+            val source =
+                """
+                package snap.combineto.distinct
+
+                import me.tbsten.cream.CombineTo
+                import me.tbsten.cream.CopyTargetSimpleName
+
+                data class Foo(val id: String)
+
+                data class Bar(val id: String)
+
+                @CombineTo(Foo::class, Bar::class, funName = "to" + CopyTargetSimpleName)
+                data class Source(val id: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            assertSoftly {
+                withClue("Compilation should succeed. Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+                }
+                // One file per distinct (source, target) pair.
+                withClue("Generated files: ${result.generatedSources().map { it.name }}") {
+                    result.generatedSources().size shouldBe 2
+                }
+            }
+            assertMatchesSnapshot("CombineDuplicateSnapshotTest.combineToDistinct") {
+                "Generated" facetOf result.generatedSourceText()
+                "Input" facetOf source
+            }
+        }
+    })

--- a/cream-ksp/src/test/resources/snapshots/CombineDuplicateSnapshotTest/combineFromDistinct.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineDuplicateSnapshotTest/combineFromDistinct.md
@@ -1,0 +1,58 @@
+## Generated
+
+````kt
+// file: CombineFrom__Alpha__Target.kt
+package snap.combinefrom.distinct
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CombineFrom] annotation of [Target])
+ * 
+ * [Alpha] + [Beta] -> [Target] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val alpha = Alpha(...)
+ * val beta = Beta(...)
+ * val target = alpha.copyToTarget(beta = Beta(...))
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val alpha = Alpha(...)
+ * val beta = Beta(...)
+ * val target = alpha.copyToTarget(beta = Beta(...), property = value)
+ * ```
+ * 
+ * 
+ * @see Alpha
+ * @see Beta
+ * @see Target
+ */
+public fun  snap.combinefrom.distinct.Alpha.copyToTarget(
+    beta: snap.combinefrom.distinct.Beta,
+    id: String = this.id,
+    count: Int = beta.count,
+) : snap.combinefrom.distinct.Target = snap.combinefrom.distinct.Target(
+    id = id,
+    count = count,
+)
+````
+
+## Input
+
+```kt
+package snap.combinefrom.distinct
+
+import me.tbsten.cream.CombineFrom
+
+data class Alpha(val id: String)
+data class Beta(val count: Int)
+
+@CombineFrom(Alpha::class)
+@CombineFrom(Beta::class)
+data class Target(val id: String, val count: Int)
+```

--- a/cream-ksp/src/test/resources/snapshots/CombineDuplicateSnapshotTest/combineFromDuplicate.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineDuplicateSnapshotTest/combineFromDuplicate.md
@@ -1,0 +1,51 @@
+## Generated
+
+````kt
+// file: CombineFrom__A__Target.kt
+package snap.combinefrom.dup
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CombineFrom] annotation of [Target])
+ * 
+ * [A] -> [Target] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val a = A(...)
+ * val target = a.copyToTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val a = A(...)
+ * val target = a.copyToTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see A
+ * @see Target
+ */
+public fun  snap.combinefrom.dup.A.copyToTarget(
+    a: String = this.a,
+) : snap.combinefrom.dup.Target = snap.combinefrom.dup.Target(
+    a = a,
+)
+````
+
+## Input
+
+```kt
+package snap.combinefrom.dup
+
+import me.tbsten.cream.CombineFrom
+
+data class A(val a: String)
+
+@CombineFrom(A::class)
+@CombineFrom(A::class)
+data class Target(val a: String)
+```

--- a/cream-ksp/src/test/resources/snapshots/CombineDuplicateSnapshotTest/combineToDistinct.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineDuplicateSnapshotTest/combineToDistinct.md
@@ -1,0 +1,89 @@
+## Generated
+
+````kt
+// file: CombineTo__Source__Bar.kt
+package snap.combineto.distinct
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CombineTo] annotation of [Source])
+ * 
+ * [Source] -> [Bar] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toBar()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toBar(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Bar
+ */
+public fun  snap.combineto.distinct.Source.toBar(
+    id: String = this.id,
+) : snap.combineto.distinct.Bar = snap.combineto.distinct.Bar(
+    id = id,
+)
+
+// ----- next file -----
+
+// file: CombineTo__Source__Foo.kt
+package snap.combineto.distinct
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CombineTo] annotation of [Source])
+ * 
+ * [Source] -> [Foo] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toFoo()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toFoo(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Foo
+ */
+public fun  snap.combineto.distinct.Source.toFoo(
+    id: String = this.id,
+) : snap.combineto.distinct.Foo = snap.combineto.distinct.Foo(
+    id = id,
+)
+````
+
+## Input
+
+```kt
+package snap.combineto.distinct
+
+import me.tbsten.cream.CombineTo
+import me.tbsten.cream.CopyTargetSimpleName
+
+data class Foo(val id: String)
+
+data class Bar(val id: String)
+
+@CombineTo(Foo::class, Bar::class, funName = "to" + CopyTargetSimpleName)
+data class Source(val id: String)
+```

--- a/cream-ksp/src/test/resources/snapshots/CombineToDiagnosticTest/duplicateTarget.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToDiagnosticTest/duplicateTarget.output.md
@@ -1,0 +1,22 @@
+## Compiler output
+
+```text
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:8: Invalid cream usage: Duplicate target diag.Foo in @CombineTo of diag.Source.
+
+Solution: 
+  Remove the duplicate target from @CombineTo (list each target at most once).
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CombineTo
+
+data class Foo(val id: String, val extra: Int)
+
+@CombineTo(Foo::class, Foo::class)
+data class Source(val id: String)
+```

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingTargetKindDiagnosticTest/sealedClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingTargetKindDiagnosticTest/sealedClass.output.md
@@ -1,0 +1,24 @@
+## Compiler output
+
+```text
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:7: Invalid cream usage: Unsupported target sealed class (diag.State). A sealed class cannot be instantiated directly.
+
+Solution: 
+  Specify one of its concrete subclasses as the target.
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CopyMapping
+
+data class Source(val id: String)
+
+sealed class State(val id: String)
+
+@CopyMapping(Source::class, State::class)
+object Mapping
+```

--- a/test/src/commonMain/kotlin/me/tbsten/cream/test/combineMapping/TypeAlias.kt
+++ b/test/src/commonMain/kotlin/me/tbsten/cream/test/combineMapping/TypeAlias.kt
@@ -1,0 +1,49 @@
+package me.tbsten.cream.test.combineMapping
+
+import me.tbsten.cream.CombineMapping
+
+/**
+ * Library model used (via a typealias) as a @CombineMapping source.
+ */
+data class LibAliasFirstModel(
+    val firstName: String,
+    val firstValue: Int,
+)
+
+/**
+ * Library model used (via a typealias) as a @CombineMapping source.
+ */
+data class LibAliasSecondModel(
+    val secondName: String,
+    val secondValue: Double,
+)
+
+/**
+ * Target model that combines both aliased sources, referenced via a typealias.
+ */
+data class LibAliasCombinedModel(
+    val firstName: String,
+    val firstValue: Int,
+    val secondName: String,
+    val secondValue: Double,
+    val extraProperty: String,
+)
+
+typealias LibAliasFirstSource = LibAliasFirstModel
+
+typealias LibAliasSecondSource = LibAliasSecondModel
+
+typealias LibAliasCombinedTarget = LibAliasCombinedModel
+
+/**
+ * Mapping object whose @CombineMapping sources and target are all type aliases.
+ *
+ * Generates: fun LibAliasFirstModel.copyToLibAliasCombinedModel(
+ *     libAliasSecondModel: LibAliasSecondModel, extraProperty: String,
+ * ): LibAliasCombinedModel
+ */
+@CombineMapping(
+    sources = [LibAliasFirstSource::class, LibAliasSecondSource::class],
+    target = LibAliasCombinedTarget::class,
+)
+private object AliasCombineMapping

--- a/test/src/commonMain/kotlin/me/tbsten/cream/test/copyMapping/TypeAlias.kt
+++ b/test/src/commonMain/kotlin/me/tbsten/cream/test/copyMapping/TypeAlias.kt
@@ -1,0 +1,38 @@
+package me.tbsten.cream.test.copyMapping
+
+import me.tbsten.cream.CopyMapping
+
+/**
+ * Library model used as the source of a typealias-based @CopyMapping.
+ *
+ * @property shareProp Shared property between the aliased source and target
+ * @property aProp Property specific to LibAliasAModel
+ */
+data class LibAliasAModel(
+    val shareProp: String,
+    val aProp: Int,
+)
+
+/**
+ * Library model used as the target of a typealias-based @CopyMapping.
+ *
+ * @property shareProp Shared property between the aliased source and target
+ * @property bProp Property specific to LibAliasBModel
+ */
+data class LibAliasBModel(
+    val shareProp: String,
+    val bProp: Int,
+)
+
+typealias LibAliasASource = LibAliasAModel
+
+typealias LibAliasBTarget = LibAliasBModel
+
+/**
+ * Mapping object whose @CopyMapping source and target are both type aliases.
+ *
+ * The generated function name is based on the resolved class (LibAliasBModel),
+ * not the alias (LibAliasBTarget): LibAliasAModel.copyToLibAliasBModel(...).
+ */
+@CopyMapping(LibAliasASource::class, LibAliasBTarget::class)
+private object AliasMapping

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/TypeAliasTest.kt
@@ -1,0 +1,55 @@
+package me.tbsten.cream.test.combineMapping
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class TypeAliasTest :
+    FunSpec({
+        test("combineMappingResolvesTypeAliasSourcesAndTarget") {
+            // sources and target are declared via type aliases, but the generated function
+            // is named after / typed by the resolved classes.
+            val first: LibAliasFirstSource = LibAliasFirstModel(firstName = "First", firstValue = 10)
+            val second: LibAliasSecondSource = LibAliasSecondModel(secondName = "Second", secondValue = 2.5)
+
+            val result: LibAliasCombinedTarget =
+                first.copyToLibAliasCombinedModel(
+                    libAliasSecondModel = second,
+                    extraProperty = "Extra",
+                )
+
+            assertSoftly {
+                result.firstName shouldBe "First"
+                result.firstValue shouldBe 10
+                result.secondName shouldBe "Second"
+                result.secondValue shouldBe 2.5
+                result.extraProperty shouldBe "Extra"
+                result.shouldBeInstanceOf<LibAliasCombinedModel>()
+            }
+        }
+
+        test("combineMappingTypeAliasAllowsOverride") {
+            val first: LibAliasFirstSource = LibAliasFirstModel(firstName = "First", firstValue = 10)
+            val second: LibAliasSecondSource = LibAliasSecondModel(secondName = "Second", secondValue = 2.5)
+
+            val result =
+                first.copyToLibAliasCombinedModel(
+                    libAliasSecondModel = second,
+                    firstName = "OverriddenFirst",
+                    secondValue = 9.99,
+                    extraProperty = "Extra",
+                )
+
+            val expected =
+                LibAliasCombinedModel(
+                    firstName = "OverriddenFirst",
+                    firstValue = 10,
+                    secondName = "Second",
+                    secondValue = 9.99,
+                    extraProperty = "Extra",
+                )
+
+            result shouldBe expected
+        }
+    })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/TypeAliasTest.kt
@@ -1,0 +1,33 @@
+package me.tbsten.cream.test.copyMapping
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class TypeAliasTest :
+    FunSpec({
+        test("copyMappingResolvesTypeAliasSourceAndTarget") {
+            // Source/target are declared via type aliases (LibAliasASource / LibAliasBTarget),
+            // but the generated function is named after the resolved class (LibAliasBModel).
+            val source: LibAliasASource = LibAliasAModel(shareProp = "shared", aProp = 7)
+
+            val result: LibAliasBTarget = source.copyToLibAliasBModel(bProp = 100)
+
+            assertSoftly {
+                result.shareProp shouldBe "shared"
+                result.bProp shouldBe 100
+                result.shouldBeInstanceOf<LibAliasBModel>()
+            }
+        }
+
+        test("copyMappingTypeAliasAllowsOverride") {
+            val source: LibAliasASource = LibAliasAModel(shareProp = "shared", aProp = 7)
+
+            val result = source.copyToLibAliasBModel(shareProp = "overridden", bProp = 100)
+
+            val expected = LibAliasBModel(shareProp = "overridden", bProp = 100)
+
+            result shouldBe expected
+        }
+    })


### PR DESCRIPTION
## Why

A duplicated target in `@CombineTo` / `@CombineFrom` made cream write the same generated file (or merge the same source) twice, crashing with a `FileAlreadyExistsException` / conflicting-declaration error that surfaced as a **KSP INTERNAL_ERROR** (issue #101). The correct handling differs per annotation because their repeatability semantics differ.

## What

Fix is **per-annotation**:

- **`@CombineTo` → reject.** `@CombineTo` is NOT `@Repeatable`; it lists targets in a single `vararg targets`. A literal duplicate like `@CombineTo(Foo::class, Foo::class)` is an unambiguous user mistake. Detect a duplicate target within a single annotation before generation and reject it with a clean positioned `logger.error(msg, sourceDeclaration)` (a normal `COMPILATION_ERROR` that names the duplicated target), then skip generating for that source so **no partial file** is left behind. No crash.

- **`@CombineFrom` → dedupe silently.** `@CombineFrom` IS `@Repeatable` and the sources of every occurrence are flattened into one merged function. Stacking it twice with the same source set is an idempotent re-declaration. Dedupe the collected sources with `.distinct()` so it collapses to a single correct function — no error, no crash. Distinct sources across occurrences still merge as before.

Builds on PR #122's transactional `createNewKotlinFile` (which already owns the `package` + `import me.tbsten.cream.*` boilerplate).

## Test

kctfork e2e under `cream-ksp/src/test/`:

- `CombineToDiagnosticTest`: `@CombineTo(Foo::class, Foo::class)` → asserts exit code is specifically `COMPILATION_ERROR` (not `INTERNAL_ERROR` / a crash), the message names the duplicate target, and **no file is generated**; compiler output snapshotted.
- `CombineDuplicateSnapshotTest`: stacked `@CombineFrom` with the same source → compiles OK and generates exactly **one** file; stacked `@CombineFrom` with distinct sources still merges into one function; `@CombineTo` with distinct targets still generates one function per target (regressions).

Local gradle (JDK 21) all green: `:cream-ksp:test`, `:test:jvmTest`, `:cream-ksp:ktlintCheck`. The matrix CI likely won't run here since the base branch predates the CI fix; relied on local verification. New snapshot goldens added for the diagnostic output and the deduped/merged generated sources (reviewed, intentional).

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)