### PR TITLE
fix(ksp): clean COMPILATION_ERROR for @CopyMapping invalid target (thread logger)

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
@@ -171,6 +171,7 @@ internal fun CreamSymbolProcessor.processCombineMapping(resolver: Resolver): Lis
                                 ),
                             visibility = mapping.visibility,
                             funNameTemplate = mapping.funNameTemplate,
+                            logger = logger,
                         )
                     }
                 }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
@@ -161,6 +161,7 @@ internal fun CreamSymbolProcessor.processCopyMapping(resolver: Resolver): List<K
                                 ),
                             notCopyToObject = false,
                             funNameTemplate = mapping.funNameTemplate,
+                            logger = logger,
                         )
 
                         if (mapping.canReverse) {
@@ -182,6 +183,7 @@ internal fun CreamSymbolProcessor.processCopyMapping(resolver: Resolver): List<K
                                     ),
                                 notCopyToObject = false,
                                 funNameTemplate = mapping.funNameTemplate,
+                                logger = logger,
                             )
                         }
                     }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Transform.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Transform.kt
@@ -22,11 +22,12 @@ import java.io.BufferedWriter
  * file), with the offending [target] attached as the [com.google.devtools.ksp.symbol.KSNode]
  * so the diagnostic carries the file/line location and IDE navigation works.
  *
- * When no logger is provided (the `@CopyMapping` / `@CombineMapping` paths do not yet thread one
- * through) the rejection is *fail-closed* by throwing [InvalidCreamUsageException]: it surfaces
- * as an `INTERNAL_ERROR` rather than the cleaner `COMPILATION_ERROR`, but an invalid target is
- * never silently dropped. Threading a logger into the mapping processors so they too get a clean
- * diagnostic is a follow-up.
+ * Every caller of [appendCopyFunction] now threads the processor's logger through — including the
+ * `@CopyMapping` path, which previously omitted it — so a rejected target reliably yields the clean
+ * `COMPILATION_ERROR`. The `null` branch remains as a *fail-closed* fallback: if a future caller
+ * forgets the logger, the rejection still throws [InvalidCreamUsageException] (surfacing as an
+ * `INTERNAL_ERROR`) instead of being silently dropped, which would generate nothing and leave the
+ * user wondering why.
  */
 private fun KSPLogger?.reportRejection(
     rejection: CopyTargetRejection,

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyMappingTargetKindDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyMappingTargetKindDiagnosticTest.kt
@@ -4,22 +4,25 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
 
 /**
- * `@CopyMapping` / `@CombineMapping` do not thread a [com.google.devtools.ksp.processing.KSPLogger]
- * into the target dispatcher yet, so a non-constructable target cannot be reported as the clean
- * `COMPILATION_ERROR` that the `@CopyTo` path produces. It must still *fail closed*: the rejection
- * throws so the invalid target reliably aborts compilation instead of being silently dropped
- * (which would generate nothing and leave the user wondering why). Threading a logger through the
- * mapping processors for a clean diagnostic is a follow-up.
+ * `@CopyMapping` reuses the same target dispatcher ([me.tbsten.cream.ksp.transform.appendCopyFunction])
+ * as `@CopyTo` / `@CopyFrom`, so a non-constructable target (sealed / abstract / enum class, plain
+ * interface, …) must be rejected with the same clean, positioned `COMPILATION_ERROR` rather than an
+ * `INTERNAL_ERROR` crash. The processor threads its [com.google.devtools.ksp.processing.KSPLogger]
+ * into the dispatcher, so the #112 target-kind rejection (`reportRejection` → `logger.error`) fires
+ * for the mapping path too. The rejection also fails closed: nothing is generated for the invalid
+ * mapping.
  */
 internal class CopyMappingTargetKindDiagnosticTest :
     FunSpec({
-        test("fails compilation instead of silently skipping a sealed class target") {
+        test("rejects a sealed class target with a clean diagnostic and generates nothing") {
             val source =
                 """
                 package diag
@@ -37,10 +40,16 @@ internal class CopyMappingTargetKindDiagnosticTest :
 
             assertSoftly {
                 withClue("Output:\n${result.normalizedCompilerOutput()}") {
-                    result.exitCode shouldBe KotlinCompilation.ExitCode.INTERNAL_ERROR
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
                 }
-                // The rejection reason still reaches the user instead of being swallowed.
-                result.messages shouldContain "Unsupported target sealed class"
+                result.messages shouldContain "sealed class"
+                result.messages shouldContain "concrete subclasses"
+                // A rejected target must not leave a half-written generated file behind.
+                result.generatedSources().shouldBeEmpty()
+            }
+            assertMatchesSnapshot("CopyMappingTargetKindDiagnosticTest.sealedClass.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
             }
         }
     })

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingTargetKindDiagnosticTest/sealedClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingTargetKindDiagnosticTest/sealedClass.output.md
@@ -1,0 +1,24 @@
+## Compiler output
+
+```text
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:7: Invalid cream usage: Unsupported target sealed class (diag.State). A sealed class cannot be instantiated directly.
+
+Solution: 
+  Specify one of its concrete subclasses as the target.
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CopyMapping
+
+data class Source(val id: String)
+
+sealed class State(val id: String)
+
+@CopyMapping(Source::class, State::class)
+object Mapping
+```


### PR DESCRIPTION
## Why

PR #112 made the copy-target dispatcher **fail-closed**: `appendCopyFunction`'s `reportRejection` throws `InvalidCreamUsageException` (surfacing as a KSP `INTERNAL_ERROR`) when no `KSPLogger` is available, so an invalid target is never silently dropped. But the `@CopyMapping` processor called `appendCopyFunction` **without** a logger, so a #112-rejected target kind (sealed / abstract / enum class, plain interface, …) crashed with `INTERNAL_ERROR` instead of the clean, positioned `COMPILATION_ERROR` that `@CopyTo` / `@CopyFrom` produce.

PR #112's own description named this as the follow-up:

> `@CopyMapping` does not thread a logger through yet, so its rejection fails closed by throwing rather than being silently dropped. A clean diagnostic there is a follow-up.

This PR completes that follow-up. `Closes #115`.

## What

- **`CopyMappingProcessor.kt`** — thread `logger = logger` into both `appendCopyFunction` calls (forward + `canReverse` reverse). This is the core fix: the #112 rejection (`reportRejection` → `logger.error` with the offending target attached) now fires for the mapping path, giving the same clean `COMPILATION_ERROR`, the same file/line position, and no half-written generated file.
- **`CombineMappingProcessor.kt`** — thread `logger = logger` into the `appendCombineToFunction` call, for parity with `CombineToProcessor` / `CombineFromProcessor` (which already pass it). This enables the `@CombineTo.Exclude` no-op warnings on the mapping path.
- **`Transform.kt`** — update the `reportRejection` KDoc that previously said the mapping paths "do not yet thread one through … follow-up". Callers now thread the logger; the `null` branch stays as a fail-closed fallback for any future caller that forgets it. The fail-closed mechanism itself is unchanged.
- **`CopyMappingTargetKindDiagnosticTest.kt`** — flipped from asserting `INTERNAL_ERROR` to the clean `COMPILATION_ERROR` now produced. Asserts the specific exit code, the #112-style sealed-class message, and that **no partial file is generated**; pins the positioned compiler output as a snapshot golden (mirrors `CopyTargetKindDiagnosticTest`).

<details>
<summary><b>Scope note: <code>@CombineMapping</code> target-kind clean diagnostic</b></summary>

The combine dispatcher (`appendCombineToFunction`) does **not** use the #112 `reportRejection` mechanism — for a non-`CLASS`/`OBJECT`/`ANNOTATION_CLASS` kind it has its own `else -> throw InvalidCreamUsageException`, and for a `sealed class` (which is `ClassKind.CLASS`) it currently generates `Target(...)` that fails downstream with a "constructor is protected" compiler error, because the combine path has no `concreteClassRejection()` check.

Making `@CombineMapping` produce the *same* clean target-kind diagnostic as `@CopyTo` would require adding concrete-class validation to the shared combine dispatcher, which also changes `@CombineTo` / `@CombineFrom` behavior — exactly the cross-cutting combine-target-rejection work PR #112 deliberately split into a separate PR. So threading the logger here is for parity (warnings); the combine target-kind clean diagnostic remains a separate follow-up and is out of scope for #115 (which is specifically the `@CopyMapping` fail-closed throw).

</details>

## Test

- `:cream-ksp:test` — green (195 tests, 0 failures), including the flipped `CopyMappingTargetKindDiagnosticTest` and the new `sealedClass.output.md` golden (now a clean `[ksp]` positioned `COMPILATION_ERROR`, no partial file).
- `:cream-ksp:ktlintCheck` — green.
- `:test:jvmTest` — green.
- Regression: `CopyMappingSnapshotTest` / `CombineMappingSnapshotTest` (valid mappings) still generate correctly; `CopyTargetKindDiagnosticTest` unaffected.

> Note: the matrix CI won't run on this PR (its base predates the CI fix); verified locally with Gradle on JDK 21. GitHub will retarget the base as the parent PRs merge.

Stacked on top of `fix/issue-98-mapping-typealias` (#122 → #123 → #121 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
