### PR TITLE
test: migrate all kotest specs from FunSpec to FreeSpec

### DIFF
--- a/.claude/rules/ksp-test.md
+++ b/.claude/rules/ksp-test.md
@@ -10,8 +10,9 @@ paths:
 (`dev.zacsweers.kctfork:core` / `:ksp`) を使った JVM 専用の end-to-end テストを置いている。
 マルチプラットフォームの `test/` モジュールでは表現しにくいシナリオを補完する。
 
-テストは [kotest](https://kotest.io) の `FunSpec` スタイルで書く
-(`internal class XxxTest : FunSpec({ test("...") { ... } })`)。assert は kotest matcher を使い、
+テストは [kotest](https://kotest.io) の `FreeSpec` スタイルで書く
+(`internal class XxxTest : FreeSpec({ "..." { ... } })`、ネストは `"group" - { "..." { ... } }`)。
+無効化テストは `"...".config(enabled = false) { }`。assert は kotest matcher を使い、
 **語順は `actual shouldBe expected`** (kotlin.test の `assertEquals(expected, actual)` とは逆)。
 失敗時メッセージは `withClue(message) { ... }` で保持する。cream-ksp は JVM のみなので
 `kotest-runner-junit5` + `tasks.test { useJUnitPlatform() }` で動く (KSP も io.kotest プラグインも不要)。
@@ -75,8 +76,8 @@ golden ファイルは `*.md` (Markdown)。すべての captured 値は **facet*
 として書き出される:
 
 ```kt
-internal class MyTest : FunSpec({
-    test("scenario") {
+internal class MyTest : FreeSpec({
+    "scenario" {
         val source = """
             @CopyTo(Target::class)
             data class Source(...)

--- a/.claude/skills/cream-snapshot-test/SKILL.md
+++ b/.claude/skills/cream-snapshot-test/SKILL.md
@@ -181,8 +181,8 @@ family imports. The exact skeleton:
 
 ```kotlin
 internal class <Feat>SnapshotTest :
-    FunSpec({
-        context("All patterns") {
+    FreeSpec({
+        "All patterns" - {
             cartesian(
                 union {
                     withNumberPrefix(length = 2) {
@@ -195,7 +195,7 @@ internal class <Feat>SnapshotTest :
             ).representativeValues()
                 .forEach { (testCaseName, value) ->
                     val (scenario, creamOptions) = value
-                    test(testCaseName!!) {
+                    testCaseName!! {
                         runCompileSnapshotTest(input = scenario.toFileSpec(), options = creamOptions)
                     }
                 }
@@ -278,7 +278,7 @@ report done with an unresolved FAIL. Run the listed command where one is given.
 - [ ] **Structure matches a reference**: `scenario/` package, one file per family, each
   `internal fun <family>Scenarios(): Generator<SnapshotScenario>`; `Utils.kt` has the
   `with<Anno>`/`<anno>` helper with the **annotated/primary declaration as the first arg**; the test
-  is the inline `FunSpec({ context("All patterns") { … } })` skeleton with family order = `NN--` order.
+  is the inline `FreeSpec({ "All patterns" - { … } })` skeleton with family order = `NN--` order.
 - [ ] **Families fit the archetype**: if this is not a 1→1 copy, the report names which of the 11
   families were dropped / recast / added and why (multiSource for combine, hierarchy-shape for
   sealed, annotation-arg `@Map` for mapping), cross-checked against `references/feature-profiles.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,8 +163,9 @@ cream/
 
 ## Testing Approach
 
-All tests use the [kotest](https://kotest.io) `FunSpec` style (`class XxxTest : FunSpec({ test("...") { ... } })`)
-with kotest matchers (`actual shouldBe expected`, `shouldBeInstanceOf`, `shouldContain`, …). The JVM
+All tests use the [kotest](https://kotest.io) `FreeSpec` style (`class XxxTest : FreeSpec({ "..." { ... } })`,
+nested groups via `"group" - { "..." { ... } }`) with kotest matchers (`actual shouldBe expected`,
+`shouldBeInstanceOf`, `shouldContain`, …). The JVM
 (`cream-ksp`, `test` jvm) and Android unit-test tasks run via the JUnit Platform (`kotest-runner-junit5`
 + `useJUnitPlatform()`); native/`commonTest` runs via `kotest-framework-engine` and the `io.kotest`
 KSP plugin (which generates a per-target spec launcher). Note for native: spec classes must have unique
@@ -186,8 +187,8 @@ data class Source(val prop: String)
 data class Target(val prop: String, val extra: Int)
 
 // test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/CopyToTest.kt
-class CopyToTest : FunSpec({
-    test("testCopyFunction") {
+class CopyToTest : FreeSpec({
+    "testCopyFunction" {
         val source = Source("value")
         val target = source.copyToTarget(extra = 42)
         target.prop shouldBe "value"

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/AllKotlinFilesTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/AllKotlinFilesTest.kt
@@ -2,7 +2,7 @@ package me.tbsten.cream.ksp
 
 import com.lemonappdev.konsist.api.verify.assertFalse
 import com.lemonappdev.konsist.api.verify.assertTrue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.testing.konsist.FILE_LINE_LIMIT_OVERRIDES
 import me.tbsten.cream.ksp.testing.konsist.KSP_ROOT
 import me.tbsten.cream.ksp.testing.konsist.MAX_FILE_LINES
@@ -23,10 +23,10 @@ import me.tbsten.cream.ksp.testing.konsist.creamKspMain
  * symbols rather than using wildcard or fully-qualified inline references.
  */
 internal class AllKotlinFilesTest :
-    FunSpec(
+    FreeSpec(
         {
-            context("root レイヤ（composition root）") {
-                test("直下には承認済みファイル（CreamSymbolProcessor / Provider / ProcessContext）以外を置かない") {
+            "root レイヤ（composition root）" - {
+                "直下には承認済みファイル（CreamSymbolProcessor / Provider / ProcessContext）以外を置かない" {
                     // The root package is the composition root only. Generation logic, helpers, exceptions
                     // (which live in :cream-ksp:shared), etc. must NOT be added here.
                     creamKspMain
@@ -35,8 +35,8 @@ internal class AllKotlinFilesTest :
                 }
             }
 
-            context("ファイル全般（モジュール共通）") {
-                test("1 ファイル原則 $MAX_FILE_LINES 行以内（FILE_LINE_LIMIT_OVERRIDES のファイルは個別上限）") {
+            "ファイル全般（モジュール共通）" - {
+                "1 ファイル原則 $MAX_FILE_LINES 行以内（FILE_LINE_LIMIT_OVERRIDES のファイルは個別上限）" {
                     creamKspMain.assertFalse { file ->
                         val limit = FILE_LINE_LIMIT_OVERRIDES[file.nameWithExtension] ?: MAX_FILE_LINES
                         file.text.lines().size > limit

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/MultipleDiagnosticsTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/MultipleDiagnosticsTest.kt
@@ -2,7 +2,7 @@ package me.tbsten.cream.ksp
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import me.tbsten.cream.ksp.testing.compile.compileWithCream
@@ -16,8 +16,8 @@ import me.tbsten.cream.ksp.testing.snapshot.assertMatchesSnapshot
  * surface from one compile, so a regression to fail-fast (only the first error shown) is caught.
  */
 internal class MultipleDiagnosticsTest :
-    FunSpec({
-        test("reportsEveryMisuseInOneRound") {
+    FreeSpec({
+        "reportsEveryMisuseInOneRound" {
             val source =
                 """
                 package multi.diag

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/OptionsDiagnosticTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/OptionsDiagnosticTest.kt
@@ -2,7 +2,7 @@ package me.tbsten.cream.ksp
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import me.tbsten.cream.ksp.testing.compile.compileWithCream
@@ -18,7 +18,7 @@ import me.tbsten.cream.ksp.testing.snapshot.assertMatchesSnapshot
  * offending value.
  */
 internal class OptionsDiagnosticTest :
-    FunSpec({
+    FreeSpec({
         val source =
             """
             package options.diag
@@ -31,7 +31,7 @@ internal class OptionsDiagnosticTest :
             data class Target(val shared: String, val extra: Int)
             """.trimIndent()
 
-        test("invalidNamingStrategy") {
+        "invalidNamingStrategy" {
             val result = compileWithCream(source, options = mapOf("cream.copyFunNamingStrategy" to "not-a-strategy"))
 
             withClue(result.messages) {
@@ -44,7 +44,7 @@ internal class OptionsDiagnosticTest :
             }
         }
 
-        test("invalidEscapeDot") {
+        "invalidEscapeDot" {
             val result = compileWithCream(source, options = mapOf("cream.escapeDot" to "not-an-escape"))
 
             withClue(result.messages) {

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/core/ArchTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/core/ArchTest.kt
@@ -2,7 +2,7 @@ package me.tbsten.cream.ksp.core
 
 import com.lemonappdev.konsist.api.verify.assertFalse
 import com.lemonappdev.konsist.api.verify.assertTrue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.testing.konsist.COMPOSITION_ROOT_TYPES
 import me.tbsten.cream.ksp.testing.konsist.CORE_PACKAGE
 import me.tbsten.cream.ksp.testing.konsist.CORE_SUBPACKAGES
@@ -31,15 +31,15 @@ import me.tbsten.cream.ksp.testing.konsist.inLayer
  * `.claude/rules/ksp-architecture.md`.
  */
 internal class ArchTest :
-    FunSpec({
-        context("core レイヤ") {
-            test("feature レイヤに依存しない") {
+    FreeSpec({
+        "core レイヤ" - {
+            "feature レイヤに依存しない" {
                 creamKspMain
                     .filter { it.inLayer(CORE_PACKAGE) }
                     .assertFalse { file -> file.importsFrom("$FEATURE_PACKAGE.") }
             }
 
-            test("root infra（ProcessContext / CreamSymbolProcessor / Provider）に依存しない") {
+            "root infra（ProcessContext / CreamSymbolProcessor / Provider）に依存しない" {
                 // core receives a narrowed `context(options, logger)` instead of the whole ProcessContext,
                 // and never reaches back into the composition root.
                 creamKspMain
@@ -49,21 +49,21 @@ internal class ArchTest :
                     }
             }
 
-            test("common / copyFun / combineFun / sealedCopy サブパッケージにのみ置く（core/ 直下に .kt を置かない）") {
+            "common / copyFun / combineFun / sealedCopy サブパッケージにのみ置く（core/ 直下に .kt を置かない）" {
                 creamKspMain
                     .filter { it.inLayer(CORE_PACKAGE) }
                     .assertTrue { file -> file.packagee?.name in CORE_SUBPACKAGES }
             }
         }
 
-        context("util レイヤ") {
-            test("core / feature レイヤに依存しない") {
+        "util レイヤ" - {
+            "core / feature レイヤに依存しない" {
                 creamKspMain
                     .filter { it.inLayer(UTIL_PACKAGE) }
                     .assertFalse { file -> file.importsFrom("$CORE_PACKAGE.", "$FEATURE_PACKAGE.") }
             }
 
-            test("cream 固有の型を参照しない（自分自身の util パッケージのみ許可）") {
+            "cream 固有の型を参照しない（自分自身の util パッケージのみ許可）" {
                 // A util file may only reference cream packages that live under `util` itself. Any other
                 // `me.tbsten.cream.*` import (core / feature / ProcessContext / options / runtime annotations, …)
                 // would make it cream-specific and therefore not a generic, reusable helper.
@@ -76,7 +76,7 @@ internal class ArchTest :
                     }
             }
 
-            test("直下（util.ksp を除く）は KSP 型に依存しない（KSP util は util/ksp に置く）") {
+            "直下（util.ksp を除く）は KSP 型に依存しない（KSP util は util/ksp に置く）" {
                 // Helpers that touch the KSP API belong in `util.ksp`. The top-level `util` package stays
                 // Kotlin-only so it can be reused in non-KSP contexts.
                 creamKspMain

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/core/common/CopyFunctionNameTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/core/common/CopyFunctionNameTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.core.common
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.options.ClassDeclarationInfo
 import me.tbsten.cream.ksp.options.CopyFunNamingStrategy
@@ -43,63 +43,63 @@ private val stateSuccess = classInfo("me.tbsten.example", "State.Success")
 private val stateSuccessMoreLoading = classInfo("me.tbsten.example", "State.Success.MoreLoading")
 
 internal class CopyFunctionNameTest :
-    FunSpec({
-        test("under-package, lower-camel-case") {
+    FreeSpec({
+        "under-package, lower-camel-case" {
             val o = options(CopyFunNamingStrategy.`under-package`, EscapeDot.`lower-camel-case`)
             name(source, target, o) shouldBe "copyToTarget"
             name(state, stateSuccess, o) shouldBe "copyToStateSuccess"
         }
 
-        test("diff, lower-camel-case") {
+        "diff, lower-camel-case" {
             val o = options(CopyFunNamingStrategy.`diff`, EscapeDot.`lower-camel-case`)
             name(source, target, o) shouldBe "copyToTargetTarget"
             name(state, stateSuccess, o) shouldBe "copyToSuccess"
         }
 
-        test("simple-name, lower-camel-case") {
+        "simple-name, lower-camel-case" {
             val o = options(CopyFunNamingStrategy.`simple-name`, EscapeDot.`lower-camel-case`)
             name(source, target, o) shouldBe "copyToTarget"
             name(state, stateSuccess, o) shouldBe "copyToSuccess"
         }
 
-        test("full-name, lower-camel-case") {
+        "full-name, lower-camel-case" {
             val o = options(CopyFunNamingStrategy.`full-name`, EscapeDot.`lower-camel-case`)
             name(source, target, o) shouldBe "copyToMeTbstenExampleTargetTarget"
             name(state, stateSuccess, o) shouldBe "copyToMeTbstenExampleStateSuccess"
         }
 
-        test("inner-name, lower-camel-case") {
+        "inner-name, lower-camel-case" {
             val o = options(CopyFunNamingStrategy.`inner-name`, EscapeDot.`lower-camel-case`)
             name(source, target, o) shouldBe "copyToTarget"
             name(state, stateSuccess, o) shouldBe "copyToSuccess"
             name(state, stateSuccessMoreLoading, o) shouldBe "copyToSuccessMoreLoading"
         }
 
-        test("under-package, replace-to-underscore") {
+        "under-package, replace-to-underscore" {
             val o = options(CopyFunNamingStrategy.`under-package`, EscapeDot.`replace-to-underscore`)
             name(source, target, o) shouldBe "copyTo_Target"
             name(state, stateSuccess, o) shouldBe "copyTo_State_Success"
         }
 
-        test("diff, replace-to-underscore") {
+        "diff, replace-to-underscore" {
             val o = options(CopyFunNamingStrategy.`diff`, EscapeDot.`replace-to-underscore`)
             name(source, target, o) shouldBe "copyTo_target_Target"
             name(state, stateSuccess, o) shouldBe "copyTo_Success"
         }
 
-        test("simple-name, replace-to-underscore") {
+        "simple-name, replace-to-underscore" {
             val o = options(CopyFunNamingStrategy.`simple-name`, EscapeDot.`replace-to-underscore`)
             name(source, target, o) shouldBe "copyTo_Target"
             name(state, stateSuccess, o) shouldBe "copyTo_Success"
         }
 
-        test("full-name, replace-to-underscore") {
+        "full-name, replace-to-underscore" {
             val o = options(CopyFunNamingStrategy.`full-name`, EscapeDot.`replace-to-underscore`)
             name(source, target, o) shouldBe "copyTo_me_tbsten_example_target_Target"
             name(state, stateSuccess, o) shouldBe "copyTo_me_tbsten_example_State_Success"
         }
 
-        test("inner-name, replace-to-underscore") {
+        "inner-name, replace-to-underscore" {
             val o = options(CopyFunNamingStrategy.`inner-name`, EscapeDot.`replace-to-underscore`)
             name(source, target, o) shouldBe "copyTo_Target"
             name(state, stateSuccess, o) shouldBe "copyTo_Success"

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/core/common/FunctionNameTemplateTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/core/common/FunctionNameTemplateTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.core.common
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import me.tbsten.cream.CopyTargetFullName
 import me.tbsten.cream.CopyTargetInnerName
@@ -37,43 +37,43 @@ private fun resolve(
 ) = resolveFunNameTemplate(template, source, target, options)
 
 internal class FunctionNameTemplateTest :
-    FunSpec({
-        test("DefaultCopyFunctionName expands to cream's derived name") {
+    FreeSpec({
+        "DefaultCopyFunctionName expands to cream's derived name" {
             resolve(DefaultCopyFunctionName) shouldBe "copyToUiStateSuccess"
         }
 
-        test("Pascal tokens upper-case each dotted segment") {
+        "Pascal tokens upper-case each dotted segment" {
             resolve(CopyTargetSimpleName) shouldBe "Success"
             resolve(CopyTargetUnderPackage) shouldBe "UiStateSuccess"
             resolve(CopyTargetInnerName) shouldBe "Success"
             resolve(CopyTargetFullName) shouldBe "ComExampleUiStateSuccess"
         }
 
-        test("snake tokens lower-case each whole dotted segment") {
+        "snake tokens lower-case each whole dotted segment" {
             resolve(copy_target_simple_name) shouldBe "success"
             resolve(copy_target_under_package) shouldBe "uistate_success"
             resolve(copy_target_inner_name) shouldBe "success"
             resolve(copy_target_full_name) shouldBe "com_example_uistate_success"
         }
 
-        test("tokens can be composed with literal prefixes and suffixes") {
+        "tokens can be composed with literal prefixes and suffixes" {
             resolve("to" + CopyTargetSimpleName) shouldBe "toSuccess"
             resolve("to_" + copy_target_under_package) shouldBe "to_uistate_success"
             resolve(DefaultCopyFunctionName + "OrNull") shouldBe "copyToUiStateSuccessOrNull"
         }
 
-        test("multiple, mid-template, and repeated tokens all expand") {
+        "multiple, mid-template, and repeated tokens all expand" {
             resolve(CopyTargetUnderPackage + "From" + CopyTargetSimpleName) shouldBe "UiStateSuccessFromSuccess"
             resolve("x" + CopyTargetSimpleName + "y") shouldBe "xSuccessy"
             resolve(CopyTargetSimpleName + "_" + copy_target_simple_name) shouldBe "Success_success"
             resolve(CopyTargetSimpleName + CopyTargetSimpleName) shouldBe "SuccessSuccess"
         }
 
-        test("a template with no token is returned verbatim") {
+        "a template with no token is returned verbatim" {
             resolve("toState") shouldBe "toState"
         }
 
-        test("CopyTarget tokens ignore the project naming/escape options but Default follows them") {
+        "CopyTarget tokens ignore the project naming/escape options but Default follows them" {
             val nonDefault =
                 CreamOptions(
                     copyFunNamePrefix = "copyTo",
@@ -88,7 +88,7 @@ internal class FunctionNameTemplateTest :
             resolve(DefaultCopyFunctionName, nonDefault) shouldBe "copyTo_Success"
         }
 
-        test("containsAnyCopyFunNameToken detects tokens") {
+        "containsAnyCopyFunNameToken detects tokens" {
             containsAnyCopyFunNameToken("to" + CopyTargetSimpleName) shouldBe true
             containsAnyCopyFunNameToken(DefaultCopyFunctionName) shouldBe true
             containsAnyCopyFunNameToken("toState") shouldBe false

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/ArchTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/ArchTest.kt
@@ -3,7 +3,7 @@ package me.tbsten.cream.ksp.feature
 import com.lemonappdev.konsist.api.verify.assertFalse
 import com.lemonappdev.konsist.api.verify.assertTrue
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import me.tbsten.cream.ksp.testing.konsist.COMPOSITION_ROOT_TYPES
 import me.tbsten.cream.ksp.testing.konsist.FEATURE_PACKAGE
@@ -25,7 +25,7 @@ import me.tbsten.cream.ksp.testing.konsist.inLayer
  * parameters.
  */
 internal class ArchTest :
-    FunSpec({
+    FreeSpec({
         // Each `feature.<name>` package gets its own sub-context so a violation points straight at the
         // offending feature. The package list is discovered from the scope at registration time.
         val featurePackages =
@@ -34,13 +34,13 @@ internal class ArchTest :
                 .groupBy { it.packagee?.name.orEmpty() }
                 .toSortedMap()
 
-        test("scope に feature パッケージが存在する") {
+        "scope に feature パッケージが存在する" {
             withClue("feature パッケージが 1 つも検出されていない（scope 設定の誤り）") {
                 featurePackages.isNotEmpty() shouldBe true
             }
         }
 
-        test("各ファイルは feature.<name> サブパッケージに置く（feature/ 直下・深いネストを禁止）") {
+        "各ファイルは feature.<name> サブパッケージに置く（feature/ 直下・深いネストを禁止）" {
             creamKspMain
                 .filter { it.inLayer(FEATURE_PACKAGE) }
                 .assertTrue { file ->
@@ -52,8 +52,8 @@ internal class ArchTest :
         }
 
         featurePackages.forEach { (packageName, files) ->
-            context(packageName.substringAfterLast('.')) {
-                test("他の feature を参照しない（feature 間で関数などを使い合わない）") {
+            packageName.substringAfterLast('.') - {
+                "他の feature を参照しない（feature 間で関数などを使い合わない）" {
                     files.assertFalse { file ->
                         file.imports.any { import ->
                             import.name.startsWith("$FEATURE_PACKAGE.") &&
@@ -62,12 +62,12 @@ internal class ArchTest :
                     }
                 }
 
-                test("composition root（CreamSymbolProcessor / Provider）に依存しない（ProcessContext のみ可）") {
+                "composition root（CreamSymbolProcessor / Provider）に依存しない（ProcessContext のみ可）" {
                     // feature は ProcessContext だけを上向きに依存してよく、合成ルート本体には触れない。
                     files.assertFalse { file -> file.importsFrom(*COMPOSITION_ROOT_TYPES) }
                 }
 
-                test("context(ProcessContext) な internal fun processXxx(): List<KSAnnotated> を公開する") {
+                "context(ProcessContext) な internal fun processXxx(): List<KSAnnotated> を公開する" {
                     val entryPoints =
                         files
                             .flatMap { it.functions(includeNested = false, includeLocal = false) }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromBasicUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromBasicUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 正常系 (example-based)。
 internal class CombineFromBasicUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromEdgeUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromEdgeUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — レアケース ＋ @Map / @Exclude 等の意味的ケース。
 internal class CombineFromEdgeUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromInvalidUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromInvalidUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 不正利用 → エラー (diagnostic)。
 internal class CombineFromInvalidUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromPropertyTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromPropertyTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — PBT。可視性 / エスケープ / オプションは Generator 次元で網羅。
 internal class CombineFromPropertyTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromSnapshotTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.feature.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.feature.combineFrom.scenario.excludeScenarios
 import me.tbsten.cream.ksp.feature.combineFrom.scenario.funNameScenarios
 import me.tbsten.cream.ksp.feature.combineFrom.scenario.genericsScenarios
@@ -43,8 +43,8 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  * - #132 + #134 (stacked occurrences merge into one fn) are FROZEN as `// TODO(#132)` / `// TODO(#134)` goldens.
  */
 internal class CombineFromSnapshotTest :
-    FunSpec({
-        context("All patterns") {
+    FreeSpec({
+        "All patterns" - {
             cartesian(
                 union {
                     withNumberPrefix(length = 2) {
@@ -68,7 +68,7 @@ internal class CombineFromSnapshotTest :
                 .forEach { (testCaseName, value) ->
                     val (scenario, creamOptions) = value
 
-                    test(testCaseName!!) {
+                    testCaseName!! {
                         runCompileSnapshotTest(input = scenario.toFileSpec(), options = creamOptions)
                     }
                 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineMapping/CombineMappingBasicUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineMapping/CombineMappingBasicUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 正常系 (example-based)。
 internal class CombineMappingBasicUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineMapping/CombineMappingEdgeUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineMapping/CombineMappingEdgeUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — レアケース ＋ @Map / @Exclude 等の意味的ケース。
 internal class CombineMappingEdgeUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineMapping/CombineMappingInvalidUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineMapping/CombineMappingInvalidUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 不正利用 → エラー (diagnostic)。
 internal class CombineMappingInvalidUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineMapping/CombineMappingPropertyTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineMapping/CombineMappingPropertyTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — PBT。可視性 / エスケープ / オプションは Generator 次元で網羅。
 internal class CombineMappingPropertyTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineMapping/CombineMappingSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineMapping/CombineMappingSnapshotTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.feature.combineMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.feature.combineMapping.scenario.funNameScenarios
 import me.tbsten.cream.ksp.feature.combineMapping.scenario.genericsScenarios
 import me.tbsten.cream.ksp.feature.combineMapping.scenario.kdocScenarios
@@ -39,8 +39,8 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  * - #132 (combine target validation) is FROZEN as `// TODO(#132)` goldens, not patched.
  */
 internal class CombineMappingSnapshotTest :
-    FunSpec({
-        context("All patterns") {
+    FreeSpec({
+        "All patterns" - {
             cartesian(
                 union {
                     withNumberPrefix(length = 2) {
@@ -64,7 +64,7 @@ internal class CombineMappingSnapshotTest :
                 .forEach { (testCaseName, value) ->
                     val (scenario, creamOptions) = value
 
-                    test(testCaseName!!) {
+                    testCaseName!! {
                         runCompileSnapshotTest(input = scenario.toFileSpec(), options = creamOptions)
                     }
                 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineTo/CombineToBasicUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineTo/CombineToBasicUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 正常系 (example-based)。
 internal class CombineToBasicUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineTo/CombineToEdgeUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineTo/CombineToEdgeUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — レアケース ＋ @Map / @Exclude 等の意味的ケース。
 internal class CombineToEdgeUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineTo/CombineToInvalidUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineTo/CombineToInvalidUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 不正利用 → エラー (diagnostic)。
 internal class CombineToInvalidUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineTo/CombineToPropertyTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineTo/CombineToPropertyTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — PBT。可視性 / エスケープ / オプションは Generator 次元で網羅。
 internal class CombineToPropertyTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineTo/CombineToSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineTo/CombineToSnapshotTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.feature.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.feature.combineTo.scenario.deprecatedScenarios
 import me.tbsten.cream.ksp.feature.combineTo.scenario.excludeScenarios
 import me.tbsten.cream.ksp.feature.combineTo.scenario.funNameScenarios
@@ -43,8 +43,8 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  * - #132 (combine lacks copy's `concreteClassRejection`) is FROZEN as `// TODO(#132)` goldens, not patched.
  */
 internal class CombineToSnapshotTest :
-    FunSpec({
-        context("All patterns") {
+    FreeSpec({
+        "All patterns" - {
             cartesian(
                 union {
                     withNumberPrefix(length = 2) {
@@ -68,7 +68,7 @@ internal class CombineToSnapshotTest :
                 .forEach { (testCaseName, value) ->
                     val (scenario, creamOptions) = value
 
-                    test(testCaseName!!) {
+                    testCaseName!! {
                         runCompileSnapshotTest(input = scenario.toFileSpec(), options = creamOptions)
                     }
                 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/CopyFromBasicUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/CopyFromBasicUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 正常系 (example-based)。
 internal class CopyFromBasicUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/CopyFromEdgeUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/CopyFromEdgeUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — レアケース ＋ @Map / @Exclude 等の意味的ケース。
 internal class CopyFromEdgeUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/CopyFromInvalidUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/CopyFromInvalidUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 不正利用 → エラー (diagnostic)。
 internal class CopyFromInvalidUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/CopyFromPropertyTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/CopyFromPropertyTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — PBT。可視性 / エスケープ / オプションは Generator 次元で網羅。
 internal class CopyFromPropertyTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/CopyFromSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/CopyFromSnapshotTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.feature.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.feature.copyFrom.scenario.constructorScenarios
 import me.tbsten.cream.ksp.feature.copyFrom.scenario.excludeScenarios
 import me.tbsten.cream.ksp.feature.copyFrom.scenario.funNameScenarios
@@ -32,8 +32,8 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  *   FROZEN as an OK golden in `targetKind/sealedInterfaceTarget`, not "fixed" — a known shared-core quirk.
  */
 internal class CopyFromSnapshotTest :
-    FunSpec({
-        context("All patterns") {
+    FreeSpec({
+        "All patterns" - {
             cartesian(
                 union {
                     withNumberPrefix(length = 2) {
@@ -57,7 +57,7 @@ internal class CopyFromSnapshotTest :
                 .forEach { (testCaseName, value) ->
                     val (scenario, creamOptions) = value
 
-                    test(testCaseName!!) {
+                    testCaseName!! {
                         runCompileSnapshotTest(input = scenario.toFileSpec(), options = creamOptions)
                     }
                 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingBasicUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingBasicUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 正常系 (example-based)。
 internal class CopyMappingBasicUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingEdgeUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingEdgeUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — レアケース ＋ @Map / @Exclude 等の意味的ケース。
 internal class CopyMappingEdgeUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingInvalidUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingInvalidUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 不正利用 → エラー (diagnostic)。
 internal class CopyMappingInvalidUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingPropertyTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingPropertyTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — PBT。可視性 / エスケープ / オプションは Generator 次元で網羅。
 internal class CopyMappingPropertyTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingSnapshotTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.feature.copyMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.feature.copyMapping.scenario.canReverseScenarios
 import me.tbsten.cream.ksp.feature.copyMapping.scenario.constructorScenarios
 import me.tbsten.cream.ksp.feature.copyMapping.scenario.funNameScenarios
@@ -39,8 +39,8 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  *   FROZEN as a known-quirk golden, not patched.
  */
 internal class CopyMappingSnapshotTest :
-    FunSpec({
-        context("All patterns") {
+    FreeSpec({
+        "All patterns" - {
             cartesian(
                 union {
                     withNumberPrefix(length = 2) {
@@ -65,7 +65,7 @@ internal class CopyMappingSnapshotTest :
                 .forEach { (testCaseName, value) ->
                     val (scenario, creamOptions) = value
 
-                    test(testCaseName!!) {
+                    testCaseName!! {
                         runCompileSnapshotTest(input = scenario.toFileSpec(), options = creamOptions)
                     }
                 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyTo/CopyToBasicUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyTo/CopyToBasicUsageTest.kt
@@ -1,10 +1,10 @@
 package me.tbsten.cream.ksp.feature.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 正常系 (example-based)。
 internal class CopyToBasicUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {
         }
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyTo/CopyToEdgeUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyTo/CopyToEdgeUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — レアケース ＋ @Map / @Exclude 等の意味的ケース。
 internal class CopyToEdgeUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyTo/CopyToInvalidUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyTo/CopyToInvalidUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 不正利用 → エラー (diagnostic)。
 internal class CopyToInvalidUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyTo/CopyToPropertyTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyTo/CopyToPropertyTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — PBT。可視性 / エスケープ / オプションは Generator 次元で網羅。
 internal class CopyToPropertyTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyTo/CopyToSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyTo/CopyToSnapshotTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.feature.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.feature.copyTo.scenario.constructorScenarios
 import me.tbsten.cream.ksp.feature.copyTo.scenario.deprecatedScenarios
 import me.tbsten.cream.ksp.feature.copyTo.scenario.escapingScenarios
@@ -36,8 +36,8 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  * - A standalone data-class `sourceKind` case — data classes are exercised throughout `propertyShape`.
  */
 internal class CopyToSnapshotTest :
-    FunSpec({
-        context("All patterns") {
+    FreeSpec({
+        "All patterns" - {
             cartesian(
                 union {
                     withNumberPrefix(length = 2) {
@@ -63,7 +63,7 @@ internal class CopyToSnapshotTest :
                 .forEach { (testCaseName, value) ->
                     val (scenario, creamOptions) = value
 
-                    test(testCaseName!!) {
+                    testCaseName!! {
                         runCompileSnapshotTest(input = scenario.toFileSpec(), options = creamOptions)
                     }
                 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenBasicUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenBasicUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyToChildren
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 正常系 (example-based)。
 internal class CopyToChildrenBasicUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenEdgeUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenEdgeUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyToChildren
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — レアケース ＋ @Map / @Exclude 等の意味的ケース。
 internal class CopyToChildrenEdgeUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenInvalidUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenInvalidUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyToChildren
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 不正利用 → エラー (diagnostic)。
 internal class CopyToChildrenInvalidUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenPropertyTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenPropertyTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.copyToChildren
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — PBT。可視性 / エスケープ / オプションは Generator 次元で網羅。
 internal class CopyToChildrenPropertyTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenSnapshotTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.feature.copyToChildren
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.feature.copyToChildren.scenario.excludeScenarios
 import me.tbsten.cream.ksp.feature.copyToChildren.scenario.genericsScenarios
 import me.tbsten.cream.ksp.feature.copyToChildren.scenario.hierarchyShapeScenarios
@@ -33,8 +33,8 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  * - `@CopyToChildren` + `@SealedCopy` on one type — cross-feature, belongs in `MultipleDiagnosticsTest`.
  */
 internal class CopyToChildrenSnapshotTest :
-    FunSpec({
-        context("All patterns") {
+    FreeSpec({
+        "All patterns" - {
             cartesian(
                 union {
                     withNumberPrefix(length = 2) {
@@ -54,7 +54,7 @@ internal class CopyToChildrenSnapshotTest :
                 .forEach { (testCaseName, value) ->
                     val (scenario, creamOptions) = value
 
-                    test(testCaseName!!) {
+                    testCaseName!! {
                         runCompileSnapshotTest(input = scenario.toFileSpec(), options = creamOptions)
                     }
                 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/SealedCopyBasicUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/SealedCopyBasicUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.sealedCopy
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 正常系 (example-based)。
 internal class SealedCopyBasicUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/SealedCopyEdgeUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/SealedCopyEdgeUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.sealedCopy
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — レアケース ＋ @Map / @Exclude 等の意味的ケース。
 internal class SealedCopyEdgeUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/SealedCopyInvalidUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/SealedCopyInvalidUsageTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.sealedCopy
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — 不正利用 → エラー (diagnostic)。
 internal class SealedCopyInvalidUsageTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/SealedCopyPropertyTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/SealedCopyPropertyTest.kt
@@ -1,9 +1,9 @@
 package me.tbsten.cream.ksp.feature.sealedCopy
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 
 // TODO(#127): reimplement — PBT。可視性 / エスケープ / オプションは Generator 次元で網羅。
 internal class SealedCopyPropertyTest :
-    FunSpec({
-        xtest("TODO(#127): not yet reimplemented") {}
+    FreeSpec({
+        "TODO(#127): not yet reimplemented".config(enabled = false) {}
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/SealedCopySnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/SealedCopySnapshotTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.feature.sealedCopy
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.feature.sealedCopy.scenario.excludeScenarios
 import me.tbsten.cream.ksp.feature.sealedCopy.scenario.funNameScenarios
 import me.tbsten.cream.ksp.feature.sealedCopy.scenario.genericsScenarios
@@ -38,8 +38,8 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  * - `@SealedCopy` + `@CopyToChildren` on one type — cross-feature, belongs in `MultipleDiagnosticsTest`.
  */
 internal class SealedCopySnapshotTest :
-    FunSpec({
-        context("All patterns") {
+    FreeSpec({
+        "All patterns" - {
             cartesian(
                 union {
                     withNumberPrefix(length = 2) {
@@ -62,7 +62,7 @@ internal class SealedCopySnapshotTest :
                 .forEach { (testCaseName, value) ->
                     val (scenario, creamOptions) = value
 
-                    test(testCaseName!!) {
+                    testCaseName!! {
                         runCompileSnapshotTest(input = scenario.toFileSpec(), options = creamOptions)
                     }
                 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/smoke/ClazzGeneratorSmokeTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/smoke/ClazzGeneratorSmokeTest.kt
@@ -27,7 +27,7 @@ import me.tbsten.cream.ksp.testing.generator.clazz.toSource
 import me.tbsten.cream.ksp.testing.generator.clazz.typeSpec
 import me.tbsten.cream.ksp.testing.generator.util.combineToList
 import me.tbsten.cream.ksp.testing.generator.util.constant
-import io.kotest.core.spec.style.FunSpec as KotestFunSpec
+import io.kotest.core.spec.style.FreeSpec as KotestFreeSpec
 
 /**
  * Smoke test for the KotlinPoet-backed code generators in `testing/generator/clazz/`. Verifies the
@@ -35,9 +35,9 @@ import io.kotest.core.spec.style.FunSpec as KotestFunSpec
  * [Generator.arb] side is usable.
  */
 internal class ClazzGeneratorSmokeTest :
-    KotestFunSpec(
+    KotestFreeSpec(
         {
-            test("basicType generator exposes resolvable representative type names") {
+            "basicType generator exposes resolvable representative type names" {
                 val labels =
                     Generator
                         .basicType()
@@ -47,7 +47,7 @@ internal class ClazzGeneratorSmokeTest :
                 labels shouldBe listOf("String", "Int", "Boolean", "String?", "List<String>")
             }
 
-            test("properties generator yields common property lists") {
+            "properties generator yields common property lists" {
                 val labels =
                     Generator
                         .properties()
@@ -71,7 +71,7 @@ internal class ClazzGeneratorSmokeTest :
                     .map { it.name } shouldBe listOf("int", "long", "float", "double", "boolean", "str", "byte", "short", "char")
             }
 
-            test("dataClassSpec renders a data class from the default property lists") {
+            "dataClassSpec renders a data class from the default property lists" {
                 val sources =
                     Generator
                         .dataClassSpec(name = Generator.constant("Sample"))
@@ -87,7 +87,7 @@ internal class ClazzGeneratorSmokeTest :
                 first shouldContain "str: String"
             }
 
-            test("classSpec emits primary and secondary constructors") {
+            "classSpec emits primary and secondary constructors" {
                 val source =
                     Generator
                         .classSpec(
@@ -112,7 +112,7 @@ internal class ClazzGeneratorSmokeTest :
                 source shouldContain ": this(TODO())"
             }
 
-            test("classSpec properties become body vals, distinct from constructor params") {
+            "classSpec properties become body vals, distinct from constructor params" {
                 val source =
                     Generator
                         .classSpec(
@@ -127,7 +127,7 @@ internal class ClazzGeneratorSmokeTest :
                 source shouldContain "val b: String = TODO()" // body property
             }
 
-            test("enumSpec shares the constructor / body-property model with classSpec") {
+            "enumSpec shares the constructor / body-property model with classSpec" {
                 val source =
                     Generator
                         .enumSpec(
@@ -144,7 +144,7 @@ internal class ClazzGeneratorSmokeTest :
                 source shouldContain "A(TODO())" // constant passes a ctor arg
             }
 
-            test("objectSpec renders an object with member functions") {
+            "objectSpec renders an object with member functions" {
                 val source =
                     Generator
                         .objectSpec(
@@ -159,7 +159,7 @@ internal class ClazzGeneratorSmokeTest :
                 source shouldContain "fun method"
             }
 
-            test("classSpec yields a built TypeSpec that can still be post-processed via toBuilder") {
+            "classSpec yields a built TypeSpec that can still be post-processed via toBuilder" {
                 val type =
                     Generator
                         .classSpec(name = Generator.constant("Foo"))
@@ -178,7 +178,7 @@ internal class ClazzGeneratorSmokeTest :
                 source shouldContain "fun extra"
             }
 
-            test("typeSpec yields a class per (kind x property variation)") {
+            "typeSpec yields a class per (kind x property variation)" {
                 val reps =
                     Generator
                         .typeSpec(name = Generator.constant("Sample"))
@@ -197,7 +197,7 @@ internal class ClazzGeneratorSmokeTest :
                 reps.count { it.label!!.startsWith("object, ") } shouldBe 6
             }
 
-            test("typeSpec renders generic class / interface declarations") {
+            "typeSpec renders generic class / interface declarations" {
                 val sources =
                     Generator
                         .typeSpec(name = Generator.constant("Sample"), kinds = listOf(TypeKind.Class))
@@ -209,7 +209,7 @@ internal class ClazzGeneratorSmokeTest :
                 sources.any { it.contains("public class Sample<K, V>") } shouldBe true
             }
 
-            test("classSpec derives multi-bound type parameters into a where clause") {
+            "classSpec derives multi-bound type parameters into a where clause" {
                 val t = TypeVariableName("T", COMPARABLE.parameterizedBy(TypeVariableName("T")), CHAR_SEQUENCE)
                 val source =
                     Generator
@@ -228,7 +228,7 @@ internal class ClazzGeneratorSmokeTest :
                 source shouldContain "where T : Comparable<T>, T : CharSequence"
             }
 
-            test("classSpec exposes an Arb usable for property tests") {
+            "classSpec exposes an Arb usable for property tests" {
                 val gen = Generator.classSpec(name = Generator.constant("Sample"))
                 gen.arb().take(5).count() shouldBe 5
             }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/smoke/CreamCompilationSmokeTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/smoke/CreamCompilationSmokeTest.kt
@@ -2,7 +2,7 @@ package me.tbsten.cream.ksp.testing.smoke
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import me.tbsten.cream.ksp.testing.compile.compileWithCream
@@ -16,8 +16,8 @@ import me.tbsten.cream.ksp.testing.compile.generatedSourceText
  * and dependency-free so it fails first and points straight at the harness.
  */
 internal class CreamCompilationSmokeTest :
-    FunSpec({
-        test("compiles a minimal @CopyTo source and generates a copy function") {
+    FreeSpec({
+        "compiles a minimal @CopyTo source and generates a copy function" {
             val result =
                 compileWithCream(
                     """
@@ -42,7 +42,7 @@ internal class CreamCompilationSmokeTest :
             }
         }
 
-        test("multi-source DSL compiles when source and target live in separate files") {
+        "multi-source DSL compiles when source and target live in separate files" {
             val result =
                 compileWithCream {
                     "Source.kt" source

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/smoke/GeneratorSmokeTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/smoke/GeneratorSmokeTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.testing.smoke
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.string
@@ -21,9 +21,9 @@ import me.tbsten.cream.ksp.testing.generator.util.union
  * actual snapshot wiring (`<Feat>SnapshotTest`) comes later.
  */
 internal class GeneratorSmokeTest :
-    FunSpec(
+    FreeSpec(
         {
-            test("generator DSL collects representative values (labelled + unlabelled) and exposes an Arb") {
+            "generator DSL collects representative values (labelled + unlabelled) and exposes an Arb" {
                 val names =
                     generator {
                         case("")
@@ -37,24 +37,24 @@ internal class GeneratorSmokeTest :
                 names.arb().take(5).count() shouldBe 5
             }
 
-            test("toGenerator wraps an existing Arb with explicit representative values") {
+            "toGenerator wraps an existing Arb with explicit representative values" {
                 val gen = Arb.string().toGenerator("x", "y")
                 gen.representativeValues().map { it.value }.toList() shouldBe listOf("x", "y")
             }
 
-            test("orNull prepends a null representative value") {
+            "orNull prepends a null representative value" {
                 val gen = Arb.string().toGenerator("x").orNull()
                 gen.representativeValues().map { it.value }.toList() shouldBe listOf(null, "x")
             }
 
-            test("Generator.list derives empty / single / all representatives") {
+            "Generator.list derives empty / single / all representatives" {
                 val element = Arb.string().toGenerator("a", "b")
                 val lists = Generator.list(element)
                 lists.representativeValues().map { it.value }.toList() shouldBe
                     listOf(emptyList(), listOf("a"), listOf("a", "b"))
             }
 
-            test("cartesian merges paired labels with a custom combiner instead of the default \", \" join") {
+            "cartesian merges paired labels with a custom combiner instead of the default \", \" join" {
                 val left =
                     generator {
                         "L1" case "l1"
@@ -75,7 +75,7 @@ internal class GeneratorSmokeTest :
                     .toList() shouldBe listOf("L1 * R1", "L1 * R2", "L2 * R1", "L2 * R2")
             }
 
-            test("combineToList merges per-element labels with a custom combiner") {
+            "combineToList merges per-element labels with a custom combiner" {
                 val a =
                     generator {
                         "A" case "a"
@@ -99,7 +99,7 @@ internal class GeneratorSmokeTest :
                     .label shouldBe "A + B"
             }
 
-            test("cartesian has a 3-arg Triple version and combine scales to 5 / 6 generators") {
+            "cartesian has a 3-arg Triple version and combine scales to 5 / 6 generators" {
                 val a = Arb.string().toGenerator("a1", "a2")
                 val b = Arb.string().toGenerator("b1")
                 val c = Arb.string().toGenerator("c1")
@@ -123,7 +123,7 @@ internal class GeneratorSmokeTest :
                     .toList() shouldBe listOf("a1-b1-c1-d1-e1-f1", "a2-b1-c1-d1-e1-f1")
             }
 
-            test("union builder (re)labels members: prefix keeps sub-labels distinct, index-fallback for unlabelled, full transform") {
+            "union builder (re)labels members: prefix keeps sub-labels distinct, index-fallback for unlabelled, full transform" {
                 val labelled =
                     generator {
                         "X" case "x"
@@ -147,7 +147,7 @@ internal class GeneratorSmokeTest :
                 u.arb().take(5).count() shouldBe 5
             }
 
-            test("union withNumberPrefix auto-numbers cases (0-based) with configurable length / padChar / separator") {
+            "union withNumberPrefix auto-numbers cases (0-based) with configurable length / padChar / separator" {
                 val labelled =
                     generator {
                         "X" case "x"

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/smoke/RunCompileSnapshotTestSmokeTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/smoke/RunCompileSnapshotTestSmokeTest.kt
@@ -10,7 +10,7 @@ import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeSpec
 import com.tschuchort.compiletesting.KotlinCompilation
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import me.tbsten.cream.CopyTo
@@ -28,8 +28,8 @@ import com.squareup.kotlinpoet.FunSpec as PoetFunSpec
  * with `-Dcream.snapshot.update=true` like every other snapshot.
  */
 internal class RunCompileSnapshotTestSmokeTest :
-    FunSpec({
-        test("compiles a @CopyTo FileSpec, exposes the result to assertions, and returns it") {
+    FreeSpec({
+        "compiles a @CopyTo FileSpec, exposes the result to assertions, and returns it" {
             var observed: CreamCompilationResult? = null
 
             val result =

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
             implementation(libs.kotestRunnerJunit5)
         }
         // Android unit tests run on the JVM via the JUnit Platform too, but androidUnitTest does not
-        // inherit jvmTest, so it needs the kotest JUnit5 runner independently to discover FunSpec.
+        // inherit jvmTest, so it needs the kotest JUnit5 runner independently to discover FreeSpec.
         androidUnitTest.dependencies {
             implementation(libs.kotestRunnerJunit5)
         }
@@ -88,7 +88,7 @@ fun Project.setupKspForMultiplatformWorkaround() {
             dependsOn(tasks.named("kspCommonMainKotlinMetadata"))
             // Disable only cream's redundant per-platform *main* generation; keep the *Test KSP tasks
             // alive so the kotest framework can generate its per-target spec launchers (required for
-            // FunSpec to start on native/Android, and harmless on JVM).
+            // FreeSpec to start on native/Android, and harmless on JVM).
             if (!name.contains("Test")) {
                 enabled = false
             }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
             implementation(libs.kotestRunnerJunit5)
         }
         // Android unit tests run on the JVM via the JUnit Platform too, but androidUnitTest does not
-        // inherit jvmTest, so it needs the kotest JUnit5 runner independently to discover FreeSpec.
+        // inherit jvmTest, so it needs the kotest JUnit5 runner independently to discover Kotest specs.
         androidUnitTest.dependencies {
             implementation(libs.kotestRunnerJunit5)
         }
@@ -88,7 +88,7 @@ fun Project.setupKspForMultiplatformWorkaround() {
             dependsOn(tasks.named("kspCommonMainKotlinMetadata"))
             // Disable only cream's redundant per-platform *main* generation; keep the *Test KSP tasks
             // alive so the kotest framework can generate its per-target spec launchers (required for
-            // FreeSpec to start on native/Android, and harmless on JVM).
+            // Kotest specs to start on native/Android, and harmless on JVM).
             if (!name.contains("Test")) {
                 enabled = false
             }

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/BasicTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class BasicTest :
-    FunSpec({
-        test("combineFromTarget") {
+    FreeSpec({
+        "combineFromTarget" {
             val sourceA = SourceStateA(propertyA = "sourceA")
             val sourceB = SourceStateB(propertyB = 42)
 
@@ -26,7 +26,7 @@ class BasicTest :
             result shouldBe expected
         }
 
-        test("combineFromTargetWithOverride") {
+        "combineFromTargetWithOverride" {
             val sourceA = SourceStateA(propertyA = "sourceA")
             val sourceB = SourceStateB(propertyB = 42)
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/FunNameTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/FunNameTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class FunNameTest :
-    FunSpec({
-        test("token override renames the combineFrom function") {
+    FreeSpec({
+        "token override renames the combineFrom function" {
             FunNameA("x").buildFunNameDst(funNameB = FunNameB(1), extra = 2L) shouldBe FunNameDst("x", 1, 2L)
         }
     })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/GenericsTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/GenericsTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class GenericsTest :
-    FunSpec({
-        test("combineFromWithGenerics") {
+    FreeSpec({
+        "combineFromWithGenerics" {
             val sourceA =
                 GenericSourceA(
                     genericProperty = "generic string",
@@ -28,7 +28,7 @@ class GenericsTest :
             result.extraProperty shouldBe 100
         }
 
-        test("combineFromWithComplexGenerics") {
+        "combineFromWithComplexGenerics" {
             val sourceA =
                 GenericSourceA(
                     genericProperty = listOf("a", "b", "c"),

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/MultiSourceTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/MultiSourceTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class MultiSourceTest :
-    FunSpec({
-        test("combineFromFourSources") {
+    FreeSpec({
+        "combineFromFourSources" {
             val sourceA = MultiSourceA(propertyA = "A")
             val sourceB = MultiSourceB(propertyB = 42)
             val sourceC = MultiSourceC(propertyC = true)
@@ -26,7 +26,7 @@ class MultiSourceTest :
             result.extraProperty shouldBe "extra"
         }
 
-        test("combineFromFourSourcesWithOverride") {
+        "combineFromFourSourcesWithOverride" {
             val sourceA = MultiSourceA(propertyA = "A")
             val sourceB = MultiSourceB(propertyB = 42)
             val sourceC = MultiSourceC(propertyC = true)

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/NullableTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/NullableTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class NullableTest :
-    FunSpec({
-        test("combineFromWithNullableProperties") {
+    FreeSpec({
+        "combineFromWithNullableProperties" {
             val sourceA =
                 NullableSourceA(
                     nullableProperty = "value",
@@ -25,7 +25,7 @@ class NullableTest :
             result.extraProperty shouldBe true
         }
 
-        test("combineFromWithNullValues") {
+        "combineFromWithNullValues" {
             val sourceA =
                 NullableSourceA(
                     nullableProperty = null,

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/ObjectTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/ObjectTargetTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 
 class ObjectTargetTest :
-    FunSpec({
-        test("combineFromToObject") {
+    FreeSpec({
+        "combineFromToObject" {
             val sourceA = ObjectSourceA(propertyA = "test")
             val sourceB = ObjectSourceB(propertyB = 42)
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/OverlapTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/OverlapTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class OverlapTest :
-    FunSpec({
-        test("overlappingPropertyPriority") {
+    FreeSpec({
+        "overlappingPropertyPriority" {
             val sourceA =
                 OverlapSourceA(
                     shared = "from A",
@@ -28,7 +28,7 @@ class OverlapTest :
             result.uniqueB shouldBe 42
         }
 
-        test("overlappingPropertyWithExplicitOverride") {
+        "overlappingPropertyWithExplicitOverride" {
             val sourceA =
                 OverlapSourceA(
                     shared = "from A",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/PropertyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/PropertyMappingTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class PropertyMappingTest :
-    FunSpec({
-        test("simplePropertyNameMapping") {
+    FreeSpec({
+        "simplePropertyNameMapping" {
             val sourceA = MappingSourceA(sourcePropertyA = "Hello")
             val sourceB = MappingSourceB(sourcePropertyB = 42)
 
@@ -20,7 +20,7 @@ class PropertyMappingTest :
             result.normalProperty shouldBe "World"
         }
 
-        test("multiplePropertyNamesMapping") {
+        "multiplePropertyNamesMapping" {
             val source = MultiMappingSource(sourceName = "SharedValue")
             val sourceB = MultiMappingSourceB(otherProp = 100)
 
@@ -34,7 +34,7 @@ class PropertyMappingTest :
             result.otherProp shouldBe 100
         }
 
-        test("mixedMappingWithDirectMatch") {
+        "mixedMappingWithDirectMatch" {
             val sourceA = MixedMappingSourceA(directMatch = "Direct")
             val sourceB = MixedMappingSourceB(originalProperty = 999)
 
@@ -49,7 +49,7 @@ class PropertyMappingTest :
             result.extraProperty shouldBe true
         }
 
-        test("mergeMappingWithDirectMatch") {
+        "mergeMappingWithDirectMatch" {
             val sourceA = MergeMappingSourceA(sourcePropertyA = "SourceA")
             val sourceB = MergeMappingSourceB(sourcePropertyB = "SourceB")
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/TypeAliasTest.kt
@@ -1,12 +1,12 @@
 package me.tbsten.cream.test.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class TypeAliasTest :
-    FunSpec({
-        test("testCombineFromWithTypeAliasTarget") {
+    FreeSpec({
+        "testCombineFromWithTypeAliasTarget" {
             // Create instances using actual class constructors and assign them to variables with typealias types.
             // Note: Typealiases are just alternative names for the same types.
             val sourceX: SourceXAlias = SourceX(propX = "x-value")
@@ -29,7 +29,7 @@ class TypeAliasTest :
             result.shouldBeInstanceOf<CombinedResult>()
         }
 
-        test("testCombineFromPreservesAllSourceProperties") {
+        "testCombineFromPreservesAllSourceProperties" {
             val sourceX: SourceXAlias = SourceX(propX = "test-x")
             val sourceY: SourceYAlias = SourceY(propY = 200)
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/VisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineFrom/VisibilityTest.kt
@@ -1,13 +1,13 @@
 package me.tbsten.cream.test.combineFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class VisibilityTest :
-    FunSpec({
+    FreeSpec({
         // The generated function being `internal` is verified at compile time: this test
         // (in the same module) can call it. A `public`-only caller would not compile.
-        test("internalVisibilityCombineFunctionIsCallable") {
+        "internalVisibilityCombineFunctionIsCallable" {
             val source = InternalVisibilityCombineSource(shared = "value")
             val target: InternalVisibilityCombineTarget =
                 source.copyToInternalVisibilityCombineTarget(extra = 42)

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/BasicTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class BasicTest :
-    FunSpec({
-        test("basicCombineMapping") {
+    FreeSpec({
+        "basicCombineMapping" {
             val libA =
                 LibAModel(
                     nameA = "NameA",
@@ -35,7 +35,7 @@ class BasicTest :
             result shouldBe expected
         }
 
-        test("basicCombineMappingWithOverride") {
+        "basicCombineMappingWithOverride" {
             val libA =
                 LibAModel(
                     nameA = "NameA",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/FunNameTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/FunNameTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class FunNameTest :
-    FunSpec({
-        test("token override renames the combineMapping function") {
+    FreeSpec({
+        "token override renames the combineMapping function" {
             FunNameCmA("x").toFunNameCmDst(funNameCmB = FunNameCmB(1), extra = 2L) shouldBe
                 FunNameCmDst("x", 1, 2L)
         }

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/MultiSourceTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/MultiSourceTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class MultiSourceTest :
-    FunSpec({
-        test("tripleSourceCombineMapping") {
+    FreeSpec({
+        "tripleSourceCombineMapping" {
             val libA =
                 LibAModel(
                     nameA = "A",
@@ -41,7 +41,7 @@ class MultiSourceTest :
             result shouldBe expected
         }
 
-        test("tripleSourceCombineMappingWithOverride") {
+        "tripleSourceCombineMappingWithOverride" {
             val libA =
                 LibAModel(
                     nameA = "A",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/OverlapTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/OverlapTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class OverlapTest :
-    FunSpec({
-        test("combineMappingWithOverlap") {
+    FreeSpec({
+        "combineMappingWithOverlap" {
             val libD =
                 LibDModel(
                     sharedName = "FromD",
@@ -32,7 +32,7 @@ class OverlapTest :
             result shouldBe expected
         }
 
-        test("combineMappingWithOverlapAndOverride") {
+        "combineMappingWithOverlapAndOverride" {
             val libD =
                 LibDModel(
                     sharedName = "FromD",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/PropertyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/PropertyMappingTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class PropertyMappingTest :
-    FunSpec({
-        test("combineMappingWithPropertyNames") {
+    FreeSpec({
+        "combineMappingWithPropertyNames" {
             val libA =
                 LibAModel(
                     nameA = "SourceNameA",
@@ -35,7 +35,7 @@ class PropertyMappingTest :
             result shouldBe expected
         }
 
-        test("combineMappingWithPropertyNamesAndOverride") {
+        "combineMappingWithPropertyNamesAndOverride" {
             val libA =
                 LibAModel(
                     nameA = "SourceNameA",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineMapping/TypeAliasTest.kt
@@ -1,13 +1,13 @@
 package me.tbsten.cream.test.combineMapping
 
 import io.kotest.assertions.assertSoftly
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class TypeAliasTest :
-    FunSpec({
-        test("combineMappingResolvesTypeAliasSourcesAndTarget") {
+    FreeSpec({
+        "combineMappingResolvesTypeAliasSourcesAndTarget" {
             // sources and target are declared via type aliases, but the generated function
             // is named after / typed by the resolved classes.
             val first: LibAliasFirstSource = LibAliasFirstModel(firstName = "First", firstValue = 10)
@@ -29,7 +29,7 @@ class TypeAliasTest :
             }
         }
 
-        test("combineMappingTypeAliasAllowsOverride") {
+        "combineMappingTypeAliasAllowsOverride" {
             val first: LibAliasFirstSource = LibAliasFirstModel(firstName = "First", firstValue = 10)
             val second: LibAliasSecondSource = LibAliasSecondModel(secondName = "Second", secondValue = 2.5)
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/BasicTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class BasicTest :
-    FunSpec({
-        test("combineToTarget") {
+    FreeSpec({
+        "combineToTarget" {
             val sourceA = SourceStateA(propertyA = "sourceA")
             val sourceB = SourceStateB(propertyB = 42)
 
@@ -26,7 +26,7 @@ class BasicTest :
             result shouldBe expected
         }
 
-        test("combineToTargetWithOverride") {
+        "combineToTargetWithOverride" {
             val sourceA = SourceStateA(propertyA = "sourceA")
             val sourceB = SourceStateB(propertyB = 42)
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/FunNameTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/FunNameTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class FunNameTest :
-    FunSpec({
-        test("token override renames the combineTo function") {
+    FreeSpec({
+        "token override renames the combineTo function" {
             FunNameSrc("x").toFunNameDst(extra = 1) shouldBe FunNameDst("x", 1)
         }
     })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/GenericsTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/GenericsTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class GenericsTest :
-    FunSpec({
-        test("combineWithGenerics") {
+    FreeSpec({
+        "combineWithGenerics" {
             val sourceA = GenericSourceA(genericProperty = 123)
             val sourceB = GenericSourceB(normalProperty = "normal")
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/MultiSourceTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/MultiSourceTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class MultiSourceTest :
-    FunSpec({
-        test("combineMultipleSources") {
+    FreeSpec({
+        "combineMultipleSources" {
             val sourceA = MultiSourceA(propertyA = "A")
             val sourceB = MultiSourceB(propertyB = 1)
             val sourceC = MultiSourceC(propertyC = true)

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/NullableTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/NullableTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class NullableTest :
-    FunSpec({
-        test("combineWithNullableProperties") {
+    FreeSpec({
+        "combineWithNullableProperties" {
             val sourceA = NullableSourceA(nullableProperty = "nullable value")
             val sourceB = NullableSourceB(requiredProperty = "required")
 
@@ -23,7 +23,7 @@ class NullableTest :
             result shouldBe expected
         }
 
-        test("combineWithNullableNull") {
+        "combineWithNullableNull" {
             val sourceA = NullableSourceA(nullableProperty = null)
             val sourceB = NullableSourceB(requiredProperty = "required")
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/ObjectTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/ObjectTargetTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 
 class ObjectTargetTest :
-    FunSpec({
-        test("combineToObject") {
+    FreeSpec({
+        "combineToObject" {
             val sourceA = ObjectSourceA(propertyA = "test")
             val sourceB = ObjectSourceB(propertyB = 42)
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/OverlapTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/OverlapTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class OverlapTest :
-    FunSpec({
-        test("combineWithOverlappingProperties") {
+    FreeSpec({
+        "combineWithOverlappingProperties" {
             val sourceA = OverlapSourceA(sharedProperty = "from A", uniqueA = 42)
             val sourceB = OverlapSourceB(sharedProperty = "from B", uniqueB = true)
 
@@ -25,7 +25,7 @@ class OverlapTest :
             result shouldBe expected
         }
 
-        test("combineWithOverlappingPropertiesWithOverrides") {
+        "combineWithOverlappingPropertiesWithOverrides" {
             val sourceA = OverlapSourceA(sharedProperty = "from A", uniqueA = 42)
             val sourceB = OverlapSourceB(sharedProperty = "from B", uniqueB = true)
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/PropertyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/PropertyMappingTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class PropertyMappingTest :
-    FunSpec({
-        test("simplePropertyNameMapping") {
+    FreeSpec({
+        "simplePropertyNameMapping" {
             val sourceA = MappingSourceA(sourcePropertyA = "Hello")
             val sourceB = MappingSourceB(sourcePropertyB = 42)
 
@@ -20,7 +20,7 @@ class PropertyMappingTest :
             result.normalProperty shouldBe "World"
         }
 
-        test("multiplePropertyNamesMapping") {
+        "multiplePropertyNamesMapping" {
             val source = MultiMappingSource(sourceName = "SharedValue")
             val sourceB = MultiMappingSourceB(otherProp = 100)
 
@@ -34,7 +34,7 @@ class PropertyMappingTest :
             result.otherProp shouldBe 100
         }
 
-        test("mixedMappingWithDirectMatch") {
+        "mixedMappingWithDirectMatch" {
             val sourceA = MixedMappingSourceA(directMatch = "Direct")
             val sourceB = MixedMappingSourceB(originalProperty = 999)
 
@@ -49,7 +49,7 @@ class PropertyMappingTest :
             result.extraProperty shouldBe true
         }
 
-        test("mergeMappingWithDirectMatch") {
+        "mergeMappingWithDirectMatch" {
             val sourceA = MergeMappingSourceA(sourcePropertyA = "SourceA")
             val sourceB = MergeMappingSourceB(sourcePropertyB = "SourceB")
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/TypeAliasTest.kt
@@ -1,12 +1,12 @@
 package me.tbsten.cream.test.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class TypeAliasTest :
-    FunSpec({
-        test("testCombineToWithTypeAliasSource") {
+    FreeSpec({
+        "testCombineToWithTypeAliasSource" {
             // Create instances using actual class constructors and assign them to variables with typealias types.
             // Note: Typealiases are just alternative names for the same types.
             val sourceA: SourceAWithAlias = SourceA(propA = "value-a")
@@ -29,7 +29,7 @@ class TypeAliasTest :
             combined.shouldBeInstanceOf<CombinedTarget>()
         }
 
-        test("testCombineToPreservesAllProperties") {
+        "testCombineToPreservesAllProperties" {
             val sourceA: SourceAWithAlias = SourceA(propA = "test-prop-a")
             val sourceB: SourceBWithAlias = SourceB(propB = 100)
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/VisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/combineTo/VisibilityTest.kt
@@ -1,13 +1,13 @@
 package me.tbsten.cream.test.combineTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class VisibilityTest :
-    FunSpec({
+    FreeSpec({
         // The generated function being `internal` is verified at compile time: this test
         // (in the same module) can call it. A `public`-only caller would not compile.
-        test("internalVisibilityCombineFunctionIsCallable") {
+        "internalVisibilityCombineFunctionIsCallable" {
             val source = InternalVisibilityCombineSource(shared = "value")
             val target: InternalVisibilityCombineTarget =
                 source.copyToInternalVisibilityCombineTarget(extra = 42)

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/BasicTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class BasicTest :
-    FunSpec({
-        test("dataLayerModelToDomainLayerModel") {
+    FreeSpec({
+        "dataLayerModelToDomainLayerModel" {
             val dataLayerModel: DataLayerModel =
                 DataLayerModel(
                     prop1 = "prop1",
@@ -23,7 +23,7 @@ class BasicTest :
             }
         }
 
-        test("domainLayerModelToDataLayerModel") {
+        "domainLayerModelToDataLayerModel" {
             val domainLayerModel: DomainLayerModel =
                 DomainLayerModel(
                     prop1 = "prop1",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/ComplexTypesTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/ComplexTypesTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class ComplexTypesTest :
-    FunSpec({
-        test("complexTypes") {
+    FreeSpec({
+        "complexTypes" {
             val source =
                 ComplexTypeSource(
                     stringList = listOf("a", "b", "c"),
@@ -24,7 +24,7 @@ class ComplexTypesTest :
                 )
         }
 
-        test("complexTypesWithNull") {
+        "complexTypesWithNull" {
             val source =
                 ComplexTypeSource(
                     stringList = listOf("a", "b", "c"),

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/FunNameTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/FunNameTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class FunNameTest :
-    FunSpec({
-        test("token override renames the copyFrom function") {
+    FreeSpec({
+        "token override renames the copyFrom function" {
             FunNameSrc("x").buildFunNameDst(extra = 1) shouldBe FunNameDst("x", 1)
         }
     })

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/NestedTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/NestedTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class NestedTest :
-    FunSpec({
-        test("nestedClasses") {
+    FreeSpec({
+        "nestedClasses" {
             val parent = ParentClass("parent", 100)
             val source = NestedSource(parent)
             val target: NestedTarget = source.copyToNestedTarget(newProperty = "new")

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/NullableTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/NullableTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class NullableTest :
-    FunSpec({
-        test("nonNullableToNullable") {
+    FreeSpec({
+        "nonNullableToNullable" {
             val source =
                 NonNullableSource(
                     str = "test string",
@@ -26,7 +26,7 @@ class NullableTest :
                 )
         }
 
-        test("nonNullableToNullableWithEmptyValues") {
+        "nonNullableToNullableWithEmptyValues" {
             val source =
                 NonNullableSource(
                     str = "",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/ObjectTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/ObjectTargetTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class ObjectTargetTest :
-    FunSpec({
-        test("dataObjectToDataObject") {
+    FreeSpec({
+        "dataObjectToDataObject" {
             val source = EmptySource
             val target: EmptyTarget = source.copyToEmptyTarget()
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/PropertyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/PropertyMappingTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class PropertyMappingTest :
-    FunSpec({
-        test("propertyMapping") {
+    FreeSpec({
+        "propertyMapping" {
             val dataModel =
                 DataModel(
                     dataId = "test-id",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/TypeAliasTest.kt
@@ -1,12 +1,12 @@
 package me.tbsten.cream.test.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class TypeAliasTest :
-    FunSpec({
-        test("testCopyFromTypeAlias") {
+    FreeSpec({
+        "testCopyFromTypeAlias" {
             // Create a SourceModel instance and assign it to a variable typed as SourceModelAlias.
             // Note: SourceModelAlias is just a type alias for SourceModel.
             val sourceModel: SourceModelAlias = SourceModel(value = "test-value")
@@ -22,7 +22,7 @@ class TypeAliasTest :
             targetModel.shouldBeInstanceOf<TargetModel>()
         }
 
-        test("testTypeAliasPreservesValue") {
+        "testTypeAliasPreservesValue" {
             val original: SourceModelAlias = SourceModel(value = "original-value")
             val copied: TargetModelAlias = original.copyToTargetModel()
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/VisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyFrom/VisibilityTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyFrom
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class VisibilityTest :
-    FunSpec({
-        test("visibilityProperties") {
+    FreeSpec({
+        "visibilityProperties" {
             val source = VisibilitySource("public", 42, true)
             val target: VisibilityTarget = source.copyToVisibilityTarget(newProperty = "new")
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/CopyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/CopyMappingTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class CopyMappingTest :
-    FunSpec({
-        test("libXModelToLibYModel") {
+    FreeSpec({
+        "libXModelToLibYModel" {
             val libXModel =
                 LibXModel(
                     shareProp = "shared",
@@ -26,7 +26,7 @@ class CopyMappingTest :
             result shouldBe expected
         }
 
-        test("libXModelToLibYModelWithOverride") {
+        "libXModelToLibYModelWithOverride" {
             val libXModel =
                 LibXModel(
                     shareProp = "shared",
@@ -48,7 +48,7 @@ class CopyMappingTest :
             result shouldBe expected
         }
 
-        test("libYModelToLibZModel") {
+        "libYModelToLibZModel" {
             val libYModel =
                 LibYModel(
                     shareProp = "shared",
@@ -69,7 +69,7 @@ class CopyMappingTest :
             result shouldBe expected
         }
 
-        test("libYModelToLibZModelWithOverride") {
+        "libYModelToLibZModelWithOverride" {
             val libYModel =
                 LibYModel(
                     shareProp = "shared",
@@ -91,7 +91,7 @@ class CopyMappingTest :
             result shouldBe expected
         }
 
-        test("libXModelToLibYModelWithPropertyMapping") {
+        "libXModelToLibYModelWithPropertyMapping" {
             // Test that xProp from LibXModel maps to yProp in LibYModel
             // via the CopyMapping.Map property mapping
             val libXModel =
@@ -111,7 +111,7 @@ class CopyMappingTest :
             result shouldBe expected
         }
 
-        test("libXModelToLibYModelWithPropertyMappingAndOverride") {
+        "libXModelToLibYModelWithPropertyMappingAndOverride" {
             // Test that property mapping can be overridden
             val libXModel =
                 LibXModel(
@@ -133,7 +133,7 @@ class CopyMappingTest :
             result shouldBe expected
         }
 
-        test("libWModelToLibVModelWithCanReverse") {
+        "libWModelToLibVModelWithCanReverse" {
             val libWModel =
                 LibWModel(
                     shareProp = "shared",
@@ -154,7 +154,7 @@ class CopyMappingTest :
             result shouldBe expected
         }
 
-        test("libVModelToLibWModelWithCanReverse") {
+        "libVModelToLibWModelWithCanReverse" {
             val libVModel =
                 LibVModel(
                     shareProp = "shared",
@@ -175,7 +175,7 @@ class CopyMappingTest :
             result shouldBe expected
         }
 
-        test("libWModelToLibVModelWithCanReverseAndOverride") {
+        "libWModelToLibVModelWithCanReverseAndOverride" {
             val libWModel =
                 LibWModel(
                     shareProp = "shared",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/FunNameTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/FunNameTest.kt
@@ -1,15 +1,15 @@
 package me.tbsten.cream.test.copyMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class FunNameTest :
-    FunSpec({
-        test("token override renames the copyMapping function") {
+    FreeSpec({
+        "token override renames the copyMapping function" {
             FunNameMapA("x").toFunNameMapB(extra = 1) shouldBe FunNameMapB("x", 1)
         }
 
-        test("canReverse with a token names both directions from their own targets") {
+        "canReverse with a token names both directions from their own targets" {
             FunNameRevA("x").toFunNameRevB() shouldBe FunNameRevB("x")
             FunNameRevB("y").toFunNameRevA() shouldBe FunNameRevA("y")
         }

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/TypeAliasTest.kt
@@ -1,13 +1,13 @@
 package me.tbsten.cream.test.copyMapping
 
 import io.kotest.assertions.assertSoftly
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class TypeAliasTest :
-    FunSpec({
-        test("copyMappingResolvesTypeAliasSourceAndTarget") {
+    FreeSpec({
+        "copyMappingResolvesTypeAliasSourceAndTarget" {
             // Source/target are declared via type aliases (LibAliasASource / LibAliasBTarget),
             // but the generated function is named after the resolved class (LibAliasBModel).
             val source: LibAliasASource = LibAliasAModel(shareProp = "shared", aProp = 7)
@@ -21,7 +21,7 @@ class TypeAliasTest :
             }
         }
 
-        test("copyMappingTypeAliasAllowsOverride") {
+        "copyMappingTypeAliasAllowsOverride" {
             val source: LibAliasASource = LibAliasAModel(shareProp = "shared", aProp = 7)
 
             val result = source.copyToLibAliasBModel(shareProp = "overridden", bProp = 100)

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/BasicTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class BasicTest :
-    FunSpec({
-        test("parentToChildren") {
+    FreeSpec({
+        "parentToChildren" {
             val parent: Parent =
                 ChildDataObject
 
@@ -30,7 +30,7 @@ class BasicTest :
             }
         }
 
-        test("parentToChildrenWithOverrideParentProp") {
+        "parentToChildrenWithOverrideParentProp" {
             val parent: Parent =
                 ChildDataObject
 
@@ -58,7 +58,7 @@ class BasicTest :
             }
         }
 
-        test("parentToGrandChildren") {
+        "parentToGrandChildren" {
             val parent: Parent =
                 ChildDataObject
 
@@ -89,7 +89,7 @@ class BasicTest :
             }
         }
 
-        test("parentToGrandChildrenWithOverrideParentProp") {
+        "parentToGrandChildrenWithOverrideParentProp" {
             val parent: Parent = ChildDataObject
 
             mapOf(
@@ -122,7 +122,7 @@ class BasicTest :
             }
         }
 
-        test("childToGrandChildren") {
+        "childToGrandChildren" {
             val child: ChildSealedInterface =
                 GrandChildDataObject
 
@@ -150,7 +150,7 @@ class BasicTest :
             }
         }
 
-        test("childToGrandChildrenWithOverrideChildProp") {
+        "childToGrandChildrenWithOverrideChildProp" {
             val child: ChildSealedInterface = GrandChildDataObject
 
             mapOf(

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/ComplexTypesTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/ComplexTypesTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class ComplexTypesTest :
-    FunSpec({
-        test("complexTypes") {
+    FreeSpec({
+        "complexTypes" {
             val source =
                 ComplexTypeSource(
                     stringList = listOf("a", "b", "c"),
@@ -24,7 +24,7 @@ class ComplexTypesTest :
                 )
         }
 
-        test("complexTypesWithNull") {
+        "complexTypesWithNull" {
             val source =
                 ComplexTypeSource(
                     stringList = listOf("a", "b", "c"),

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/CopyVisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/CopyVisibilityTest.kt
@@ -1,13 +1,13 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class CopyVisibilityTest :
-    FunSpec({
+    FreeSpec({
         // The generated function being `internal` is verified at compile time: this test
         // (in the same module) can call it. A `public`-only caller would not compile.
-        test("internalVisibilityCopyFunctionIsCallable") {
+        "internalVisibilityCopyFunctionIsCallable" {
             val source = InternalVisibilitySource(shared = "value")
             val target: InternalVisibilityTarget = source.copyToInternalVisibilityTarget(extra = 42)
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/FunNameTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/FunNameTest.kt
@@ -1,19 +1,19 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class FunNameTest :
-    FunSpec({
-        test("token override renames the copy function") {
+    FreeSpec({
+        "token override renames the copy function" {
             FunNameSource("x").toFunNameTarget(extra = 1) shouldBe FunNameTarget("x", 1)
         }
 
-        test("backtick-quoted funName is callable") {
+        "backtick-quoted funName is callable" {
             FunNameBacktickSource("x").`to backtick`() shouldBe FunNameBacktickTarget("x")
         }
 
-        test("sealed target names each child function from its own child") {
+        "sealed target names each child function from its own child" {
             val source = FunNameStateSource("i")
             source.intoA() shouldBe FunNameState.A("i")
             source.intoB(x = 5) shouldBe FunNameState.B("i", 5)

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/KDocTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/KDocTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 /**
@@ -11,8 +11,8 @@ import io.kotest.matchers.shouldBe
  * break code generation or the runtime behavior of the generated copy function.
  */
 class KDocTest :
-    FunSpec({
-        test("copyToKDocTarget_behavesNormally_evenWhenKDocIsProvided") {
+    FreeSpec({
+        "copyToKDocTarget_behavesNormally_evenWhenKDocIsProvided" {
             val source = KDocSource(shared = "value", onlyOnSource = 1)
 
             val target = source.copyToKDocTarget(extra = 42)

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/NestedTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/NestedTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class NestedTest :
-    FunSpec({
-        test("nestedClasses") {
+    FreeSpec({
+        "nestedClasses" {
             val parent = ParentClass("parent", 100)
             val source = NestedSource(parent)
             val target: NestedTarget = source.copyToNestedTarget(newProperty = "new")

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/NullableTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/NullableTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class NullableTest :
-    FunSpec({
-        test("nonNullableToNullable") {
+    FreeSpec({
+        "nonNullableToNullable" {
             val source =
                 NonNullableSource(
                     str = "test string",
@@ -26,7 +26,7 @@ class NullableTest :
                 )
         }
 
-        test("nonNullableToNullableWithEmptyValues") {
+        "nonNullableToNullableWithEmptyValues" {
             val source =
                 NonNullableSource(
                     str = "",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/ObjectTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/ObjectTargetTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class ObjectTargetTest :
-    FunSpec({
-        test("dataObjectToDataObject") {
+    FreeSpec({
+        "dataObjectToDataObject" {
             val source = EmptySource
             val target: EmptyTarget = source.copyToEmptyTarget()
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/PropertyMappingTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/PropertyMappingTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class PropertyMappingTest :
-    FunSpec({
-        test("propertyMapping") {
+    FreeSpec({
+        "propertyMapping" {
             val domainSource =
                 DomainSourceModel(
                     domainId = "test-id",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/TypeAliasTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/TypeAliasTest.kt
@@ -1,12 +1,12 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class TypeAliasTest :
-    FunSpec({
-        test("testCopyToTypeAlias") {
+    FreeSpec({
+        "testCopyToTypeAlias" {
             // Create a DomainModel instance and assign it to a variable typed as DomainModelAlias.
             // Note: DomainModelAlias is just a type alias for DomainModel.
             val domainModel: DomainModelAlias = DomainModel(id = "test-id-123")
@@ -22,7 +22,7 @@ class TypeAliasTest :
             dataModel.shouldBeInstanceOf<DataModel>()
         }
 
-        test("testTypeAliasPreservesIdentity") {
+        "testTypeAliasPreservesIdentity" {
             val original: DomainModelAlias = DomainModel(id = "original-id")
             val copied: DataModelAlias = original.copyToDataModel()
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/VisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/VisibilityTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyTo
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class VisibilityTest :
-    FunSpec({
-        test("visibilityProperties") {
+    FreeSpec({
+        "visibilityProperties" {
             val source = VisibilitySource("public", 42, true)
             val target: VisibilityTarget = source.copyToVisibilityTarget(newProperty = "new")
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/BasicTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyToChildren
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class BasicTest :
-    FunSpec({
-        test("parentToChildren") {
+    FreeSpec({
+        "parentToChildren" {
             val parent: Parent = ChildDataObject
 
             mapOf(
@@ -28,7 +28,7 @@ class BasicTest :
             }
         }
 
-        test("parentToChildrenWithOverrideParentProp") {
+        "parentToChildrenWithOverrideParentProp" {
             val parent: Parent = ChildDataObject
 
             mapOf(
@@ -54,7 +54,7 @@ class BasicTest :
             }
         }
 
-        test("parentToGrandChildren") {
+        "parentToGrandChildren" {
             val parent: Parent = ChildDataObject
 
             mapOf(
@@ -83,7 +83,7 @@ class BasicTest :
             }
         }
 
-        test("parentToGrandChildrenWithOverrideParentProp") {
+        "parentToGrandChildrenWithOverrideParentProp" {
             val parent: Parent = ChildDataObject
 
             mapOf(
@@ -119,7 +119,7 @@ class BasicTest :
         // grandchild leaf from a grandchild-level value still resolves to the Parent extension.
         // Because the receiver is typed as Parent, intermediate (child-level) properties are not
         // carried over automatically and must be supplied explicitly.
-        test("grandChildLevelValueToGrandChildLeafViaAnnotatedClassReceiver") {
+        "grandChildLevelValueToGrandChildLeafViaAnnotatedClassReceiver" {
             val grandChild: GrandChildSealedInterface = GreatGrandChildDataObject
 
             mapOf(

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/ComplexTypesTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/ComplexTypesTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyToChildren
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class ComplexTypesTest :
-    FunSpec({
-        test("complexTypes") {
+    FreeSpec({
+        "complexTypes" {
             val source =
                 ComplexTypeChild1(
                     stringList = listOf("a", "b", "c"),
@@ -21,7 +21,7 @@ class ComplexTypesTest :
                 )
         }
 
-        test("complexTypesWithNull") {
+        "complexTypesWithNull" {
             val source =
                 ComplexTypeChild1(
                     stringList = emptyList(),
@@ -37,7 +37,7 @@ class ComplexTypesTest :
                 )
         }
 
-        test("multipleTransitions") {
+        "multipleTransitions" {
             val source =
                 ComplexTypeChild1(
                     stringList = listOf("a", "b"),

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/NestedTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/NestedTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyToChildren
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class NestedTest :
-    FunSpec({
-        test("nestedClasses") {
+    FreeSpec({
+        "nestedClasses" {
             val parent = ParentClass("test", 100)
             val source = NestedChild1(parent, "test name")
             val target: NestedChild2 = source.copyToNestedChild2(value = 0)

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/ObjectTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/ObjectTargetTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyToChildren
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class ObjectTargetTest :
-    FunSpec({
-        test("dataObjectToDataObject") {
+    FreeSpec({
+        "dataObjectToDataObject" {
             val source = EmptyChild1
             val target: EmptyChild2 = source.copyToEmptyChild2()
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/VisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/VisibilityTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.copyToChildren
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class VisibilityTest :
-    FunSpec({
-        test("visibilityProperties") {
+    FreeSpec({
+        "visibilityProperties" {
             val source = VisibilityChild1(publicProp = "public", internalProp = "internal")
             val target: VisibilityChild2 = source.copyToVisibilityChild2(newProperty = "new")
 

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/exclude/ExcludeTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/exclude/ExcludeTest.kt
@@ -1,32 +1,32 @@
 package me.tbsten.cream.test.exclude
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class ExcludeTest :
-    FunSpec({
+    FreeSpec({
 
-        test("CopyFrom.Exclude - caller-supplied value is reflected") {
+        "CopyFrom.Exclude - caller-supplied value is reflected" {
             val source: CopyFromState = CopyFromState.Loading(name = "alice", count = 5)
             val result = source.copyToCopyFromStateSuccess(count = 99)
             result.name shouldBe "alice"
             result.count shouldBe 99
         }
 
-        test("CopyFrom.Exclude - source value is not auto-copied") {
+        "CopyFrom.Exclude - source value is not auto-copied" {
             val source: CopyFromState = CopyFromState.Loading(name = "bob", count = 5)
             val result = source.copyToCopyFromStateSuccess(count = 0)
             result.count shouldBe 0
         }
 
-        test("CopyTo.Exclude - caller-supplied value is reflected") {
+        "CopyTo.Exclude - caller-supplied value is reflected" {
             val source = CopyToSource(name = "bob", count = 3)
             val result = source.copyToCopyToTarget(count = 42)
             result.name shouldBe "bob"
             result.count shouldBe 42
         }
 
-        test("CombineFrom.Exclude - explicit value is used instead of auto-copied source value") {
+        "CombineFrom.Exclude - explicit value is used instead of auto-copied source value" {
             val loading = CombineFromLoading(itemId = "item-1")
             val action = CombineFromAction(data = "payload")
             val result =
@@ -40,21 +40,21 @@ class ExcludeTest :
             result.extra shouldBe 7
         }
 
-        test("CombineTo.Exclude - explicit value is used instead of auto-copied source value") {
+        "CombineTo.Exclude - explicit value is used instead of auto-copied source value" {
             val source = CombineToSource(itemId = "item-2", sessionId = "session-original")
             val result = source.copyToCombineToTarget(sessionId = "session-new", extra = 0)
             result.itemId shouldBe "item-2"
             result.sessionId shouldBe "session-new"
         }
 
-        test("SealedCopy.Exclude - caller-supplied count is reflected") {
+        "SealedCopy.Exclude - caller-supplied count is reflected" {
             val state: SealedCopyExcludeState =
                 SealedCopyExcludeState.Loading(name = "init", count = 1)
             val result = state.copy(count = 99)
             result shouldBe SealedCopyExcludeState.Loading(name = "init", count = 99)
         }
 
-        test("SealedCopy.Exclude - non-excluded property is still auto-copied") {
+        "SealedCopy.Exclude - non-excluded property is still auto-copied" {
             val state: SealedCopyExcludeState =
                 SealedCopyExcludeState.Success(name = "keep", count = 0, data = "d")
             val result = state.copy(count = 5)
@@ -63,7 +63,7 @@ class ExcludeTest :
             result.data shouldBe "d"
         }
 
-        test("CopyToChildren.Exclude - copyToLoading uses caller-supplied count") {
+        "CopyToChildren.Exclude - copyToLoading uses caller-supplied count" {
             val state: CopyToChildrenExcludeState =
                 CopyToChildrenExcludeState.Loading(sessionId = "s1", count = 0)
             val loading = state.copyToCopyToChildrenExcludeStateLoading(count = 10)
@@ -71,7 +71,7 @@ class ExcludeTest :
             loading.count shouldBe 10
         }
 
-        test("CopyToChildren.Exclude - copyToSuccess also uses caller-supplied count") {
+        "CopyToChildren.Exclude - copyToSuccess also uses caller-supplied count" {
             val state: CopyToChildrenExcludeState =
                 CopyToChildrenExcludeState.Loading(sessionId = "s2", count = 0)
             val success =

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/generic/GenericClassTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/generic/GenericClassTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.generic
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class GenericClassTest :
-    FunSpec({
-        test("twoArgToThreeArg") {
+    FreeSpec({
+        "twoArgToThreeArg" {
             val source =
                 GenericSourceWithTwoTypeArg(
                     a = "test",
@@ -42,7 +42,7 @@ class GenericClassTest :
             }
         }
 
-        test("threeArgToTwoArg") {
+        "threeArgToTwoArg" {
             val source =
                 GenericSourceWithThreeTypeArg(
                     a = "test",
@@ -75,7 +75,7 @@ class GenericClassTest :
             }
         }
 
-        test("threeArgToObject") {
+        "threeArgToObject" {
             val source =
                 GenericSourceWithThreeTypeArg(
                     a = "test",

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/sealedCopy/BasicTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/sealedCopy/BasicTest.kt
@@ -1,20 +1,20 @@
 package me.tbsten.cream.test.sealedCopy
 
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 
 class BasicTest :
-    FunSpec({
-        test("copy_preservesSubtype_andUpdatesSharedProperty") {
+    FreeSpec({
+        "copy_preservesSubtype_andUpdatesSharedProperty" {
             val loading: BasicState = BasicState.Loading(sessionId = "abc", attempt = 1)
             val updated = loading.copy(attempt = 2)
 
             updated shouldBe BasicState.Loading(sessionId = "abc", attempt = 2)
         }
 
-        test("copy_withNoArguments_returnsEquivalentInstance") {
+        "copy_withNoArguments_returnsEquivalentInstance" {
             val success: BasicState =
                 BasicState.Success(sessionId = "abc", attempt = 1, payload = "hi")
 
@@ -23,7 +23,7 @@ class BasicTest :
             updated shouldBe success
         }
 
-        test("copy_dispatchesPerSubtype") {
+        "copy_dispatchesPerSubtype" {
             val states: List<BasicState> =
                 listOf(
                     BasicState.Loading(sessionId = "a", attempt = 1),
@@ -40,7 +40,7 @@ class BasicTest :
             (updated[1] as BasicState.Success).payload shouldBe "x"
         }
 
-        test("copy_doesNotShareIdentityWithReceiver") {
+        "copy_doesNotShareIdentityWithReceiver" {
             val loading = BasicState.Loading(sessionId = "abc", attempt = 1)
 
             val updated = loading.copy()

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/sealedCopy/FunNameTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/sealedCopy/FunNameTest.kt
@@ -1,16 +1,16 @@
 package me.tbsten.cream.test.sealedCopy
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class FunNameTest :
-    FunSpec({
-        test("DefaultCopyFunctionName resolves to copy and the prefix applies") {
+    FreeSpec({
+        "DefaultCopyFunctionName resolves to copy and the prefix applies" {
             val state: FunNameSealed = FunNameSealed.A("i")
             state.mycopy(id = "j") shouldBe FunNameSealed.A("j")
         }
 
-        test("a CopyTarget token renders the sealed type name") {
+        "a CopyTarget token renders the sealed type name" {
             val state: FunNameSealed = FunNameSealed.B("i", 5)
             state.toFunNameSealed(id = "k") shouldBe FunNameSealed.B("k", 5)
         }

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/sealedCopy/MultipleTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/sealedCopy/MultipleTest.kt
@@ -1,14 +1,14 @@
 package me.tbsten.cream.test.sealedCopy
 
 import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 
 class MultipleTest :
-    FunSpec({
-        test("withUpdated_andWithUpdatedOrNull_areBothGenerated") {
+    FreeSpec({
+        "withUpdated_andWithUpdatedOrNull_areBothGenerated" {
             val loading: MultiSealedCopyState =
                 MultiSealedCopyState.Loading(sessionId = "abc")
 
@@ -21,7 +21,7 @@ class MultipleTest :
             viaNullable shouldBe MultiSealedCopyState.Loading(sessionId = "y")
         }
 
-        test("withUpdated_returnsEmptyAsIs_forObjectBranch") {
+        "withUpdated_returnsEmptyAsIs_forObjectBranch" {
             val empty: MultiSealedCopyState = MultiSealedCopyState.Empty
 
             val result = empty.withUpdated(sessionId = "ignored")
@@ -34,7 +34,7 @@ class MultipleTest :
             }
         }
 
-        test("withUpdatedOrNull_returnsNull_forObjectBranch") {
+        "withUpdatedOrNull_returnsNull_forObjectBranch" {
             val empty: MultiSealedCopyState = MultiSealedCopyState.Empty
 
             val result: MultiSealedCopyState? = empty.withUpdatedOrNull(sessionId = "ignored")
@@ -43,7 +43,7 @@ class MultipleTest :
             result shouldBe null
         }
 
-        test("bothStrategies_delegateToCopy_forDataClassBranch") {
+        "bothStrategies_delegateToCopy_forDataClassBranch" {
             val loading: MultiSealedCopyState = MultiSealedCopyState.Loading(sessionId = "abc")
 
             val viaAsIs = loading.withUpdated(sessionId = "x")

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/vararg/VarargTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/vararg/VarargTest.kt
@@ -1,11 +1,11 @@
 package me.tbsten.cream.test.vararg
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 class VarargTest :
-    FunSpec({
-        test("copies a vararg ctor param from the source without an override") {
+    FreeSpec({
+        "copies a vararg ctor param from the source without an override" {
             val source = VarargSource(id = 1, "a", "b", "c")
 
             val target = source.copyToVarargTarget()
@@ -14,7 +14,7 @@ class VarargTest :
             target.tags.toList() shouldBe listOf("a", "b", "c")
         }
 
-        test("overriding a vararg param replaces it while id is carried over from the source") {
+        "overriding a vararg param replaces it while id is carried over from the source" {
             val source = VarargSource(id = 7, "a", "b", "c")
 
             val target = source.copyToVarargTarget(tags = arrayOf("x", "y"))
@@ -23,7 +23,7 @@ class VarargTest :
             target.tags.toList() shouldBe listOf("x", "y")
         }
 
-        test("copies a primitive vararg ctor param from the source") {
+        "copies a primitive vararg ctor param from the source" {
             val source = PrimitiveVarargSource(id = 2, 10, 20, 30)
 
             val target = source.copyToPrimitiveVarargTarget()
@@ -32,7 +32,7 @@ class VarargTest :
             target.nums.toList() shouldBe listOf(10, 20, 30)
         }
 
-        test("copies an Array source property into a vararg target param") {
+        "copies an Array source property into a vararg target param" {
             val source = ArrayToVarargSource(id = 3, arrayOf("a", "b"))
 
             val target = source.copyToArrayToVarargTarget()


### PR DESCRIPTION
## 概要

kotest のテストスタイルを **FunSpec → FreeSpec** に全面移行しました（全 **111 ファイル**：`cream-ksp` + `test` モジュール）。

FreeSpec は StringSpec と同じ leaf 記法 `"name" { }` を持ちつつ、`-` 演算子でネストできるため、`context(...)` ベースのテスト（スナップショット / アーキテクチャ）も自然に表現できます。

## 変換ルール

| 変換前（FunSpec） | 変換後（FreeSpec） |
|---|---|
| `test("x") { }` | `"x" { }` |
| `context("x") { }` | `"x" - { }`（snapshot / arch のネスト） |
| `xtest("x") { }` | `"x".config(enabled = false) { }`（無効化スタブ 32 件） |
| `test(testCaseName!!) { }` | `testCaseName!! { }`（snapshot のマトリクス動的登録） |

### 個別対応した特殊ケース
- KotlinPoet の `FunSpec` との名前衝突回避（`testing/smoke`, scenario 系）
- `import ... FunSpec as KotestFunSpec` エイリアス → `KotestFreeSpec`
- 改行分割された `FunSpec(` （`AllKotlinFilesTest` / `GeneratorSmokeTest`）
- テスト名の文字列内に `context(` を含むケースの保持（`feature/ArchTest`）

## スナップショット golden への影響なし

スナップショットの golden パスは `testCase.parents()`（＝ `context("All patterns")`）に依存しますが、`"All patterns" - { }` コンテナを維持したため **golden ファイル（.md）は 0 件変更**です。

## ドキュメント追従

`CLAUDE.md` / `.claude/rules/ksp-test.md` / `.claude/skills/cream-snapshot-test/SKILL.md` / `test/build.gradle.kts` の FunSpec 記述を FreeSpec に更新。

## 検証

- ✅ `:cream-ksp:test`（snapshot / arch / smoke 実行）— BUILD SUCCESSFUL、失敗 0
- ✅ `:test:jvmTest` — BUILD SUCCESSFUL
- ✅ `ktlintCheck` — BUILD SUCCESSFUL
- ✅ スナップショット golden（.md）0 件変更

> 注: `gradle/libs.versions.toml` の kotest バージョン更新は本リファクタとは無関係なため本 PR には含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAiiB1gueBky3gV7M5DYpW