### PR TITLE
build: specify jvmToolchain 17 across all modules

### DIFF
--- a/buildLogic/convention/build.gradle.kts
+++ b/buildLogic/convention/build.gradle.kts
@@ -1,20 +1,14 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     `kotlin-dsl`
 }
 
 group = "me.tbsten.cream.buildLogic"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-
 kotlin {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
-    }
+    // Compile against a provisioned JDK 17 (configures both the Java and Kotlin toolchains) so the
+    // included build does not depend on the JDK that happens to launch Gradle. Provisioning is
+    // enabled by the foojay resolver in buildLogic/settings.gradle.kts.
+    jvmToolchain(17)
 }
 
 dependencies {

--- a/buildLogic/convention/build.gradle.kts
+++ b/buildLogic/convention/build.gradle.kts
@@ -7,13 +7,13 @@ plugins {
 group = "me.tbsten.cream.buildLogic"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/buildLogic/settings.gradle.kts
+++ b/buildLogic/settings.gradle.kts
@@ -6,6 +6,12 @@ pluginManagement {
     }
 }
 
+// Mirror the root build: auto-provision the JDK 17 toolchain for this included build too, so
+// `jvmToolchain(17)` in convention/build.gradle.kts resolves even without a matching local JDK.
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         google()

--- a/cream-ksp/build.gradle.kts
+++ b/cream-ksp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 kotlin {
     explicitApi()
+    jvmToolchain(17)
 
     compilerOptions.optIn.addAll(
         "com.google.devtools.ksp.KspExperimental",

--- a/cream-ksp/shared/build.gradle.kts
+++ b/cream-ksp/shared/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 kotlin {
     explicitApi()
+    jvmToolchain(17)
 
     jvm()
     js(IR) {

--- a/cream-runtime/build.gradle.kts
+++ b/cream-runtime/build.gradle.kts
@@ -1,6 +1,4 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -11,6 +9,7 @@ plugins {
 
 kotlin {
     explicitApi()
+    jvmToolchain(17)
 
     // tested on CI
     iosSimulatorArm64()
@@ -18,10 +17,6 @@ kotlin {
     linuxX64()
     androidTarget {
         publishLibraryVariants("release")
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
-        }
     }
     // not tested on CI
     macosX64()
@@ -81,8 +76,8 @@ android {
                 .toInt()
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 

--- a/optionBuilder/desktopApp/build.gradle.kts
+++ b/optionBuilder/desktopApp/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
     id("buildLogic.lint")
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 dependencies {
     implementation(project(":optionBuilder:sharedUI"))
     implementation(compose.ui)

--- a/optionBuilder/sharedUI/build.gradle.kts
+++ b/optionBuilder/sharedUI/build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(17)
+
     jvm()
 
     js { browser() }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,12 @@ pluginManagement {
     }
 }
 
+// Auto-provision the JDK 17 toolchain (`jvmToolchain(17)`) for contributors who do not have a
+// matching JDK installed locally, so the toolchain spec never fails with "No matching toolchains".
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         google()

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -1,8 +1,6 @@
 @file:OptIn(KspExperimental::class)
 
 import com.google.devtools.ksp.KspExperimental
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -26,17 +24,18 @@ android {
                 .get()
                 .toInt()
     }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 kotlin {
+    jvmToolchain(17)
+
     iosSimulatorArm64()
     jvm()
-    androidTarget {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
-        }
-    }
+    androidTarget()
 
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
## 概要

Closes #133

JVM ターゲットを持つ全モジュールを `jvmToolchain(17)` で Java 17 toolchain に固定し、散在していた `JvmTarget.JVM_11` / `JavaVersion.VERSION_11` を 17 に統一しました。これによりビルド JDK が固定され、生成バイトコードも Java 17 に揃います。

> [!NOTE]
> 方針確認の結果「全部17へ」を採用しています。**cream-runtime の利用者の最低要件が Java 11 → 17 に上がる** 点にご注意ください（公開ライブラリのため利用者影響あり）。

## 変更内容

- **cream-runtime / cream-ksp / cream-ksp:shared / test / optionBuilder(sharedUI, desktopApp)**: `jvmToolchain(17)` を追加。冗長になる per-target の `jvmTarget` オーバーライドを削除し、Android `compileOptions` を 17 に更新。
- **buildLogic convention plugin**: java + kotlin の jvmTarget を 11 → 17。
- **settings**: `foojay-resolver-convention` を適用。JDK 17 を持たないコントリビュータでも toolchain が自動プロビジョニングされ、toolchain 導入前は任意の JDK で通っていたビルドが「No matching toolchains」で失敗する退行を防ぎます。
- `optionBuilder:webApp` は JS のみのため対象外。

## 確認

ローカル (JDK 26 上で Gradle 実行 → toolchain は provisioned JDK 17 を解決) で検証済み:

- `./gradlew jvmTest :cream-ksp:test testDebugUnitTest` → **BUILD SUCCESSFUL**
- `./gradlew ktlintCheck` → **BUILD SUCCESSFUL**
- 生成バイトコードの major version が **61 (Java 17)** であることを `javap -v` で確認（cream-runtime jvm / cream-ksp）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)