### PR TITLE
refactor: enable explicit API mode for published modules

### DIFF
--- a/cream-ksp/build.gradle.kts
+++ b/cream-ksp/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 }
 
 kotlin {
+    explicitApi()
+
     compilerOptions.optIn.addAll(
         "com.google.devtools.ksp.KspExperimental",
         "me.tbsten.cream.InternalCreamApi",

--- a/cream-ksp/shared/build.gradle.kts
+++ b/cream-ksp/shared/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 }
 
 kotlin {
+    explicitApi()
+
     jvm()
     js(IR) {
         browser()

--- a/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/CreamException.kt
+++ b/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/CreamException.kt
@@ -4,7 +4,7 @@ import me.tbsten.cream.InternalCreamApi
 import me.tbsten.cream.ksp.util.appendLines
 
 @InternalCreamApi
-abstract class CreamException(
+public abstract class CreamException(
     message: String,
     solution: String? = null,
     cause: Throwable? = null,
@@ -24,7 +24,7 @@ abstract class CreamException(
 )
 
 @InternalCreamApi
-open class InvalidCreamUsageException(
+public open class InvalidCreamUsageException(
     message: String,
     solution: String?,
     cause: Throwable? = null,
@@ -35,7 +35,7 @@ open class InvalidCreamUsageException(
 )
 
 @InternalCreamApi
-class InvalidCreamOptionException(
+public class InvalidCreamOptionException(
     message: String,
     solution: String?,
     cause: Throwable? = null,
@@ -46,7 +46,7 @@ class InvalidCreamOptionException(
 )
 
 @InternalCreamApi
-class UnknownCreamException(
+public class UnknownCreamException(
     message: String? = null,
     solution: String? = null,
     cause: Throwable? = null,
@@ -57,7 +57,7 @@ class UnknownCreamException(
 )
 
 @InternalCreamApi
-fun reportToGithub(vararg with: String) =
+public fun reportToGithub(vararg with: String): String =
     buildString {
         appendLines(
             "Please report this issue at:",

--- a/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/core/common/CopyFunctionName.kt
+++ b/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/core/common/CopyFunctionName.kt
@@ -5,7 +5,7 @@ import me.tbsten.cream.ksp.options.ClassDeclarationInfo
 import me.tbsten.cream.ksp.options.CreamOptions
 
 @InternalCreamApi
-fun copyFunctionName(
+public fun copyFunctionName(
     source: ClassDeclarationInfo,
     target: ClassDeclarationInfo,
     options: CreamOptions,
@@ -23,9 +23,9 @@ fun copyFunctionName(
     )
 }
 
-data class CopyFunctionName(
+public data class CopyFunctionName(
     val prefix: String,
     val targetName: String,
 ) {
-    override fun toString() = "$prefix$targetName"
+    override fun toString(): String = "$prefix$targetName"
 }

--- a/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/core/common/FunctionNameTemplate.kt
+++ b/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/core/common/FunctionNameTemplate.kt
@@ -29,7 +29,7 @@ import me.tbsten.cream.ksp.options.CreamOptions
  * Kotlin's identifier rules here would only become a maintenance burden as they change.
  */
 @InternalCreamApi
-fun resolveFunNameTemplate(
+public fun resolveFunNameTemplate(
     template: String,
     source: ClassDeclarationInfo,
     target: ClassDeclarationInfo,
@@ -54,7 +54,7 @@ fun resolveFunNameTemplate(
  * would emit duplicate names).
  */
 @InternalCreamApi
-fun containsAnyCopyFunNameToken(template: String): Boolean =
+public fun containsAnyCopyFunNameToken(template: String): Boolean =
     template.contains(DefaultCopyFunctionName) ||
         copyTargetTokenExpanders.any { (placeholder, _) -> template.contains(placeholder) }
 

--- a/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/options/CopyFunNamingStrategy.kt
+++ b/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/options/CopyFunNamingStrategy.kt
@@ -4,7 +4,7 @@ import me.tbsten.cream.InternalCreamApi
 
 @Suppress("EnumEntryName", "RemoveRedundantBackticks")
 @InternalCreamApi
-enum class CopyFunNamingStrategy(val funName: (source: ClassDeclarationInfo, target: ClassDeclarationInfo) -> String) {
+public enum class CopyFunNamingStrategy(public val funName: (source: ClassDeclarationInfo, target: ClassDeclarationInfo) -> String) {
     `under-package`({ _, target ->
         target.fullName.replace(target.packageName + ".", "")
     }),
@@ -46,16 +46,16 @@ enum class CopyFunNamingStrategy(val funName: (source: ClassDeclarationInfo, tar
     )
     ;
 
-    companion object {
-        val default = `under-package`
+    public companion object {
+        public val default: CopyFunNamingStrategy = `under-package`
     }
 }
 
 @InternalCreamApi
-interface ClassDeclarationInfo {
-    val packageName: String
-    val underPackageName: String
-    val simpleName: String
+public interface ClassDeclarationInfo {
+    public val packageName: String
+    public val underPackageName: String
+    public val simpleName: String
 
-    val fullName: String
+    public val fullName: String
 }

--- a/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/options/CreamOptions.kt
+++ b/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/options/CreamOptions.kt
@@ -7,14 +7,14 @@ import me.tbsten.cream.ksp.util.lines
 
 @InternalCreamApi
 @Serializable
-data class CreamOptions(
+public data class CreamOptions(
     val copyFunNamePrefix: String,
     val copyFunNamingStrategy: CopyFunNamingStrategy,
     val escapeDot: EscapeDot,
     val notCopyToObject: Boolean,
 ) {
-    companion object {
-        val default = CreamOptions(
+    public companion object {
+        public val default: CreamOptions = CreamOptions(
             copyFunNamePrefix = "copyTo",
             copyFunNamingStrategy = CopyFunNamingStrategy.default,
             escapeDot = EscapeDot.default,
@@ -24,7 +24,7 @@ data class CreamOptions(
 }
 
 @InternalCreamApi
-fun Map<String, String>.toCreamOptions(): CreamOptions {
+public fun Map<String, String>.toCreamOptions(): CreamOptions {
     return CreamOptions(
         copyFunNamePrefix =
             this["cream.copyFunNamePrefix"] ?: CreamOptions.default.copyFunNamePrefix,

--- a/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/options/EscapeDot.kt
+++ b/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/options/EscapeDot.kt
@@ -5,8 +5,8 @@ import me.tbsten.cream.InternalCreamApi
 
 @Suppress("EnumEntryName")
 @InternalCreamApi
-enum class EscapeDot(
-    val escape: (String) -> String,
+public enum class EscapeDot(
+    public val escape: (String) -> String,
 ) {
     `lower-camel-case`({
         it
@@ -20,7 +20,7 @@ enum class EscapeDot(
     }),
     ;
 
-    companion object {
-        val default = `lower-camel-case`
+    public companion object {
+        public val default: EscapeDot = `lower-camel-case`
     }
 }

--- a/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/util/Sequence.kt
+++ b/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/util/Sequence.kt
@@ -3,7 +3,7 @@ package me.tbsten.cream.ksp.util
 import me.tbsten.cream.InternalCreamApi
 
 @InternalCreamApi
-fun <T> Sequence<T>.isCountMoreThan(count: Int, include: Boolean): Boolean {
+public fun <T> Sequence<T>.isCountMoreThan(count: Int, include: Boolean): Boolean {
     if (count < 0) return true // 負の数よりは常に多い
     val threshold = if (include) count else count + 1
     var currentCount = 0
@@ -15,7 +15,7 @@ fun <T> Sequence<T>.isCountMoreThan(count: Int, include: Boolean): Boolean {
 }
 
 @InternalCreamApi
-fun <T> Sequence<T>.isCountLessThan(count: Int, include: Boolean): Boolean {
+public fun <T> Sequence<T>.isCountLessThan(count: Int, include: Boolean): Boolean {
     if (count < 0) return false // 負の数より少なくなることはない
     val threshold = if (include) count else count - 1
     if (threshold < 0) return false // 0未満の閾値より少なくなることはない (空のシーケンスの場合を除くが、その場合は currentCount < 0 となるので問題ない)

--- a/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/util/String.kt
+++ b/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/util/String.kt
@@ -3,11 +3,11 @@ package me.tbsten.cream.ksp.util
 import me.tbsten.cream.InternalCreamApi
 
 @InternalCreamApi
-fun lines(vararg lines: String, indent: String = ""): String =
+public fun lines(vararg lines: String, indent: String = ""): String =
     lines.joinToString("\n") { "$indent$it" }
 
 @InternalCreamApi
-fun StringBuilder.appendLines(vararg lines: String, indent: String = ""): String {
+public fun StringBuilder.appendLines(vararg lines: String, indent: String = ""): String {
     val lines = lines(*lines, indent = indent)
     append(lines)
     return lines

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/CreamSymbolProcessor.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/CreamSymbolProcessor.kt
@@ -16,7 +16,7 @@ import me.tbsten.cream.ksp.feature.sealedCopy.processSealedCopy
 import me.tbsten.cream.ksp.options.CreamOptions
 import me.tbsten.cream.ksp.options.toCreamOptions
 
-class CreamSymbolProcessor(
+internal class CreamSymbolProcessor(
     private val rawOptions: Map<String, String>,
     internal val codeGenerator: CodeGenerator,
     internal val logger: KSPLogger,

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/CreamSymbolProcessorProvider.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/CreamSymbolProcessorProvider.kt
@@ -4,7 +4,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 
-class CreamSymbolProcessorProvider : SymbolProcessorProvider {
+public class CreamSymbolProcessorProvider : SymbolProcessorProvider {
     override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
         CreamSymbolProcessor(
             rawOptions = environment.options,

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/With.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/With.kt
@@ -4,7 +4,7 @@ package me.tbsten.cream.ksp.util
  * Calls [block] with [a] and [b] as context receivers, avoiding nested `with` calls.
  */
 @Suppress("NOTHING_TO_INLINE")
-inline fun <A, B, R> with(
+internal inline fun <A, B, R> with(
     a: A,
     b: B,
     block: context(A, B) () -> R,

--- a/cream-runtime/build.gradle.kts
+++ b/cream-runtime/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 }
 
 kotlin {
+    explicitApi()
+
     // tested on CI
     iosSimulatorArm64()
     jvm()

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CombineFrom.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CombineFrom.kt
@@ -58,14 +58,14 @@ import kotlin.reflect.KClass
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS)
 @Repeatable
-annotation class CombineFrom(
+public annotation class CombineFrom(
     vararg val sources: KClass<*>,
     val kdoc: KDoc = KDoc(),
     val visibility: CopyVisibility = CopyVisibility.INHERIT,
     val funName: String = DefaultCopyFunctionName,
 ) {
     @Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE_PARAMETER)
-    annotation class Map(
+    public annotation class Map(
         vararg val propertyNames: String,
     )
 
@@ -106,5 +106,5 @@ annotation class CombineFrom(
      * @see CombineFrom
      */
     @Target(AnnotationTarget.VALUE_PARAMETER)
-    annotation class Exclude
+    public annotation class Exclude
 }

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CombineMapping.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CombineMapping.kt
@@ -97,7 +97,7 @@ import kotlin.reflect.KClass
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS)
 @Retention(AnnotationRetention.SOURCE)
 @Repeatable
-annotation class CombineMapping(
+public annotation class CombineMapping(
     val sources: Array<KClass<*>>,
     val target: KClass<*>,
     val properties: Array<Map> = [],
@@ -127,7 +127,7 @@ annotation class CombineMapping(
      * ```
      */
     @Target()
-    annotation class Map(
+    public annotation class Map(
         val source: String,
         val target: String,
     )

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CombineTo.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CombineTo.kt
@@ -56,14 +56,14 @@ import kotlin.reflect.KClass
  * @see DefaultCopyFunctionName
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS)
-annotation class CombineTo(
+public annotation class CombineTo(
     vararg val targets: KClass<*>,
     val kdoc: KDoc = KDoc(),
     val visibility: CopyVisibility = CopyVisibility.INHERIT,
     val funName: String = DefaultCopyFunctionName,
 ) {
     @Target(AnnotationTarget.PROPERTY, AnnotationTarget.TYPE_PARAMETER)
-    annotation class Map(
+    public annotation class Map(
         vararg val propertyNames: String,
     )
 
@@ -99,5 +99,5 @@ annotation class CombineTo(
      * @see CombineTo
      */
     @Target(AnnotationTarget.PROPERTY)
-    annotation class Exclude
+    public annotation class Exclude
 }

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyFrom.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyFrom.kt
@@ -47,14 +47,14 @@ import kotlin.reflect.KClass
  * @see DefaultCopyFunctionName
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS)
-annotation class CopyFrom(
+public annotation class CopyFrom(
     vararg val sources: KClass<*>,
     val kdoc: KDoc = KDoc(),
     val visibility: CopyVisibility = CopyVisibility.INHERIT,
     val funName: String = DefaultCopyFunctionName,
 ) {
     @Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE_PARAMETER)
-    annotation class Map(
+    public annotation class Map(
         vararg val propertyNames: String,
     )
 
@@ -89,5 +89,5 @@ annotation class CopyFrom(
      * @see CopyFrom
      */
     @Target(AnnotationTarget.VALUE_PARAMETER)
-    annotation class Exclude
+    public annotation class Exclude
 }

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyFunctionNameToken.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyFunctionNameToken.kt
@@ -45,28 +45,28 @@ package me.tbsten.cream
  * `funName` keeps cream's existing behaviour. Embed it to keep the derived name and only
  * add a prefix/suffix, e.g. `funName = DefaultCopyFunctionName + "OrNull"`.
  */
-const val DefaultCopyFunctionName: String = "{{cream:DefaultCopyFunctionName}}"
+public const val DefaultCopyFunctionName: String = "{{cream:DefaultCopyFunctionName}}"
 
 /** Target simple name in Pascal case, e.g. `UiState.Success` -> `Success`. */
-const val CopyTargetSimpleName: String = "{{cream:CopyTargetSimpleName}}"
+public const val CopyTargetSimpleName: String = "{{cream:CopyTargetSimpleName}}"
 
 /** Target simple name in snake case, e.g. `UiState.Success` -> `success`. */
-const val copy_target_simple_name: String = "{{cream:copy_target_simple_name}}"
+public const val copy_target_simple_name: String = "{{cream:copy_target_simple_name}}"
 
 /** Target name below its package, Pascal case, e.g. `com.example.UiState.Success` -> `UiStateSuccess`. */
-const val CopyTargetUnderPackage: String = "{{cream:CopyTargetUnderPackage}}"
+public const val CopyTargetUnderPackage: String = "{{cream:CopyTargetUnderPackage}}"
 
 /** Target name below its package, snake case, e.g. `com.example.UiState.Success` -> `uistate_success`. */
-const val copy_target_under_package: String = "{{cream:copy_target_under_package}}"
+public const val copy_target_under_package: String = "{{cream:copy_target_under_package}}"
 
 /** Target name below its outermost declaration, Pascal case, e.g. `UiState.Success` -> `Success`. */
-const val CopyTargetInnerName: String = "{{cream:CopyTargetInnerName}}"
+public const val CopyTargetInnerName: String = "{{cream:CopyTargetInnerName}}"
 
 /** Target name below its outermost declaration, snake case, e.g. `UiState.Success` -> `success`. */
-const val copy_target_inner_name: String = "{{cream:copy_target_inner_name}}"
+public const val copy_target_inner_name: String = "{{cream:copy_target_inner_name}}"
 
 /** Fully-qualified target name, Pascal case, e.g. `com.example.UiState.Success` -> `ComExampleUiStateSuccess`. */
-const val CopyTargetFullName: String = "{{cream:CopyTargetFullName}}"
+public const val CopyTargetFullName: String = "{{cream:CopyTargetFullName}}"
 
 /** Fully-qualified target name, snake case, e.g. `com.example.UiState.Success` -> `com_example_uistate_success`. */
-const val copy_target_full_name: String = "{{cream:copy_target_full_name}}"
+public const val copy_target_full_name: String = "{{cream:copy_target_full_name}}"

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyMapping.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyMapping.kt
@@ -97,7 +97,7 @@ import kotlin.reflect.KClass
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS)
 @Retention(AnnotationRetention.SOURCE)
 @Repeatable
-annotation class CopyMapping(
+public annotation class CopyMapping(
     val source: KClass<*>,
     val target: KClass<*>,
     val canReverse: Boolean = false,
@@ -127,7 +127,7 @@ annotation class CopyMapping(
      * ```
      */
     @Target()
-    annotation class Map(
+    public annotation class Map(
         val source: String,
         val target: String,
     )

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyTo.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyTo.kt
@@ -48,14 +48,14 @@ import kotlin.reflect.KClass
  * @see DefaultCopyFunctionName
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS)
-annotation class CopyTo(
+public annotation class CopyTo(
     vararg val targets: KClass<*>,
     val kdoc: KDoc = KDoc(),
     val visibility: CopyVisibility = CopyVisibility.INHERIT,
     val funName: String = DefaultCopyFunctionName,
 ) {
     @Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE_PARAMETER)
-    annotation class Map(
+    public annotation class Map(
         vararg val propertyNames: String,
     )
 
@@ -92,5 +92,5 @@ annotation class CopyTo(
      * @see CopyTo
      */
     @Target(AnnotationTarget.VALUE_PARAMETER)
-    annotation class Exclude
+    public annotation class Exclude
 }

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyToChildren.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyToChildren.kt
@@ -61,7 +61,7 @@ package me.tbsten.cream
  * @see CopyVisibility
  */
 @Target(AnnotationTarget.CLASS)
-annotation class CopyToChildren(
+public annotation class CopyToChildren(
     val notCopyToObject: Boolean = false,
     val kdoc: KDoc = KDoc(),
     val visibility: CopyVisibility = CopyVisibility.INHERIT,
@@ -110,5 +110,5 @@ annotation class CopyToChildren(
      * @see SealedCopy.Exclude
      */
     @Target(AnnotationTarget.PROPERTY)
-    annotation class Exclude
+    public annotation class Exclude
 }

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyVisibility.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyVisibility.kt
@@ -29,7 +29,7 @@ package me.tbsten.cream
  * @see CombineTo
  * @see CombineFrom
  */
-enum class CopyVisibility {
+public enum class CopyVisibility {
     /**
      * Keep cream's current behaviour: the generated function inherits the visibility of
      * the target/sealed declaration it is derived from. This is the default so that

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/InternalCreamApi.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/InternalCreamApi.kt
@@ -2,4 +2,4 @@ package me.tbsten.cream
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @RequiresOptIn(message = "This API is used internally within cream.kt. Direct use is not recommended.")
-annotation class InternalCreamApi
+public annotation class InternalCreamApi

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/KDoc.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/KDoc.kt
@@ -48,7 +48,7 @@ package me.tbsten.cream
  */
 @Target()
 @Retention(AnnotationRetention.SOURCE)
-annotation class KDoc(
+public annotation class KDoc(
     val description: String = "",
     val examples: Array<String> = [],
 )

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/SealedCopy.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/SealedCopy.kt
@@ -103,7 +103,7 @@ package me.tbsten.cream
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 @Repeatable
-annotation class SealedCopy(
+public annotation class SealedCopy(
     val funName: String = DefaultCopyFunctionName,
     val nonCopyableStrategy: NonCopyableStrategy = NonCopyableStrategy.ERROR,
     val kdoc: KDoc = KDoc(),
@@ -136,7 +136,7 @@ annotation class SealedCopy(
      * `Custom` branch instead of `this.copy(...)`.
      */
     @Target(AnnotationTarget.FUNCTION)
-    annotation class Map
+    public annotation class Map
 
     /**
      * Remove the auto-copy default from a sealed parent's abstract property, making the
@@ -174,7 +174,7 @@ annotation class SealedCopy(
      * @see CopyToChildren.Exclude
      */
     @Target(AnnotationTarget.PROPERTY)
-    annotation class Exclude
+    public annotation class Exclude
 }
 
 /**
@@ -203,7 +203,7 @@ annotation class SealedCopy(
  *
  * @see SealedCopy.nonCopyableStrategy
  */
-enum class NonCopyableStrategy {
+public enum class NonCopyableStrategy {
     /**
      * Refuse to generate the function. The KSP processor raises an
      * `InvalidCreamUsageException` whose message names the offending subtype(s) and


### PR DESCRIPTION
## 概要

Closes #140

公開3モジュール（`cream-runtime` / `cream-ksp` / `cream-ksp:shared`）で Kotlin の strict `explicitApi()` を有効化し、公開宣言の可視性（および推論されていた返り値型）を明示しました。

## 方針

「公開3モジュールを strict で適用」という確認結果に基づき、**暗黙の可視性を明示化する純加算的な変更**に限定しています（実態としての公開範囲は変えない）。

- **cream-runtime**: 利用者向けアノテーション / enum / name token は本ライブラリの公開 API → `public`。
- **cream-ksp:shared**: `@InternalCreamApi` で公開している options / naming / exception ヘルパは cream-ksp・optionBuilder からモジュール跨ぎで参照される → `public`。推論されていた5箇所の返り値型を明示。
- **cream-ksp**: もともと `.claude/rules/ksp-architecture.md` で「`internal` 実装の規約」とされており、実際ほぼ全てが既に `internal`。残っていた3箇所を規約に合わせて `internal` 化。ただし KSP が ServiceLoader でロードする `CreamSymbolProcessorProvider` のみ `public` を維持。

> [!NOTE]
> processor (`cream-ksp`) に残る「偶発的に public な内部実装」をさらに `internal` へ絞り込む監査は、公開 API サーフェスを変える別作業のため follow-up とします。本 PR は explicit API mode を有効化する純加算的変更に留めています。

## 確認

ローカルで検証済み（いずれも **BUILD SUCCESSFUL**、explicit-api エラー 0）:

- 3モジュールの `compileKotlinJvm`
- commonMain が全ターゲットで通ること: cream-runtime の `compileKotlinIosSimulatorArm64` / `compileKotlinJs` / `compileKotlinWasmJs`、cream-ksp:shared の `compileKotlinJs` / `compileKotlinWasmJs`
- `:cream-ksp:test`（architecture(Konsist) / snapshot / diagnostic / options / unit）
- `:test:jvmTest` / `:test:testDebugUnitTest`（生成コードは不変）
- `:cream-runtime:ktlintCheck` / `:cream-ksp:ktlintCheck`（`public` 付与は redundant 判定されず 0 violation）
- `:optionBuilder:sharedUI:compileKotlinJvm`（shared の公開 API 利用側が壊れないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)