### PR TITLE
fix(ksp): emit clean COMPILATION_ERROR for all user-misuse diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .gradle
+.gradle-agent-*/
 .idea
 .DS_Store
 build

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/CreamSymbolProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/CreamSymbolProcessor.kt
@@ -5,6 +5,7 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
+import me.tbsten.cream.ksp.options.CreamOptions
 import me.tbsten.cream.ksp.options.toCreamOptions
 import me.tbsten.cream.ksp.process.processCombineFrom
 import me.tbsten.cream.ksp.process.processCombineMapping
@@ -16,13 +17,28 @@ import me.tbsten.cream.ksp.process.processCopyToChildren
 import me.tbsten.cream.ksp.process.processSealedCopy
 
 class CreamSymbolProcessor(
-    options: Map<String, String>,
+    private val rawOptions: Map<String, String>,
     internal val codeGenerator: CodeGenerator,
     internal val logger: KSPLogger,
 ) : SymbolProcessor {
-    internal val options = options.toCreamOptions()
+    // Parsed lazily so an invalid KSP option value surfaces as a clean COMPILATION_ERROR from
+    // process() (where the logger is used), rather than as a constructor crash that KSP reports as
+    // an INTERNAL_ERROR. Backing field is set once on first successful parse.
+    private var parsedOptions: CreamOptions? = null
+    internal val options: CreamOptions
+        get() = parsedOptions ?: rawOptions.toCreamOptions().also { parsedOptions = it }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
+        // Validate options up front. An invalid value is a build-script mistake with no source
+        // location, so it is reported via logger.error(message) without a KSNode, and processing is
+        // skipped entirely for this round (no partial files).
+        try {
+            options
+        } catch (e: InvalidCreamOptionException) {
+            logger.error(e.message.orEmpty())
+            return emptyList()
+        }
+
         val invalidTargets = mutableListOf<KSAnnotated>()
 
         processCopyFrom(resolver)

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/CreamSymbolProcessorProvider.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/CreamSymbolProcessorProvider.kt
@@ -7,7 +7,7 @@ import com.google.devtools.ksp.processing.SymbolProcessorProvider
 class CreamSymbolProcessorProvider : SymbolProcessorProvider {
     override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
         CreamSymbolProcessor(
-            options = environment.options,
+            rawOptions = environment.options,
             codeGenerator = environment.codeGenerator,
             logger = environment.logger,
         )

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineFromProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineFromProcessor.kt
@@ -29,8 +29,7 @@ import me.tbsten.cream.ksp.util.fullName
 import me.tbsten.cream.ksp.util.funNameTemplate
 import me.tbsten.cream.ksp.util.isSealed
 import me.tbsten.cream.ksp.util.lines
-import me.tbsten.cream.ksp.util.requireClassDeclaration
-import me.tbsten.cream.ksp.util.resolveToClassDeclaration
+import me.tbsten.cream.ksp.util.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.util.underPackageName
 
 internal fun CreamSymbolProcessor.processCombineFrom(resolver: Resolver): List<KSAnnotated> {
@@ -43,11 +42,21 @@ internal fun CreamSymbolProcessor.processCombineFrom(resolver: Resolver): List<K
     combineFromTargets.forEach { target ->
         val targetDeclaration =
             target as? KSDeclaration
-                ?: throw InvalidCreamUsageException(
-                    message = "@${CombineFrom::class.simpleName} must be applied to a class, interface, or typealias.",
-                    solution = "Please apply @${CombineFrom::class.simpleName} to `class`, `interface`, or `typealias`",
-                )
-        val targetClass = targetDeclaration.requireClassDeclaration(annotationName = CombineFrom::class.simpleName!!)
+                ?: run {
+                    logger.reportCreamError(
+                        InvalidCreamUsageException(
+                            message = "@${CombineFrom::class.simpleName} must be applied to a class, interface, or typealias.",
+                            solution = "Please apply @${CombineFrom::class.simpleName} to `class`, `interface`, or `typealias`",
+                        ),
+                        target,
+                    )
+                    return@forEach
+                }
+        val targetClass =
+            targetDeclaration.resolveClassDeclarationOrReport(
+                annotationName = CombineFrom::class.simpleName!!,
+                logger = logger,
+            ) ?: return@forEach
 
         val combineFromAnnotations = target.annotationsOf(CombineFrom::class)
 
@@ -56,24 +65,31 @@ internal fun CreamSymbolProcessor.processCombineFrom(resolver: Resolver): List<K
         // class across occurrences) is an idempotent re-declaration, so dedupe the collected
         // sources: keeping a duplicate would emit a function with two identically named parameters
         // ("Conflicting declarations") and re-list the same source in KDoc (issue #101).
-        val sourceClasses =
+        val resolvedSources =
             combineFromAnnotations
                 .classListArgument("sources")
                 .map { it.declaration }
                 .map { declaration ->
-                    declaration.requireClassDeclaration(
+                    declaration.resolveClassDeclarationOrReport(
                         annotationName = CombineFrom::class.simpleName!!,
+                        logger = logger,
                         context = "Specified in @${CombineFrom::class.simpleName}.sources of ${target.fullName}",
+                        ksNode = targetDeclaration,
                     )
-                }.distinct()
-                .toList()
+                }.toList()
+        if (resolvedSources.any { it == null }) return@forEach
+        val sourceClasses = resolvedSources.filterNotNull().distinct()
 
         // Need at least one source class
         if (sourceClasses.isEmpty()) {
-            throw InvalidCreamUsageException(
-                message = "@${CombineFrom::class.simpleName} requires at least one source class.",
-                solution = "Specify at least one source class in @${CombineFrom::class.simpleName}.sources of ${target.fullName}.",
+            logger.reportCreamError(
+                InvalidCreamUsageException(
+                    message = "@${CombineFrom::class.simpleName} requires at least one source class.",
+                    solution = "Specify at least one source class in @${CombineFrom::class.simpleName}.sources of ${target.fullName}.",
+                ),
+                targetDeclaration,
             )
+            return@forEach
         }
 
         // First source class is the primary source (extension function receiver)
@@ -105,18 +121,22 @@ internal fun CreamSymbolProcessor.processCombineFrom(resolver: Resolver): List<K
                 .map { resolveFunName(it, primarySource, targetClass, options) }
                 .distinct()
         if (explicitFunNames.size > 1) {
-            throw InvalidCreamUsageException(
-                message =
-                    lines(
-                        "@${CombineFrom::class.simpleName} on ${targetClass.fullName} is repeated with conflicting funName values:",
-                        explicitFunNames.joinToString(", ") { "\"$it\"" },
-                        "Stacked @${CombineFrom::class.simpleName} annotations are merged into a single generated function, so funName must be unambiguous.",
-                    ),
-                solution =
-                    lines(
-                        "Set the same funName on every @${CombineFrom::class.simpleName} of ${targetClass.fullName}, or set it on only one.",
-                    ),
+            logger.reportCreamError(
+                InvalidCreamUsageException(
+                    message =
+                        lines(
+                            "@${CombineFrom::class.simpleName} on ${targetClass.fullName} is repeated with conflicting funName values:",
+                            explicitFunNames.joinToString(", ") { "\"$it\"" },
+                            "Stacked @${CombineFrom::class.simpleName} annotations are merged into a single generated function, so funName must be unambiguous.",
+                        ),
+                    solution =
+                        lines(
+                            "Set the same funName on every @${CombineFrom::class.simpleName} of ${targetClass.fullName}, or set it on only one.",
+                        ),
+                ),
+                targetDeclaration,
             )
+            return@forEach
         }
         val funNameTemplate = explicitFunNameTemplates.firstOrNull() ?: DefaultCopyFunctionName
 

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineMappingProcessor.kt
@@ -2,6 +2,7 @@ package me.tbsten.cream.ksp.process
 
 import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
@@ -27,7 +28,7 @@ import me.tbsten.cream.ksp.util.extractPropertyMappings
 import me.tbsten.cream.ksp.util.fullName
 import me.tbsten.cream.ksp.util.funNameTemplate
 import me.tbsten.cream.ksp.util.isSealed
-import me.tbsten.cream.ksp.util.requireClassDeclaration
+import me.tbsten.cream.ksp.util.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.util.resolveToClassDeclaration
 import me.tbsten.cream.ksp.util.underPackageName
 
@@ -50,6 +51,104 @@ private data class CombineMappingInfo(
     val funNameTemplate: String,
 )
 
+/**
+ * Parse one `@CombineMapping` annotation into a [CombineMappingInfo]. On any user-misuse error
+ * (missing `sources` / `target`, fewer than 2 sources, a non-class source, or a `target` that
+ * cannot be resolved to a class), reports a clean positioned `COMPILATION_ERROR` via [logger]
+ * (anchored at [annotatedDeclaration]) and returns `null` so the caller can skip the whole
+ * declaration without crashing KSP.
+ */
+private fun parseCombineMapping(
+    annotation: KSAnnotation,
+    annotatedDeclaration: KSClassDeclaration,
+    logger: KSPLogger,
+): CombineMappingInfo? {
+    val sourcesTypes =
+        annotation.arguments
+            .firstOrNull { it.name?.asString() == "sources" }
+            ?.value as? List<*>
+            ?: run {
+                logger.reportCreamError(
+                    InvalidCreamUsageException(
+                        message = "sources parameter is required in @${CombineMapping::class.simpleName}",
+                        solution = "Specify at least 2 source classes in @${CombineMapping::class.simpleName}",
+                    ),
+                    annotatedDeclaration,
+                )
+                return null
+            }
+
+    val targetType =
+        annotation.arguments
+            .firstOrNull { it.name?.asString() == "target" }
+            ?.value as? KSType
+            ?: run {
+                logger.reportCreamError(
+                    InvalidCreamUsageException(
+                        message = "target parameter is required in @${CombineMapping::class.simpleName}",
+                        solution = "Specify target class in @${CombineMapping::class.simpleName}",
+                    ),
+                    annotatedDeclaration,
+                )
+                return null
+            }
+
+    val propertyMaps = annotation.extractPropertyMappings()
+
+    val sourceClasses =
+        sourcesTypes.mapNotNull { sourceType ->
+            (sourceType as? KSType)?.declaration?.resolveToClassDeclaration()
+        }
+
+    if (sourceClasses.size < 2) {
+        logger.reportCreamError(
+            InvalidCreamUsageException(
+                message = "@${CombineMapping::class.simpleName} requires at least 2 source classes, but got ${sourceClasses.size}.",
+                solution = "Specify at least 2 source classes in @${CombineMapping::class.simpleName}.sources",
+            ),
+            annotatedDeclaration,
+        )
+        return null
+    }
+
+    sourceClasses.forEach { sourceClass ->
+        if (sourceClass.classKind != ClassKind.CLASS &&
+            sourceClass.classKind != ClassKind.ANNOTATION_CLASS
+        ) {
+            logger.reportCreamError(
+                InvalidCreamUsageException(
+                    message = "${sourceClass.fullName} (Specified in @${CombineMapping::class.simpleName}.sources) must be a class.",
+                    solution = "Specify a class in @${CombineMapping::class.simpleName}.sources",
+                ),
+                annotatedDeclaration,
+            )
+            return null
+        }
+    }
+
+    val targetClass =
+        targetType.declaration.resolveClassDeclarationOrReport(
+            annotationName = CombineMapping::class.simpleName!!,
+            logger = logger,
+            context = "Specified in @${CombineMapping::class.simpleName}.target",
+            ksNode = annotatedDeclaration,
+        ) ?: return null
+
+    val (kdocDescription, kdocExamples) = annotation.extractKDoc()
+
+    val visibility = annotation.copyVisibilityArgument()
+
+    return CombineMappingInfo(
+        sourceClasses = sourceClasses,
+        targetClass = targetClass,
+        propertyMappings = propertyMaps,
+        kdocDescription = kdocDescription,
+        kdocExamples = kdocExamples,
+        visibility = visibility,
+        funNameTemplate = annotation.funNameTemplate(),
+    )
+}
+
 internal fun CreamSymbolProcessor.processCombineMapping(resolver: Resolver): List<KSAnnotated> {
     val (combineMappingTargets, invalidCombineMappingTargets) =
         resolver
@@ -60,79 +159,26 @@ internal fun CreamSymbolProcessor.processCombineMapping(resolver: Resolver): Lis
     combineMappingTargets.forEach { target ->
         val annotatedDeclaration =
             (target as? KSClassDeclaration)
-                ?: throw InvalidCreamUsageException(
-                    message = "@${CombineMapping::class.simpleName} must be applied to a class.",
-                    solution = "Please apply @${CombineMapping::class.simpleName} to a `class` or `object`",
-                )
+                ?: run {
+                    logger.reportCreamError(
+                        InvalidCreamUsageException(
+                            message = "@${CombineMapping::class.simpleName} must be applied to a class.",
+                            solution = "Please apply @${CombineMapping::class.simpleName} to a `class` or `object`",
+                        ),
+                        target,
+                    )
+                    return@forEach
+                }
 
-        // Extract all CombineMapping annotations from the target
-        val combineMappings =
+        // Extract all CombineMapping annotations from the target. A malformed annotation reports a
+        // clean diagnostic and yields null; skip the whole declaration so no partial file is emitted.
+        val parsedMappings =
             target
                 .annotationsOf(CombineMapping::class)
-                .map { annotation ->
-                    val sourcesTypes =
-                        annotation.arguments
-                            .firstOrNull { it.name?.asString() == "sources" }
-                            ?.value as? List<*>
-                            ?: throw InvalidCreamUsageException(
-                                message = "sources parameter is required in @${CombineMapping::class.simpleName}",
-                                solution = "Specify at least 2 source classes in @${CombineMapping::class.simpleName}",
-                            )
-
-                    val targetType =
-                        annotation.arguments
-                            .firstOrNull { it.name?.asString() == "target" }
-                            ?.value as? KSType
-                            ?: throw InvalidCreamUsageException(
-                                message = "target parameter is required in @${CombineMapping::class.simpleName}",
-                                solution = "Specify target class in @${CombineMapping::class.simpleName}",
-                            )
-
-                    val propertyMaps = annotation.extractPropertyMappings()
-
-                    val sourceClasses =
-                        sourcesTypes.mapNotNull { sourceType ->
-                            (sourceType as? KSType)?.declaration?.resolveToClassDeclaration()
-                        }
-
-                    if (sourceClasses.size < 2) {
-                        throw InvalidCreamUsageException(
-                            message = "@${CombineMapping::class.simpleName} requires at least 2 source classes, but got ${sourceClasses.size}.",
-                            solution = "Specify at least 2 source classes in @${CombineMapping::class.simpleName}.sources",
-                        )
-                    }
-
-                    sourceClasses.forEach { sourceClass ->
-                        if (sourceClass.classKind != ClassKind.CLASS &&
-                            sourceClass.classKind != ClassKind.ANNOTATION_CLASS
-                        ) {
-                            throw InvalidCreamUsageException(
-                                message = "${sourceClass.fullName} (Specified in @${CombineMapping::class.simpleName}.sources) must be a class.",
-                                solution = "Specify a class in @${CombineMapping::class.simpleName}.sources",
-                            )
-                        }
-                    }
-
-                    val targetClass =
-                        targetType.declaration.requireClassDeclaration(
-                            annotationName = CombineMapping::class.simpleName!!,
-                            context = "Specified in @${CombineMapping::class.simpleName}.target",
-                        )
-
-                    val (kdocDescription, kdocExamples) = annotation.extractKDoc()
-
-                    val visibility = annotation.copyVisibilityArgument()
-
-                    CombineMappingInfo(
-                        sourceClasses = sourceClasses,
-                        targetClass = targetClass,
-                        propertyMappings = propertyMaps,
-                        kdocDescription = kdocDescription,
-                        kdocExamples = kdocExamples,
-                        visibility = visibility,
-                        funNameTemplate = annotation.funNameTemplate(),
-                    )
-                }
+                .map { annotation -> parseCombineMapping(annotation, annotatedDeclaration, logger) }
+                .toList()
+        if (parsedMappings.any { it == null }) return@forEach
+        val combineMappings = parsedMappings.filterNotNull()
 
         // Group by first source class package to create one file per source package
         combineMappings

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineToProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CombineToProcessor.kt
@@ -29,7 +29,7 @@ import me.tbsten.cream.ksp.util.extractPropertyMappings
 import me.tbsten.cream.ksp.util.fullName
 import me.tbsten.cream.ksp.util.funNameTemplate
 import me.tbsten.cream.ksp.util.isSealed
-import me.tbsten.cream.ksp.util.requireClassDeclaration
+import me.tbsten.cream.ksp.util.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.util.resolveToClassDeclaration
 import me.tbsten.cream.ksp.util.underPackageName
 
@@ -63,25 +63,40 @@ internal fun CreamSymbolProcessor.processCombineTo(resolver: Resolver): List<KSA
     combineToTargets.forEach { target ->
         val sourceDeclaration =
             target as? KSDeclaration
-                ?: throw InvalidCreamUsageException(
-                    message = "@${CombineTo::class.simpleName} must be applied to a class, interface, or typealias.",
-                    solution = "Please apply @${CombineTo::class.simpleName} to `class`, `interface`, or `typealias`",
-                )
-        val sourceClass = sourceDeclaration.requireClassDeclaration(annotationName = CombineTo::class.simpleName!!)
+                ?: run {
+                    logger.reportCreamError(
+                        InvalidCreamUsageException(
+                            message = "@${CombineTo::class.simpleName} must be applied to a class, interface, or typealias.",
+                            solution = "Please apply @${CombineTo::class.simpleName} to `class`, `interface`, or `typealias`",
+                        ),
+                        target,
+                    )
+                    return@forEach
+                }
+        val sourceClass =
+            sourceDeclaration.resolveClassDeclarationOrReport(
+                annotationName = CombineTo::class.simpleName!!,
+                logger = logger,
+            ) ?: return@forEach
 
         val combineToAnnotations = target.annotationsOf(CombineTo::class)
 
-        // CombineTo.targets: List<KClass<*>>
-        val targetClasses =
+        // CombineTo.targets: List<KClass<*>>. If any target cannot be resolved to a class, an error
+        // has been reported and we skip this source so no partial file is emitted.
+        val resolvedTargets =
             combineToAnnotations
                 .classListArgument("targets")
                 .map { it.declaration }
                 .map { declaration ->
-                    declaration.requireClassDeclaration(
+                    declaration.resolveClassDeclarationOrReport(
                         annotationName = CombineTo::class.simpleName!!,
+                        logger = logger,
                         context = "Specified in @${CombineTo::class.simpleName}.targets of ${target.fullName}",
+                        ksNode = sourceDeclaration,
                     )
                 }.toList()
+        if (resolvedTargets.any { it == null }) return@forEach
+        val targetClasses = resolvedTargets.filterNotNull()
 
         // @CombineTo is NOT @Repeatable: it lists its targets in a single `vararg targets`. Listing
         // the same target twice (`@CombineTo(Foo::class, Foo::class)`) is an unambiguous user
@@ -117,12 +132,16 @@ internal fun CreamSymbolProcessor.processCombineTo(resolver: Resolver): List<KSA
         val funNameTemplate =
             combineToAnnotations.firstOrNull()?.funNameTemplate() ?: DefaultCopyFunctionName
 
-        requireFunNameSupportsFanout(
-            funNameTemplate = funNameTemplate,
-            generatesMultipleFunctions = targetClasses.size > 1,
-            annotationSimpleName = CombineTo::class.simpleName!!,
-            declarationFullName = sourceClass.fullName,
-        )
+        val funNameOk =
+            requireFunNameSupportsFanout(
+                funNameTemplate = funNameTemplate,
+                generatesMultipleFunctions = targetClasses.size > 1,
+                annotationSimpleName = CombineTo::class.simpleName!!,
+                declarationFullName = sourceClass.fullName,
+                logger = logger,
+                ksNode = sourceDeclaration,
+            )
+        if (!funNameOk) return@forEach
 
         // Warn ONCE per source for @CombineTo.Exclude properties that match no parameter in ANY of
         // this source's target classes. Computed here (per source, union of all targets) rather than

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyFromProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyFromProcessor.kt
@@ -28,8 +28,7 @@ import me.tbsten.cream.ksp.util.extractPropertyMappings
 import me.tbsten.cream.ksp.util.fullName
 import me.tbsten.cream.ksp.util.funNameTemplate
 import me.tbsten.cream.ksp.util.isSealed
-import me.tbsten.cream.ksp.util.requireClassDeclaration
-import me.tbsten.cream.ksp.util.resolveToClassDeclaration
+import me.tbsten.cream.ksp.util.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.util.underPackageName
 
 internal fun CreamSymbolProcessor.processCopyFrom(resolver: Resolver): List<KSAnnotated> {
@@ -42,25 +41,40 @@ internal fun CreamSymbolProcessor.processCopyFrom(resolver: Resolver): List<KSAn
     copyFromTargets.forEach { target ->
         val targetDeclaration =
             target as? KSDeclaration
-                ?: throw InvalidCreamUsageException(
-                    message = "@${CopyFrom::class.simpleName} must be applied to a class, interface, or typealias.",
-                    solution = "Please apply @${CopyFrom::class.simpleName} to `class`, `interface`, or `typealias`",
-                )
-        val targetClass = targetDeclaration.requireClassDeclaration(annotationName = CopyFrom::class.simpleName!!)
+                ?: run {
+                    logger.reportCreamError(
+                        InvalidCreamUsageException(
+                            message = "@${CopyFrom::class.simpleName} must be applied to a class, interface, or typealias.",
+                            solution = "Please apply @${CopyFrom::class.simpleName} to `class`, `interface`, or `typealias`",
+                        ),
+                        target,
+                    )
+                    return@forEach
+                }
+        val targetClass =
+            targetDeclaration.resolveClassDeclarationOrReport(
+                annotationName = CopyFrom::class.simpleName!!,
+                logger = logger,
+            ) ?: return@forEach
 
         val copyFromAnnotations = target.annotationsOf(CopyFrom::class)
 
-        // CopyFrom.sources: List<KClass<*>>
-        val sourceClasses =
+        // CopyFrom.sources: List<KClass<*>>. If any source cannot be resolved to a class, an error
+        // has been reported and we skip this target so no partial file is emitted.
+        val resolvedSources =
             copyFromAnnotations
                 .classListArgument("sources")
                 .map { it.declaration }
                 .map { declaration ->
-                    declaration.requireClassDeclaration(
+                    declaration.resolveClassDeclarationOrReport(
                         annotationName = CopyFrom::class.simpleName!!,
+                        logger = logger,
                         context = "Specified in @${CopyFrom::class.simpleName}.sources of ${target.fullName}",
+                        ksNode = targetDeclaration,
                     )
                 }.toList()
+        if (resolvedSources.any { it == null }) return@forEach
+        val sourceClasses = resolvedSources.filterNotNull()
 
         val (kdocDescription, kdocExamples) =
             copyFromAnnotations.firstOrNull()?.extractKDoc() ?: ("" to emptyList())
@@ -71,12 +85,16 @@ internal fun CreamSymbolProcessor.processCopyFrom(resolver: Resolver): List<KSAn
         val funNameTemplate =
             copyFromAnnotations.firstOrNull()?.funNameTemplate() ?: DefaultCopyFunctionName
 
-        requireFunNameSupportsFanout(
-            funNameTemplate = funNameTemplate,
-            generatesMultipleFunctions = sourceClasses.size > 1 || targetClass.isSealed(),
-            annotationSimpleName = CopyFrom::class.simpleName!!,
-            declarationFullName = targetClass.fullName,
-        )
+        val funNameOk =
+            requireFunNameSupportsFanout(
+                funNameTemplate = funNameTemplate,
+                generatesMultipleFunctions = sourceClasses.size > 1 || targetClass.isSealed(),
+                annotationSimpleName = CopyFrom::class.simpleName!!,
+                declarationFullName = targetClass.fullName,
+                logger = logger,
+                ksNode = targetDeclaration,
+            )
+        if (!funNameOk) return@forEach
 
         codeGenerator
             .createNewKotlinFile(

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyMappingProcessor.kt
@@ -2,6 +2,7 @@ package me.tbsten.cream.ksp.process
 
 import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
@@ -26,7 +27,7 @@ import me.tbsten.cream.ksp.util.extractPropertyMappings
 import me.tbsten.cream.ksp.util.fullName
 import me.tbsten.cream.ksp.util.funNameTemplate
 import me.tbsten.cream.ksp.util.isSealed
-import me.tbsten.cream.ksp.util.requireClassDeclaration
+import me.tbsten.cream.ksp.util.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.util.underPackageName
 
 /**
@@ -49,6 +50,84 @@ private data class CopyMappingInfo(
     val funNameTemplate: String,
 )
 
+/**
+ * Parse one `@CopyMapping` annotation into a [CopyMappingInfo]. On any user-misuse error (missing
+ * `source` / `target`, or a `source` / `target` that cannot be resolved to a class), reports a
+ * clean positioned `COMPILATION_ERROR` via [logger] (anchored at [annotatedDeclaration]) and
+ * returns `null` so the caller can skip the whole declaration without crashing KSP.
+ */
+private fun parseCopyMapping(
+    annotation: KSAnnotation,
+    annotatedDeclaration: KSClassDeclaration,
+    logger: KSPLogger,
+): CopyMappingInfo? {
+    val sourceType =
+        annotation.arguments
+            .firstOrNull { it.name?.asString() == "source" }
+            ?.value as? KSType
+            ?: run {
+                logger.reportCreamError(
+                    InvalidCreamUsageException(
+                        message = "source parameter is required in @${CopyMapping::class.simpleName}",
+                        solution = "Specify source class in @${CopyMapping::class.simpleName}",
+                    ),
+                    annotatedDeclaration,
+                )
+                return null
+            }
+
+    val targetType =
+        annotation.arguments
+            .firstOrNull { it.name?.asString() == "target" }
+            ?.value as? KSType
+            ?: run {
+                logger.reportCreamError(
+                    InvalidCreamUsageException(
+                        message = "target parameter is required in @${CopyMapping::class.simpleName}",
+                        solution = "Specify target class in @${CopyMapping::class.simpleName}",
+                    ),
+                    annotatedDeclaration,
+                )
+                return null
+            }
+
+    val canReverse =
+        annotation.arguments
+            .firstOrNull { it.name?.asString() == "canReverse" }
+            ?.value as? Boolean
+            ?: false
+
+    val propertyMaps = annotation.extractPropertyMappings()
+
+    val sourceClass =
+        sourceType.declaration.resolveClassDeclarationOrReport(
+            annotationName = CopyMapping::class.simpleName!!,
+            logger = logger,
+            context = "Specified in @${CopyMapping::class.simpleName}.source",
+            ksNode = annotatedDeclaration,
+        ) ?: return null
+
+    val targetClass =
+        targetType.declaration.resolveClassDeclarationOrReport(
+            annotationName = CopyMapping::class.simpleName!!,
+            logger = logger,
+            context = "Specified in @${CopyMapping::class.simpleName}.target",
+            ksNode = annotatedDeclaration,
+        ) ?: return null
+
+    val (kdocDescription, kdocExamples) = annotation.extractKDoc()
+
+    return CopyMappingInfo(
+        sourceClass = sourceClass,
+        targetClass = targetClass,
+        canReverse = canReverse,
+        propertyMappings = propertyMaps,
+        kdocDescription = kdocDescription,
+        kdocExamples = kdocExamples,
+        funNameTemplate = annotation.funNameTemplate(),
+    )
+}
+
 internal fun CreamSymbolProcessor.processCopyMapping(resolver: Resolver): List<KSAnnotated> {
     val (copyMappingTargets, invalidCopyMappingTargets) =
         resolver
@@ -59,78 +138,42 @@ internal fun CreamSymbolProcessor.processCopyMapping(resolver: Resolver): List<K
     copyMappingTargets.forEach { target ->
         val annotatedDeclaration =
             (target as? KSClassDeclaration)
-                ?: throw InvalidCreamUsageException(
-                    message = "@${CopyMapping::class.simpleName} must be applied to a class.",
-                    solution = "Please apply @${CopyMapping::class.simpleName} to a `class` or `object`",
-                )
+                ?: run {
+                    logger.reportCreamError(
+                        InvalidCreamUsageException(
+                            message = "@${CopyMapping::class.simpleName} must be applied to a class.",
+                            solution = "Please apply @${CopyMapping::class.simpleName} to a `class` or `object`",
+                        ),
+                        target,
+                    )
+                    return@forEach
+                }
 
-        // Extract all CopyMapping annotations from the target
-        val copyMappings =
+        // Extract all CopyMapping annotations from the target. A malformed annotation reports a
+        // clean diagnostic and yields null; skip the whole declaration so no partial file is emitted.
+        val parsedMappings =
             target
                 .annotationsOf(CopyMapping::class)
-                .map { annotation ->
-                    val sourceType =
-                        annotation.arguments
-                            .firstOrNull { it.name?.asString() == "source" }
-                            ?.value as? KSType
-                            ?: throw InvalidCreamUsageException(
-                                message = "source parameter is required in @${CopyMapping::class.simpleName}",
-                                solution = "Specify source class in @${CopyMapping::class.simpleName}",
-                            )
-
-                    val targetType =
-                        annotation.arguments
-                            .firstOrNull { it.name?.asString() == "target" }
-                            ?.value as? KSType
-                            ?: throw InvalidCreamUsageException(
-                                message = "target parameter is required in @${CopyMapping::class.simpleName}",
-                                solution = "Specify target class in @${CopyMapping::class.simpleName}",
-                            )
-
-                    val canReverse =
-                        annotation.arguments
-                            .firstOrNull { it.name?.asString() == "canReverse" }
-                            ?.value as? Boolean
-                            ?: false
-
-                    val propertyMaps = annotation.extractPropertyMappings()
-
-                    val sourceClass =
-                        sourceType.declaration.requireClassDeclaration(
-                            annotationName = CopyMapping::class.simpleName!!,
-                            context = "Specified in @${CopyMapping::class.simpleName}.source",
-                        )
-
-                    val targetClass =
-                        targetType.declaration.requireClassDeclaration(
-                            annotationName = CopyMapping::class.simpleName!!,
-                            context = "Specified in @${CopyMapping::class.simpleName}.target",
-                        )
-
-                    val (kdocDescription, kdocExamples) = annotation.extractKDoc()
-
-                    CopyMappingInfo(
-                        sourceClass = sourceClass,
-                        targetClass = targetClass,
-                        canReverse = canReverse,
-                        propertyMappings = propertyMaps,
-                        kdocDescription = kdocDescription,
-                        kdocExamples = kdocExamples,
-                        funNameTemplate = annotation.funNameTemplate(),
-                    )
-                }.toList()
+                .map { annotation -> parseCopyMapping(annotation, annotatedDeclaration, logger) }
+                .toList()
+        if (parsedMappings.any { it == null }) return@forEach
+        val copyMappings = parsedMappings.filterNotNull()
 
         // Fail fast (before opening any output file) when a plain-literal funName would
         // fan out to multiple colliding names. Mirrors CopyTo/CopyFrom, which guard before
         // createNewKotlinFile so a rejected funName never leaves a partial generated file.
-        copyMappings.forEach { mapping ->
-            requireFunNameSupportsFanout(
-                funNameTemplate = mapping.funNameTemplate,
-                generatesMultipleFunctions = mapping.canReverse || mapping.targetClass.isSealed(),
-                annotationSimpleName = CopyMapping::class.simpleName!!,
-                declarationFullName = annotatedDeclaration.fullName,
-            )
-        }
+        val allFunNamesOk =
+            copyMappings.all { mapping ->
+                requireFunNameSupportsFanout(
+                    funNameTemplate = mapping.funNameTemplate,
+                    generatesMultipleFunctions = mapping.canReverse || mapping.targetClass.isSealed(),
+                    annotationSimpleName = CopyMapping::class.simpleName!!,
+                    declarationFullName = annotatedDeclaration.fullName,
+                    logger = logger,
+                    ksNode = annotatedDeclaration,
+                )
+            }
+        if (!allFunNamesOk) return@forEach
 
         // Group by source class to create one file per source package
         copyMappings

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToChildrenProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToChildrenProcessor.kt
@@ -26,8 +26,6 @@ import me.tbsten.cream.ksp.util.extractKDoc
 import me.tbsten.cream.ksp.util.extractPropertyMappings
 import me.tbsten.cream.ksp.util.fullName
 import me.tbsten.cream.ksp.util.isSealed
-import me.tbsten.cream.ksp.util.requireClassDeclaration
-import me.tbsten.cream.ksp.util.resolveToClassDeclaration
 import me.tbsten.cream.ksp.util.underPackageName
 
 internal fun CreamSymbolProcessor.processCopyToChildren(resolver: Resolver): List<KSAnnotated> {
@@ -38,38 +36,43 @@ internal fun CreamSymbolProcessor.processCopyToChildren(resolver: Resolver): Lis
             ).partition { it.validate() }
 
     copyToChildrenTargets.forEach { copyToChildren ->
-        val sourceSealedClass =
-            run {
-                if (copyToChildren !is KSClassDeclaration) {
-                    throw InvalidCreamUsageException(
-                        message =
-                            "@${CopyToChildren::class.simpleName} annotation must be applied to a sealed class/interface." +
-                                if (copyToChildren is KSDeclaration) {
-                                    copyToChildren.simpleName.asString() +
-                                        " is not sealed class/interface"
-                                } else {
-                                    ""
-                                },
-                        solution = (copyToChildren as? KSDeclaration)?.let { "Make ${it.fullName} a sealed class/interface." },
-                    )
-                }
+        if (copyToChildren !is KSClassDeclaration) {
+            logger.reportCreamError(
+                InvalidCreamUsageException(
+                    message =
+                        "@${CopyToChildren::class.simpleName} annotation must be applied to a sealed class/interface." +
+                            if (copyToChildren is KSDeclaration) {
+                                copyToChildren.simpleName.asString() +
+                                    " is not sealed class/interface"
+                            } else {
+                                ""
+                            },
+                    solution = (copyToChildren as? KSDeclaration)?.let { "Make ${it.fullName} a sealed class/interface." },
+                ),
+                copyToChildren,
+            )
+            return@forEach
+        }
 
-                if (!copyToChildren.isSealed()) {
-                    // Avoid `fullName`, which throws UnknownCreamException when qualifiedName is null
-                    // (e.g. local/anonymous declarations) and would mask this InvalidCreamUsageException.
-                    val displayName =
-                        copyToChildren.qualifiedName?.asString()
-                            ?: copyToChildren.simpleName.asString()
-                    throw InvalidCreamUsageException(
-                        message =
-                            "@${CopyToChildren::class.simpleName} annotation must be applied to a sealed class/interface, " +
-                                "but $displayName is not sealed (classKind: ${copyToChildren.classKind}).",
-                        solution = "Make $displayName a sealed class/interface.",
-                    )
-                }
+        if (!copyToChildren.isSealed()) {
+            // Avoid `fullName`, which throws UnknownCreamException when qualifiedName is null
+            // (e.g. local/anonymous declarations) and would mask this InvalidCreamUsageException.
+            val displayName =
+                copyToChildren.qualifiedName?.asString()
+                    ?: copyToChildren.simpleName.asString()
+            logger.reportCreamError(
+                InvalidCreamUsageException(
+                    message =
+                        "@${CopyToChildren::class.simpleName} annotation must be applied to a sealed class/interface, " +
+                            "but $displayName is not sealed (classKind: ${copyToChildren.classKind}).",
+                    solution = "Make $displayName a sealed class/interface.",
+                ),
+                copyToChildren,
+            )
+            return@forEach
+        }
 
-                copyToChildren
-            }
+        val sourceSealedClass = copyToChildren
         // Enclose notCopyToObject in runCatching because it may cause an error if notCopyToObject cannot be obtained.
         val notCopyToObject =
             runCatching {

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/CopyToProcessor.kt
@@ -30,8 +30,7 @@ import me.tbsten.cream.ksp.util.extractPropertyMappings
 import me.tbsten.cream.ksp.util.fullName
 import me.tbsten.cream.ksp.util.funNameTemplate
 import me.tbsten.cream.ksp.util.isSealed
-import me.tbsten.cream.ksp.util.requireClassDeclaration
-import me.tbsten.cream.ksp.util.resolveToClassDeclaration
+import me.tbsten.cream.ksp.util.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.util.underPackageName
 
 internal fun CreamSymbolProcessor.processCopyTo(resolver: Resolver): List<KSAnnotated> {
@@ -44,25 +43,40 @@ internal fun CreamSymbolProcessor.processCopyTo(resolver: Resolver): List<KSAnno
     copyToTargets.forEach { target ->
         val sourceDeclaration =
             target as? KSDeclaration
-                ?: throw InvalidCreamUsageException(
-                    message = "@${CopyTo::class.simpleName} must be applied to a class, interface, or typealias.",
-                    solution = "Please apply @${CopyTo::class.simpleName} to `class`, `interface`, or `typealias`",
-                )
-        val sourceClass = sourceDeclaration.requireClassDeclaration(annotationName = CopyTo::class.simpleName!!)
+                ?: run {
+                    logger.reportCreamError(
+                        InvalidCreamUsageException(
+                            message = "@${CopyTo::class.simpleName} must be applied to a class, interface, or typealias.",
+                            solution = "Please apply @${CopyTo::class.simpleName} to `class`, `interface`, or `typealias`",
+                        ),
+                        target,
+                    )
+                    return@forEach
+                }
+        val sourceClass =
+            sourceDeclaration.resolveClassDeclarationOrReport(
+                annotationName = CopyTo::class.simpleName!!,
+                logger = logger,
+            ) ?: return@forEach
 
         val copyToAnnotations = target.annotationsOf(CopyTo::class)
 
-        // CopyTo.targets: List<KClass<*>>
-        val targetClasses =
+        // CopyTo.targets: List<KClass<*>>. If any target cannot be resolved to a class, an error has
+        // been reported and we skip this source so no partial file is emitted.
+        val resolvedTargets =
             copyToAnnotations
                 .classListArgument("targets")
                 .map { it.declaration }
                 .map { declaration ->
-                    declaration.requireClassDeclaration(
+                    declaration.resolveClassDeclarationOrReport(
                         annotationName = CopyTo::class.simpleName!!,
+                        logger = logger,
                         context = "Specified in @${CopyTo::class.simpleName}.targets of ${target.fullName}",
+                        ksNode = sourceDeclaration,
                     )
                 }.toList()
+        if (resolvedTargets.any { it == null }) return@forEach
+        val targetClasses = resolvedTargets.filterNotNull()
 
         val (kdocDescription, kdocExamples) =
             copyToAnnotations.firstOrNull()?.extractKDoc() ?: ("" to emptyList())
@@ -73,12 +87,16 @@ internal fun CreamSymbolProcessor.processCopyTo(resolver: Resolver): List<KSAnno
         val funNameTemplate =
             copyToAnnotations.firstOrNull()?.funNameTemplate() ?: DefaultCopyFunctionName
 
-        requireFunNameSupportsFanout(
-            funNameTemplate = funNameTemplate,
-            generatesMultipleFunctions = targetClasses.size > 1 || targetClasses.any { it.isSealed() },
-            annotationSimpleName = CopyTo::class.simpleName!!,
-            declarationFullName = sourceClass.fullName,
-        )
+        val funNameOk =
+            requireFunNameSupportsFanout(
+                funNameTemplate = funNameTemplate,
+                generatesMultipleFunctions = targetClasses.size > 1 || targetClasses.any { it.isSealed() },
+                annotationSimpleName = CopyTo::class.simpleName!!,
+                declarationFullName = sourceClass.fullName,
+                logger = logger,
+                ksNode = sourceDeclaration,
+            )
+        if (!funNameOk) return@forEach
 
         val gsa =
             GenerateSourceAnnotation.CopyTo(

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/ReportCreamError.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/ReportCreamError.kt
@@ -1,0 +1,29 @@
+package me.tbsten.cream.ksp.process
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSNode
+import me.tbsten.cream.ksp.CreamException
+
+/**
+ * Report a user-misuse [CreamException] (invalid annotation usage / invalid option) as a clean,
+ * positioned `COMPILATION_ERROR` via [KSPLogger.error], rather than letting it propagate as a raw
+ * `throw` (which KSP reports as an `INTERNAL_ERROR` — a "processor crashed" stack trace plus, in
+ * the worst case, a half-written generated file).
+ *
+ * [ksNode] anchors the diagnostic to the offending declaration / annotation so the file and line
+ * are shown and IDE navigation works. Pass `null` only for errors that have no source location
+ * (e.g. an invalid KSP option, which comes from the build script, not the user's source).
+ *
+ * Mirrors the `reportRejection` helper used by the target-kind dispatcher
+ * ([me.tbsten.cream.ksp.transform.appendCopyFunction]); both funnel cream's user-facing errors
+ * through `logger.error` so every misuse surfaces the same way. After calling this, the caller
+ * MUST stop processing the offending unit (e.g. `return@forEach`) so no partial file is emitted.
+ */
+internal fun KSPLogger.reportCreamError(
+    exception: CreamException,
+    ksNode: KSNode?,
+) {
+    // CreamException always builds a non-null message; orEmpty() keeps the call non-null without
+    // an unsafe assertion.
+    error(exception.message.orEmpty(), ksNode)
+}

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/SealedCopyProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/process/SealedCopyProcessor.kt
@@ -33,21 +33,29 @@ internal fun CreamSymbolProcessor.processSealedCopy(resolver: Resolver): List<KS
 
     sealedCopyTargets.forEach { annotated ->
         if (annotated !is KSClassDeclaration) {
-            throw InvalidCreamUsageException(
-                message = "@${SealedCopy::class.simpleName} must be applied to a sealed class/interface.",
-                solution = "Please apply @${SealedCopy::class.simpleName} to a `sealed class` or `sealed interface`.",
+            logger.reportCreamError(
+                InvalidCreamUsageException(
+                    message = "@${SealedCopy::class.simpleName} must be applied to a sealed class/interface.",
+                    solution = "Please apply @${SealedCopy::class.simpleName} to a `sealed class` or `sealed interface`.",
+                ),
+                annotated,
             )
+            return@forEach
         }
         if (!annotated.isSealed()) {
             // Avoid `fullName`, which throws UnknownCreamException when qualifiedName is null
             // (e.g. local/anonymous declarations) and would mask this InvalidCreamUsageException.
             val displayName = annotated.qualifiedName?.asString() ?: annotated.simpleName.asString()
-            throw InvalidCreamUsageException(
-                message =
-                    "@${SealedCopy::class.simpleName} must be applied to a sealed class/interface, " +
-                        "but $displayName is not sealed.",
-                solution = "Make $displayName a `sealed class` or `sealed interface`.",
+            logger.reportCreamError(
+                InvalidCreamUsageException(
+                    message =
+                        "@${SealedCopy::class.simpleName} must be applied to a sealed class/interface, " +
+                            "but $displayName is not sealed.",
+                    solution = "Make $displayName a `sealed class` or `sealed interface`.",
+                ),
+                annotated,
             )
+            return@forEach
         }
 
         // Read directly from KSAnnotation rather than via getAnnotationsByType:
@@ -90,17 +98,21 @@ internal fun CreamSymbolProcessor.processSealedCopy(resolver: Resolver): List<KS
                 ?.key
         if (duplicateFunName != null) {
             val displayName = annotated.qualifiedName?.asString() ?: annotated.simpleName.asString()
-            throw InvalidCreamUsageException(
-                message =
-                    lines(
-                        "@${SealedCopy::class.simpleName} on $displayName generates more than one function named \"$duplicateFunName\".",
-                        "Stacked @${SealedCopy::class.simpleName} annotations are written to one file, so each must produce a distinct name.",
-                    ),
-                solution =
-                    lines(
-                        "Give each @${SealedCopy::class.simpleName} a distinct funName, e.g. funName = \"copyOrNull\".",
-                    ),
+            logger.reportCreamError(
+                InvalidCreamUsageException(
+                    message =
+                        lines(
+                            "@${SealedCopy::class.simpleName} on $displayName generates more than one function named \"$duplicateFunName\".",
+                            "Stacked @${SealedCopy::class.simpleName} annotations are written to one file, so each must produce a distinct name.",
+                        ),
+                    solution =
+                        lines(
+                            "Give each @${SealedCopy::class.simpleName} a distinct funName, e.g. funName = \"copyOrNull\".",
+                        ),
+                ),
+                annotated,
             )
+            return@forEach
         }
 
         // Warn for @SealedCopy.Exclude on non-abstract properties (no-op: they are not in copy())
@@ -152,6 +164,7 @@ internal fun CreamSymbolProcessor.processSealedCopy(resolver: Resolver): List<KS
                                 kdocExamples = kdocExamples,
                             ),
                         visibility = visibility,
+                        logger = logger,
                     )
                 }
             }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CopyFunctionNameExt.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/CopyFunctionNameExt.kt
@@ -1,6 +1,8 @@
 package me.tbsten.cream.ksp.transform
 
+import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSNode
 import me.tbsten.cream.ksp.InvalidCreamUsageException
 import me.tbsten.cream.ksp.options.ClassDeclarationInfo
 import me.tbsten.cream.ksp.options.CreamOptions
@@ -68,20 +70,15 @@ internal fun resolveSealedCopyFunName(
 }
 
 /**
- * Fail the build when [funNameTemplate] is a plain literal (contains no naming token) yet the
- * annotation generates more than one function: the functions would all share that one name
- * and collide. A template containing any token is fine because each generated function then
- * derives a distinct name from its own target.
+ * Build the [InvalidCreamUsageException] reported when a plain-literal [funNameTemplate] would
+ * fan out to more than one identically named function. Single source of truth for the message.
  */
-internal fun requireFunNameSupportsFanout(
+private fun fixedFunNameFanoutException(
     funNameTemplate: String,
-    generatesMultipleFunctions: Boolean,
     annotationSimpleName: String,
     declarationFullName: String,
-) {
-    if (!generatesMultipleFunctions) return
-    if (containsAnyCopyFunNameToken(funNameTemplate)) return
-    throw InvalidCreamUsageException(
+): InvalidCreamUsageException =
+    InvalidCreamUsageException(
         message =
             lines(
                 "@$annotationSimpleName on $declarationFullName sets a fixed funName \"$funNameTemplate\",",
@@ -95,4 +92,30 @@ internal fun requireFunNameSupportsFanout(
                 "or split the declaration into separate annotations.",
             ),
     )
+
+/**
+ * Reject (with a clean positioned `COMPILATION_ERROR` via [KSPLogger.error] anchored at [ksNode])
+ * a [funNameTemplate] that is a plain literal (contains no naming token) yet generates more than
+ * one function: the functions would all share that one name and collide. A template containing any
+ * token is fine because each generated function then derives a distinct name from its own target.
+ *
+ * @return `true` when the funName is acceptable (caller proceeds); `false` when it was rejected and
+ * an error has already been reported (caller must skip the offending unit so no partial file is
+ * emitted).
+ */
+internal fun requireFunNameSupportsFanout(
+    funNameTemplate: String,
+    generatesMultipleFunctions: Boolean,
+    annotationSimpleName: String,
+    declarationFullName: String,
+    logger: KSPLogger,
+    ksNode: KSNode?,
+): Boolean {
+    if (!generatesMultipleFunctions) return true
+    if (containsAnyCopyFunNameToken(funNameTemplate)) return true
+    logger.error(
+        fixedFunNameFanoutException(funNameTemplate, annotationSimpleName, declarationFullName).message.orEmpty(),
+        ksNode,
+    )
+    return false
 }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/SealedCopy.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/SealedCopy.kt
@@ -1,6 +1,7 @@
 package me.tbsten.cream.ksp.transform
 
 import com.google.devtools.ksp.isAbstract
+import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
@@ -34,6 +35,7 @@ internal fun BufferedWriter.appendSealedCopyFunction(
     omitPackages: List<String>,
     generateSourceAnnotation: GenerateSourceAnnotation.SealedCopy,
     visibility: CopyVisibility = CopyVisibility.INHERIT,
+    logger: KSPLogger? = null,
 ) {
     val abstractProperties = sealedClass.collectAbstractProperties()
     val classifiedLeaves =
@@ -44,7 +46,17 @@ internal fun BufferedWriter.appendSealedCopyFunction(
     val nonCopyableLeaves = classifiedLeaves.filterIsInstance<SealedCopyLeaf.NonCopyable>()
 
     if (nonCopyableStrategy == NonCopyableStrategy.ERROR && nonCopyableLeaves.isNotEmpty()) {
-        throw nonCopyableErrorException(sealedClass, nonCopyableLeaves, funName)
+        val exception = nonCopyableErrorException(sealedClass, nonCopyableLeaves, funName)
+        // Report a clean positioned COMPILATION_ERROR and emit nothing for this function so the
+        // transactional writer leaves no partial file behind. The `null` branch fails closed: a
+        // future caller without a logger still surfaces the misuse (as an INTERNAL_ERROR) rather
+        // than silently dropping it.
+        if (logger != null) {
+            logger.error(exception.message.orEmpty(), sealedClass)
+            return
+        } else {
+            throw exception
+        }
     }
 
     val nullable = nonCopyableStrategy == NonCopyableStrategy.RETURN_NULL && nonCopyableLeaves.isNotEmpty()

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Transform.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/transform/Transform.kt
@@ -151,12 +151,34 @@ internal fun BufferedWriter.appendCombineToFunction(
                 )
             }
 
-        else -> throw InvalidCreamUsageException(
+        // A combine target must be constructable (class / annotation class / object). Interfaces and
+        // enums cannot be built, so reject them — branches are listed explicitly (no `else`) so a new
+        // ClassKind forces a compile-time decision here.
+        ClassKind.INTERFACE,
+        ClassKind.ENUM_CLASS,
+        ClassKind.ENUM_ENTRY,
+        -> logger.reportUnsupportedCombineTarget(target)
+    }
+}
+
+/**
+ * Report a [target] whose [ClassKind] cannot be a `@CombineTo` / `@CombineFrom` / `@CombineMapping`
+ * target. Mirrors [reportRejection]: a clean positioned `COMPILATION_ERROR` via [KSPLogger.error]
+ * when a logger is available (leaving no partial generated file), falling back to a `throw` (an
+ * `INTERNAL_ERROR`) only when no logger was threaded, so the misuse is never silently dropped.
+ */
+private fun KSPLogger?.reportUnsupportedCombineTarget(target: KSClassDeclaration) {
+    val exception =
+        InvalidCreamUsageException(
             message =
                 "Unsupported combine to ${
                     target.classKind.name.lowercase().replace("_", " ")
                 } (${target.fullName}).",
             solution = "Please make ${target.fullName} a class or object.",
         )
+    if (this != null) {
+        error(exception.message.orEmpty(), target)
+    } else {
+        throw exception
     }
 }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/TypeAlias.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/TypeAlias.kt
@@ -1,7 +1,9 @@
 package me.tbsten.cream.ksp.util
 
+import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import me.tbsten.cream.ksp.InvalidCreamUsageException
 
@@ -28,29 +30,46 @@ internal fun KSDeclaration.resolveToClassDeclaration(): KSClassDeclaration? =
     }
 
 /**
- * Resolves a declaration to a class declaration, throwing an exception if it fails.
+ * Build the [InvalidCreamUsageException] describing why this declaration could not be resolved to a
+ * class. Single source of truth for the message used by [resolveClassDeclarationOrReport].
+ */
+private fun KSDeclaration.unresolvableClassException(
+    annotationName: String,
+    context: String,
+): InvalidCreamUsageException =
+    InvalidCreamUsageException(
+        message =
+            if (context.isEmpty()) {
+                "$fullName must be class, interface, or typealias."
+            } else {
+                "$fullName ($context) must be class, interface, or typealias."
+            },
+        solution =
+            if (context.isEmpty()) {
+                "Please apply @$annotationName to `class`, `interface`, or `typealias`"
+            } else {
+                "Specify class, interface, or typealias in $context."
+            },
+    )
+
+/**
+ * Resolves a declaration to a class declaration, emitting a clean positioned `COMPILATION_ERROR`
+ * via [KSPLogger.error] (anchored at [ksNode], defaulting to this declaration) and returning `null`
+ * instead of throwing when resolution fails, so the caller can skip the offending unit without
+ * crashing KSP with an `INTERNAL_ERROR`.
  *
  * @param annotationName The name of the annotation being processed (e.g., "CopyTo", "CopyFrom")
  * @param context Additional context for the error message (e.g., "Specified in @CopyTo.targets of Foo")
- * @return The resolved KSClassDeclaration
- * @throws InvalidCreamUsageException if the declaration cannot be resolved to a class
  */
-internal fun KSDeclaration.requireClassDeclaration(
+internal fun KSDeclaration.resolveClassDeclarationOrReport(
     annotationName: String,
+    logger: KSPLogger,
     context: String = "",
-): KSClassDeclaration =
-    this.resolveToClassDeclaration()
-        ?: throw InvalidCreamUsageException(
-            message =
-                if (context.isEmpty()) {
-                    "$fullName must be class, interface, or typealias."
-                } else {
-                    "$fullName ($context) must be class, interface, or typealias."
-                },
-            solution =
-                if (context.isEmpty()) {
-                    "Please apply @$annotationName to `class`, `interface`, or `typealias`"
-                } else {
-                    "Specify class, interface, or typealias in $context."
-                },
-        )
+    ksNode: KSNode = this,
+): KSClassDeclaration? {
+    val resolved = this.resolveToClassDeclaration()
+    if (resolved == null) {
+        logger.error(unresolvableClassException(annotationName, context).message.orEmpty(), ksNode)
+    }
+    return resolved
+}

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CombineFromDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CombineFromDiagnosticTest.kt
@@ -1,0 +1,45 @@
+package me.tbsten.cream.ksp.diagnostic
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
+
+/**
+ * `@CombineFrom` needs at least one source class to combine. Declaring it with no sources is a
+ * clean, positioned `COMPILATION_ERROR` (via `logger.error`) anchored at the annotated declaration
+ * — never a KSP `INTERNAL_ERROR` — and leaves no partial generated file.
+ */
+internal class CombineFromDiagnosticTest :
+    FunSpec({
+        test("@CombineFrom with no sources fails compilation cleanly") {
+            val source =
+                """
+                package diag
+
+                import me.tbsten.cream.CombineFrom
+
+                @CombineFrom()
+                data class Target(val a: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.messages shouldContain "at least one source class"
+                result.generatedSources().shouldBeEmpty()
+            }
+            assertMatchesSnapshot("CombineFromDiagnosticTest.noSources.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CombineMappingDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CombineMappingDiagnosticTest.kt
@@ -1,0 +1,49 @@
+package me.tbsten.cream.ksp.diagnostic
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
+
+/**
+ * `@CombineMapping` combines two or more sources into a target. Misusing it (fewer than two
+ * sources) is a clean, positioned `COMPILATION_ERROR` (via `logger.error`) anchored at the
+ * annotated declaration — never a KSP `INTERNAL_ERROR` — and leaves no partial generated file.
+ */
+internal class CombineMappingDiagnosticTest :
+    FunSpec({
+        test("@CombineMapping with fewer than two sources fails compilation cleanly") {
+            val source =
+                """
+                package diag
+
+                import me.tbsten.cream.CombineMapping
+
+                data class A(val a: String)
+
+                @CombineMapping(sources = [A::class], target = Target::class)
+                object Mapping
+
+                data class Target(val a: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.messages shouldContain "at least 2 source classes"
+                result.generatedSources().shouldBeEmpty()
+            }
+            assertMatchesSnapshot("CombineMappingDiagnosticTest.tooFewSources.output") {
+                facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
+                "Input" facetOf source
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToChildrenDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToChildrenDiagnosticTest.kt
@@ -1,14 +1,20 @@
 package me.tbsten.cream.ksp.diagnostic
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
 
+/**
+ * `@CopyToChildren` must be applied to a sealed class/interface. Applying it to anything else is a
+ * clean, positioned `COMPILATION_ERROR` (via `logger.error`), never a KSP `INTERNAL_ERROR`, and no
+ * partial / empty generated file is left behind.
+ */
 internal class CopyToChildrenDiagnosticTest :
     FunSpec({
         test("non-sealed class with @CopyToChildren fails compilation") {
@@ -23,8 +29,11 @@ internal class CopyToChildrenDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("CopyToChildrenDiagnosticTest.nonSealedClass.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -44,8 +53,11 @@ internal class CopyToChildrenDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("CopyToChildrenDiagnosticTest.dataClass.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/CopyToDiagnosticTest.kt
@@ -1,8 +1,10 @@
 package me.tbsten.cream.ksp.diagnostic
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
@@ -24,8 +26,11 @@ internal class CopyToDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+            assertSoftly {
+                withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("CopyToDiagnosticTest.enumTarget.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -49,8 +54,11 @@ internal class CopyToDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+            assertSoftly {
+                withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("CopyToDiagnosticTest.nonSealedInterface.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -72,8 +80,11 @@ internal class CopyToDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+            assertSoftly {
+                withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("CopyToDiagnosticTest.annotationTarget.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/FunNameDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/FunNameDiagnosticTest.kt
@@ -1,9 +1,11 @@
 package me.tbsten.cream.ksp.diagnostic
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
@@ -11,7 +13,8 @@ import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
 // cream does not validate the Kotlin-legality of a funName (keywords, illegal characters, …) —
 // such names simply fail to compile at the use site. These diagnostics cover the cases cream
 // *does* reject up front: fan-out / repeatable collisions, where a fixed name would produce more
-// than one function with the same signature.
+// than one function with the same signature. Every rejection is a clean, positioned
+// COMPILATION_ERROR (via logger.error) — never a KSP INTERNAL_ERROR — and leaves no partial file.
 internal class FunNameDiagnosticTest :
     FunSpec({
         test("a plain-literal funName with multiple targets fails compilation") {
@@ -29,8 +32,11 @@ internal class FunNameDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("FunNameDiagnosticTest.literalFanoutMultiTarget.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -57,8 +63,11 @@ internal class FunNameDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("FunNameDiagnosticTest.literalFanoutSealed.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -81,8 +90,11 @@ internal class FunNameDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("FunNameDiagnosticTest.copyFromLiteralFanout.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -105,8 +117,11 @@ internal class FunNameDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("FunNameDiagnosticTest.combineToLiteralFanout.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -129,8 +144,11 @@ internal class FunNameDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("FunNameDiagnosticTest.copyMappingCanReverseLiteral.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -156,8 +174,11 @@ internal class FunNameDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("FunNameDiagnosticTest.combineFromConflictingFunName.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -187,8 +208,11 @@ internal class FunNameDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("FunNameDiagnosticTest.sealedCopyDuplicateName.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/MultipleDiagnosticsTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/MultipleDiagnosticsTest.kt
@@ -1,0 +1,48 @@
+package me.tbsten.cream.ksp.diagnostic
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.tbsten.cream.ksp.testing.compileWithCream
+import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
+
+/**
+ * cream runs ~8 processors sequentially in one round. Because every user-misuse error is reported
+ * per-site via `logger.error` (not a raw `throw`), the processors run to completion and KSP
+ * collects *all* diagnostics in a single compilation — a `throw` would abort the round and hide the
+ * remaining errors. This locks that guarantee in: two independent misuses, handled by two different
+ * processors, are both reported as clean `COMPILATION_ERROR`s, and nothing is generated.
+ */
+internal class MultipleDiagnosticsTest :
+    FunSpec({
+        test("independent misuses across processors are all reported, none swallowed") {
+            val source =
+                """
+                package diag
+
+                import me.tbsten.cream.CopyToChildren
+                import me.tbsten.cream.SealedCopy
+
+                @CopyToChildren
+                class NotSealedChildren(val a: String)
+
+                @SealedCopy
+                class NotSealedCopy(val b: String)
+                """.trimIndent()
+            val result = compileWithCream(source)
+
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                // Both diagnostics are present — neither processor's error aborted the other.
+                result.messages shouldContain "NotSealedChildren"
+                result.messages shouldContain "NotSealedCopy"
+                result.generatedSources().shouldBeEmpty()
+            }
+        }
+    })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/OptionsDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/OptionsDiagnosticTest.kt
@@ -1,14 +1,20 @@
 package me.tbsten.cream.ksp.diagnostic
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
 
+/**
+ * An invalid KSP option value (a build-script mistake) must surface as a clean `COMPILATION_ERROR`
+ * (via `logger.error`), never as a KSP `INTERNAL_ERROR`. The option has no source location, so the
+ * diagnostic carries no `file:line`; processing is skipped entirely, so nothing is generated.
+ */
 internal class OptionsDiagnosticTest :
     FunSpec({
         val validSource: String =
@@ -30,8 +36,11 @@ internal class OptionsDiagnosticTest :
                     options = mapOf("cream.copyFunNamingStrategy" to "not-a-strategy"),
                 )
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("OptionsDiagnosticTest.invalidCopyFunNamingStrategy.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -46,8 +55,11 @@ internal class OptionsDiagnosticTest :
                     options = mapOf("cream.escapeDot" to "not-an-escape"),
                 )
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("OptionsDiagnosticTest.invalidEscapeDot.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/SealedCopyDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/diagnostic/SealedCopyDiagnosticTest.kt
@@ -1,13 +1,21 @@
 package me.tbsten.cream.ksp.diagnostic
 
 import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.assertMatchesSnapshot
 import me.tbsten.cream.ksp.testing.compileWithCream
 import me.tbsten.cream.ksp.testing.normalizedCompilerOutput
 
+/**
+ * `@SealedCopy` misuse must surface as a clean, positioned `COMPILATION_ERROR` (via
+ * `logger.error`), never as a KSP `INTERNAL_ERROR` (a processor-crash stack trace). Each rejection
+ * also fails closed: when no copy function can be generated, the transactional writer leaves no
+ * partial / empty generated file behind.
+ */
 internal class SealedCopyDiagnosticTest :
     FunSpec({
         test("object subtype under default ERROR strategy fails compilation") {
@@ -27,8 +35,11 @@ internal class SealedCopyDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("SealedCopyDiagnosticTest.objectErrorDefault.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -53,8 +64,11 @@ internal class SealedCopyDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("SealedCopyDiagnosticTest.missingCopy.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -79,8 +93,11 @@ internal class SealedCopyDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("SealedCopyDiagnosticTest.missingCopyCustomFunName.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")
@@ -100,8 +117,11 @@ internal class SealedCopyDiagnosticTest :
                 """.trimIndent()
             val result = compileWithCream(source)
 
-            withClue("Compilation should fail. Output:\n${result.normalizedCompilerOutput()}") {
-                result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+            assertSoftly {
+                withClue("Output:\n${result.normalizedCompilerOutput()}") {
+                    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+                }
+                result.generatedSources().shouldBeEmpty()
             }
             assertMatchesSnapshot("SealedCopyDiagnosticTest.nonSealedClass.output") {
                 facet("Compiler output", result.normalizedCompilerOutput(), lang = "text")

--- a/cream-ksp/src/test/resources/snapshots/CombineFromDiagnosticTest/noSources.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromDiagnosticTest/noSources.output.md
@@ -1,0 +1,20 @@
+## Compiler output
+
+```text
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:6: Invalid cream usage: @CombineFrom requires at least one source class.
+
+Solution: 
+  Specify at least one source class in @CombineFrom.sources of diag.Target.
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CombineFrom
+
+@CombineFrom()
+data class Target(val a: String)
+```

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingDiagnosticTest/tooFewSources.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingDiagnosticTest/tooFewSources.output.md
@@ -1,0 +1,24 @@
+## Compiler output
+
+```text
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:8: Invalid cream usage: @CombineMapping requires at least 2 source classes, but got 1.
+
+Solution: 
+  Specify at least 2 source classes in @CombineMapping.sources
+```
+
+## Input
+
+```kt
+package diag
+
+import me.tbsten.cream.CombineMapping
+
+data class A(val a: String)
+
+@CombineMapping(sources = [A::class], target = Target::class)
+object Mapping
+
+data class Target(val a: String)
+```

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest/dataClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest/dataClass.output.md
@@ -1,17 +1,11 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.JustData is not sealed (classKind: CLASS).
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:6: Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.JustData is not sealed (classKind: CLASS).
 
 Solution: 
   Make diag.JustData a sealed class/interface.
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.JustData is not sealed (classKind: CLASS).
-
-Solution: 
-  Make diag.JustData a sealed class/interface.
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest/nonSealedClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenDiagnosticTest/nonSealedClass.output.md
@@ -1,17 +1,11 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.NotSealed is not sealed (classKind: CLASS).
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:6: Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.NotSealed is not sealed (classKind: CLASS).
 
 Solution: 
   Make diag.NotSealed a sealed class/interface.
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyToChildren annotation must be applied to a sealed class/interface, but diag.NotSealed is not sealed (classKind: CLASS).
-
-Solution: 
-  Make diag.NotSealed a sealed class/interface.
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/combineFromConflictingFunName.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/combineFromConflictingFunName.output.md
@@ -1,21 +1,13 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @CombineFrom on diag.Target is repeated with conflicting funName values:
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:10: Invalid cream usage: @CombineFrom on diag.Target is repeated with conflicting funName values:
 "buildX", "buildY"
 Stacked @CombineFrom annotations are merged into a single generated function, so funName must be unambiguous.
 
 Solution: 
   Set the same funName on every @CombineFrom of diag.Target, or set it on only one.
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CombineFrom on diag.Target is repeated with conflicting funName values:
-"buildX", "buildY"
-Stacked @CombineFrom annotations are merged into a single generated function, so funName must be unambiguous.
-
-Solution: 
-  Set the same funName on every @CombineFrom of diag.Target, or set it on only one.
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/combineToLiteralFanout.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/combineToLiteralFanout.output.md
@@ -1,7 +1,8 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @CombineTo on diag.Source sets a fixed funName "toThem",
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:6: Invalid cream usage: @CombineTo on diag.Source sets a fixed funName "toThem",
 but it generates more than one function (multiple targets or sources, a sealed
 target, or a reversible mapping). Those functions would all share that name and collide.
 
@@ -9,17 +10,6 @@ Solution:
   Include a naming token so each generated function gets a distinct name, e.g.
     funName = "to" + CopyTargetSimpleName
   or split the declaration into separate annotations.
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CombineTo on diag.Source sets a fixed funName "toThem",
-but it generates more than one function (multiple targets or sources, a sealed
-target, or a reversible mapping). Those functions would all share that name and collide.
-
-Solution: 
-  Include a naming token so each generated function gets a distinct name, e.g.
-    funName = "to" + CopyTargetSimpleName
-  or split the declaration into separate annotations.
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/copyFromLiteralFanout.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/copyFromLiteralFanout.output.md
@@ -1,7 +1,8 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @CopyFrom on diag.Target sets a fixed funName "fromThem",
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:9: Invalid cream usage: @CopyFrom on diag.Target sets a fixed funName "fromThem",
 but it generates more than one function (multiple targets or sources, a sealed
 target, or a reversible mapping). Those functions would all share that name and collide.
 
@@ -9,17 +10,6 @@ Solution:
   Include a naming token so each generated function gets a distinct name, e.g.
     funName = "to" + CopyTargetSimpleName
   or split the declaration into separate annotations.
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyFrom on diag.Target sets a fixed funName "fromThem",
-but it generates more than one function (multiple targets or sources, a sealed
-target, or a reversible mapping). Those functions would all share that name and collide.
-
-Solution: 
-  Include a naming token so each generated function gets a distinct name, e.g.
-    funName = "to" + CopyTargetSimpleName
-  or split the declaration into separate annotations.
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/copyMappingCanReverseLiteral.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/copyMappingCanReverseLiteral.output.md
@@ -1,7 +1,8 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @CopyMapping on diag.Mapping sets a fixed funName "convert",
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:9: Invalid cream usage: @CopyMapping on diag.Mapping sets a fixed funName "convert",
 but it generates more than one function (multiple targets or sources, a sealed
 target, or a reversible mapping). Those functions would all share that name and collide.
 
@@ -9,17 +10,6 @@ Solution:
   Include a naming token so each generated function gets a distinct name, e.g.
     funName = "to" + CopyTargetSimpleName
   or split the declaration into separate annotations.
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyMapping on diag.Mapping sets a fixed funName "convert",
-but it generates more than one function (multiple targets or sources, a sealed
-target, or a reversible mapping). Those functions would all share that name and collide.
-
-Solution: 
-  Include a naming token so each generated function gets a distinct name, e.g.
-    funName = "to" + CopyTargetSimpleName
-  or split the declaration into separate annotations.
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/literalFanoutMultiTarget.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/literalFanoutMultiTarget.output.md
@@ -1,7 +1,8 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @CopyTo on diag.Source sets a fixed funName "toThem",
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:6: Invalid cream usage: @CopyTo on diag.Source sets a fixed funName "toThem",
 but it generates more than one function (multiple targets or sources, a sealed
 target, or a reversible mapping). Those functions would all share that name and collide.
 
@@ -9,17 +10,6 @@ Solution:
   Include a naming token so each generated function gets a distinct name, e.g.
     funName = "to" + CopyTargetSimpleName
   or split the declaration into separate annotations.
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyTo on diag.Source sets a fixed funName "toThem",
-but it generates more than one function (multiple targets or sources, a sealed
-target, or a reversible mapping). Those functions would all share that name and collide.
-
-Solution: 
-  Include a naming token so each generated function gets a distinct name, e.g.
-    funName = "to" + CopyTargetSimpleName
-  or split the declaration into separate annotations.
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/literalFanoutSealed.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/literalFanoutSealed.output.md
@@ -1,7 +1,8 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @CopyTo on diag.Source sets a fixed funName "toState",
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:6: Invalid cream usage: @CopyTo on diag.Source sets a fixed funName "toState",
 but it generates more than one function (multiple targets or sources, a sealed
 target, or a reversible mapping). Those functions would all share that name and collide.
 
@@ -9,17 +10,6 @@ Solution:
   Include a naming token so each generated function gets a distinct name, e.g.
     funName = "to" + CopyTargetSimpleName
   or split the declaration into separate annotations.
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @CopyTo on diag.Source sets a fixed funName "toState",
-but it generates more than one function (multiple targets or sources, a sealed
-target, or a reversible mapping). Those functions would all share that name and collide.
-
-Solution: 
-  Include a naming token so each generated function gets a distinct name, e.g.
-    funName = "to" + CopyTargetSimpleName
-  or split the declaration into separate annotations.
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/sealedCopyDuplicateName.output.md
+++ b/cream-ksp/src/test/resources/snapshots/FunNameDiagnosticTest/sealedCopyDuplicateName.output.md
@@ -1,19 +1,12 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @SealedCopy on diag.State generates more than one function named "toState".
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:8: Invalid cream usage: @SealedCopy on diag.State generates more than one function named "toState".
 Stacked @SealedCopy annotations are written to one file, so each must produce a distinct name.
 
 Solution: 
   Give each @SealedCopy a distinct funName, e.g. funName = "copyOrNull".
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @SealedCopy on diag.State generates more than one function named "toState".
-Stacked @SealedCopy annotations are written to one file, so each must produce a distinct name.
-
-Solution: 
-  Give each @SealedCopy a distinct funName, e.g. funName = "copyOrNull".
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest/invalidCopyFunNamingStrategy.output.md
+++ b/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest/invalidCopyFunNamingStrategy.output.md
@@ -1,7 +1,8 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: Invalid option: Invalid ksp.arg["cream.copyFunNamingStrategy"] = not-a-strategy.
+e: Error occurred in KSP, check log for detail
+e: [ksp] Invalid cream usage: Invalid option: Invalid ksp.arg["cream.copyFunNamingStrategy"] = not-a-strategy.
 It must be on of under-package, diff, simple-name, full-name, inner-name
 
 Solution: 
@@ -13,25 +14,6 @@ Solution:
     - "simple-name"
     - "full-name"
     - "inner-name"
-  
-
-me.tbsten.cream.ksp.InvalidCreamOptionException: Invalid cream usage: Invalid option: Invalid ksp.arg["cream.copyFunNamingStrategy"] = not-a-strategy.
-It must be on of under-package, diff, simple-name, full-name, inner-name
-
-Solution: 
-  Set one of the following for ksp.arg: 
-  
-  
-    - "under-package"
-    - "diff"
-    - "simple-name"
-    - "full-name"
-    - "inner-name"
-  
-
-	<stack trace omitted>
-Caused by: java.lang.IllegalArgumentException: No enum constant me.tbsten.cream.ksp.options.CopyFunNamingStrategy.not-a-strategy
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest/invalidEscapeDot.output.md
+++ b/cream-ksp/src/test/resources/snapshots/OptionsDiagnosticTest/invalidEscapeDot.output.md
@@ -1,27 +1,14 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: Invalid option: Invalid ksp.arg["cream.escapeDot"] = not-an-escape
+e: Error occurred in KSP, check log for detail
+e: [ksp] Invalid cream usage: Invalid option: Invalid ksp.arg["cream.escapeDot"] = not-an-escape
 
 Solution: 
   Set one of the following for ksp.arg:
   
     - lower-camel-case
     - replace-to-underscore
-  
-
-me.tbsten.cream.ksp.InvalidCreamOptionException: Invalid cream usage: Invalid option: Invalid ksp.arg["cream.escapeDot"] = not-an-escape
-
-Solution: 
-  Set one of the following for ksp.arg:
-  
-    - lower-camel-case
-    - replace-to-underscore
-  
-
-	<stack trace omitted>
-Caused by: java.lang.IllegalArgumentException: No enum constant me.tbsten.cream.ksp.options.EscapeDot.not-an-escape
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/SealedCopyDiagnosticTest/missingCopy.output.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopyDiagnosticTest/missingCopy.output.md
@@ -1,7 +1,8 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: Cannot generate copy() for sealed type 'MyState' because the following subclass(es) have no compatible 'copy(...)' function: MyState.Frozen
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:6: Invalid cream usage: Cannot generate copy() for sealed type 'MyState' because the following subclass(es) have no compatible 'copy(...)' function: MyState.Frozen
 
 Solution: 
   Choose one of the following strategies on @SealedCopy:
@@ -14,24 +15,6 @@ Solution:
     • Make the subtype a 'data class'
     • Add a 'copy(...)' member function that accepts the abstract properties
     • Or annotate that copy-shaped function with @SealedCopy.Map
-  
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: Cannot generate copy() for sealed type 'MyState' because the following subclass(es) have no compatible 'copy(...)' function: MyState.Frozen
-
-Solution: 
-  Choose one of the following strategies on @SealedCopy:
-    • @SealedCopy(nonCopyableStrategy = RETURN_AS_IS)
-      → emits 'is X -> this' for non-copyable branches
-    • @SealedCopy(nonCopyableStrategy = RETURN_NULL)
-      → widens the return type to 'MyState?' and emits 'is X -> null'
-  
-  For non-data class subtypes you can also:
-    • Make the subtype a 'data class'
-    • Add a 'copy(...)' member function that accepts the abstract properties
-    • Or annotate that copy-shaped function with @SealedCopy.Map
-  
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/SealedCopyDiagnosticTest/missingCopyCustomFunName.output.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopyDiagnosticTest/missingCopyCustomFunName.output.md
@@ -1,7 +1,8 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: Cannot generate updated() for sealed type 'MyState' because the following subclass(es) have no compatible 'copy(...)' function: MyState.Frozen
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:6: Invalid cream usage: Cannot generate updated() for sealed type 'MyState' because the following subclass(es) have no compatible 'copy(...)' function: MyState.Frozen
 
 Solution: 
   Choose one of the following strategies on @SealedCopy:
@@ -14,24 +15,6 @@ Solution:
     • Make the subtype a 'data class'
     • Add a 'copy(...)' member function that accepts the abstract properties
     • Or annotate that copy-shaped function with @SealedCopy.Map
-  
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: Cannot generate updated() for sealed type 'MyState' because the following subclass(es) have no compatible 'copy(...)' function: MyState.Frozen
-
-Solution: 
-  Choose one of the following strategies on @SealedCopy:
-    • @SealedCopy(nonCopyableStrategy = RETURN_AS_IS)
-      → emits 'is X -> this' for non-copyable branches
-    • @SealedCopy(nonCopyableStrategy = RETURN_NULL)
-      → widens the return type to 'MyState?' and emits 'is X -> null'
-  
-  For non-data class subtypes you can also:
-    • Make the subtype a 'data class'
-    • Add a 'copy(...)' member function that accepts the abstract properties
-    • Or annotate that copy-shaped function with @SealedCopy.Map
-  
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/SealedCopyDiagnosticTest/nonSealedClass.output.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopyDiagnosticTest/nonSealedClass.output.md
@@ -1,17 +1,11 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: @SealedCopy must be applied to a sealed class/interface, but diag.sealedCopy.NotSealed is not sealed.
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:6: Invalid cream usage: @SealedCopy must be applied to a sealed class/interface, but diag.sealedCopy.NotSealed is not sealed.
 
 Solution: 
   Make diag.sealedCopy.NotSealed a `sealed class` or `sealed interface`.
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: @SealedCopy must be applied to a sealed class/interface, but diag.sealedCopy.NotSealed is not sealed.
-
-Solution: 
-  Make diag.sealedCopy.NotSealed a `sealed class` or `sealed interface`.
-
-	<stack trace omitted>
 ```
 
 ## Input

--- a/cream-ksp/src/test/resources/snapshots/SealedCopyDiagnosticTest/objectErrorDefault.output.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopyDiagnosticTest/objectErrorDefault.output.md
@@ -1,7 +1,8 @@
 ## Compiler output
 
 ```text
-Invalid cream usage: Cannot generate copy() for sealed type 'MyState' because it contains object subtype(s): MyState.Empty. Objects are singletons and have no .copy() to delegate to.
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Test.kt:6: Invalid cream usage: Cannot generate copy() for sealed type 'MyState' because it contains object subtype(s): MyState.Empty. Objects are singletons and have no .copy() to delegate to.
 
 Solution: 
   Choose one of the following strategies on @SealedCopy:
@@ -9,19 +10,6 @@ Solution:
       → emits 'is X -> this' for non-copyable branches
     • @SealedCopy(nonCopyableStrategy = RETURN_NULL)
       → widens the return type to 'MyState?' and emits 'is X -> null'
-  
-
-me.tbsten.cream.ksp.InvalidCreamUsageException: Invalid cream usage: Cannot generate copy() for sealed type 'MyState' because it contains object subtype(s): MyState.Empty. Objects are singletons and have no .copy() to delegate to.
-
-Solution: 
-  Choose one of the following strategies on @SealedCopy:
-    • @SealedCopy(nonCopyableStrategy = RETURN_AS_IS)
-      → emits 'is X -> this' for non-copyable branches
-    • @SealedCopy(nonCopyableStrategy = RETURN_NULL)
-      → widens the return type to 'MyState?' and emits 'is X -> null'
-  
-
-	<stack trace omitted>
 ```
 
 ## Input


### PR DESCRIPTION
## Why

cream's user-misuse errors were raised with raw `throw InvalidCreamUsageException` /
`InvalidCreamOptionException`. KSP reports an uncaught processor exception as an **`INTERNAL_ERROR`** —
a "the processor crashed" stack trace (with the message duplicated and the exception class name
leaked), and in the worst case a half-written generated file. That looks like a cream bug, not a
clear "you used the annotation wrong" message.

PR #112 fixed the target-kind path and #115 fixed the `@CopyMapping` path. This is the **capstone**:
it sweeps the rest so that **every** user-misuse surfaces as a clean, positioned
`COMPILATION_ERROR` (via `logger.error(message, ksNode)`), while genuine internal-bug guards
(`UnknownCreamException`) stay as `INTERNAL_ERROR`.

## What

Per-site conversion — **no** top-level `try/catch` in `process()`. The ~8 processors run
sequentially; one catch would swallow every processor after the first failure. Instead each throw
site reports via `logger.error` and skips its own unit (`return@forEach` / `return null` / skip),
so KSP collects **all** diagnostics in one round and the transactional writer (#113) emits no
partial file.

**Converted throw sites (19):**

| Site | Annotation / area |
|------|-------------------|
| `CopyToProcessor` (source not decl, target resolve, funName fanout) | `@CopyTo` |
| `CopyFromProcessor` (target not decl, source resolve, funName fanout) | `@CopyFrom` |
| `CopyToChildrenProcessor` (not class decl, not sealed) | `@CopyToChildren` |
| `SealedCopyProcessor` (not class decl, not sealed, duplicate funName) | `@SealedCopy` |
| `appendSealedCopyFunction` (non-copyable under `ERROR` strategy) | `@SealedCopy` |
| `CombineToProcessor` (source not decl, target resolve, funName fanout) | `@CombineTo` |
| `CombineFromProcessor` (target not decl, source resolve, no sources, conflicting funName) | `@CombineFrom` |
| `CopyMappingProcessor` (not class decl, `source`/`target` missing, resolve, funName fanout) | `@CopyMapping` |
| `CombineMappingProcessor` (not class decl, `sources`/`target` missing, <2 sources, non-class source, target resolve) | `@CombineMapping` |
| `appendCombineToFunction` unsupported-kind branch | combine dispatch |
| `CreamOptions` (`copyFunNamingStrategy`, `escapeDot`) | KSP options |

**Mechanism**

- New `reportCreamError(exception, ksNode)` helper funnels every misuse through `logger.error`,
  mirroring the existing `reportRejection`.
- The throwing `requireClassDeclaration` is replaced by
  `resolveClassDeclarationOrReport(logger, ksNode)` (reports + returns `null`); `classListArgument`
  loops collect nullable results and skip the unit if any failed (a non-local return out of a
  non-inline `map` isn't allowed).
- `requireFunNameSupportsFanout` reports via logger and returns `Boolean`.
- The combine-dispatch `when (target.classKind)` lists `INTERFACE` / `ENUM_CLASS` / `ENUM_ENTRY`
  explicitly (no `else`) so a new `ClassKind` forces a compile-time decision.
- Options are parsed **lazily** and validated at the start of `process()`; an invalid value has no
  source location, so it is reported with `logger.error(message)` (no node) and the round is
  skipped.

**Out of scope / kept as-is**

- `UnknownCreamException` (9 sites): internal-bug guard — intentionally remains an `INTERNAL_ERROR`.
- 3 null-logger fallbacks in helpers (`reportRejection`, `reportUnsupportedCombineTarget`,
  `appendSealedCopyFunction`): fail-closed throws so a future caller that forgets the logger still
  surfaces the misuse rather than silently dropping it.
- No deeper `@CombineTo`/`@CombineFrom` concrete-class validation (that would change combine
  semantics; the `@CombineMapping` target-kind gap is tracked separately).

No functional change to valid codegen — only diagnostic-path goldens changed.

## Test

- **Strengthened** every diagnostic spec: assert `exitCode == COMPILATION_ERROR` *specifically*
  (not `shouldNotBe OK`) **and** no partial file (`generatedSources()` empty), all in
  `assertSoftly`. Covers enum / non-sealed interface / annotation-class targets, `@SealedCopy`
  (non-sealed, duplicate funName, non-copyable ERROR), `@CopyToChildren` (non-sealed, data class),
  funName fanout (`@CopyTo`/`@CopyFrom`/`@CombineTo`/`@CopyMapping`/`@CombineFrom`/`@SealedCopy`),
  and invalid options.
- **New specs**: `CombineFromDiagnosticTest` (no sources), `CombineMappingDiagnosticTest` (<2
  sources), and `MultipleDiagnosticsTest` — two independent misuses across two processors are both
  reported in one run (proves nothing is swallowed).
- **17 goldens** regenerated/added (15 INTERNAL_ERROR → COMPILATION_ERROR conversions + 2 new):
  each now shows a single clean `e: [ksp] …: Invalid cream usage: …` instead of the old
  duplicated-message + exception-class + stack-trace output.

Local (JDK 21): `:cream-ksp:test`, `:test:jvmTest`, `:cream-ksp:ktlintCheck` all green.
(Matrix CI won't run — this base predates the CI fix.)

<details>
<summary><b>Regenerated / added goldens (17)</b></summary>

INTERNAL_ERROR → COMPILATION_ERROR (15):

- `CopyToChildrenDiagnosticTest/dataClass.output.md`
- `CopyToChildrenDiagnosticTest/nonSealedClass.output.md`
- `SealedCopyDiagnosticTest/nonSealedClass.output.md`
- `SealedCopyDiagnosticTest/objectErrorDefault.output.md`
- `SealedCopyDiagnosticTest/missingCopy.output.md`
- `SealedCopyDiagnosticTest/missingCopyCustomFunName.output.md`
- `FunNameDiagnosticTest/literalFanoutMultiTarget.output.md`
- `FunNameDiagnosticTest/literalFanoutSealed.output.md`
- `FunNameDiagnosticTest/copyFromLiteralFanout.output.md`
- `FunNameDiagnosticTest/combineToLiteralFanout.output.md`
- `FunNameDiagnosticTest/copyMappingCanReverseLiteral.output.md`
- `FunNameDiagnosticTest/combineFromConflictingFunName.output.md`
- `FunNameDiagnosticTest/sealedCopyDuplicateName.output.md`
- `OptionsDiagnosticTest/invalidCopyFunNamingStrategy.output.md`
- `OptionsDiagnosticTest/invalidEscapeDot.output.md`

New (2):

- `CombineFromDiagnosticTest/noSources.output.md`
- `CombineMappingDiagnosticTest/tooFewSources.output.md`

</details>

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
