### PR TITLE
refactor: consolidate omitPackages construction into a core/common helper

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/common/OmitPackages.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/common/OmitPackages.kt
@@ -1,0 +1,5 @@
+package me.tbsten.cream.ksp.core.common
+
+import com.google.devtools.ksp.symbol.KSName
+
+internal fun omitPackagesFor(basePackage: KSName): List<String> = listOf("kotlin", basePackage.asString())

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/combineFrom/ProcessCombineFrom.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/combineFrom/ProcessCombineFrom.kt
@@ -17,6 +17,7 @@ import me.tbsten.cream.ksp.core.common.asDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.createNewKotlinFile
 import me.tbsten.cream.ksp.core.common.fullName
 import me.tbsten.cream.ksp.core.common.funNameTemplate
+import me.tbsten.cream.ksp.core.common.omitPackagesFor
 import me.tbsten.cream.ksp.core.common.reportCreamError
 import me.tbsten.cream.ksp.core.common.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.resolveClassListOrReport
@@ -118,7 +119,7 @@ internal fun processCombineFrom(): List<KSAnnotated> =
                         primarySource = primarySource,
                         otherSources = otherSources,
                         target = targetClass,
-                        omitPackages = listOf("kotlin", primarySource.packageName.asString()),
+                        omitPackages = omitPackagesFor(primarySource.packageName),
                         generateSourceAnnotation = generateSourceAnnotation,
                         annotated = targetDeclaration,
                     )

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/combineMapping/ProcessCombineMapping.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/combineMapping/ProcessCombineMapping.kt
@@ -17,6 +17,7 @@ import me.tbsten.cream.ksp.core.common.annotationsOf
 import me.tbsten.cream.ksp.core.common.asClassDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.createNewKotlinFile
 import me.tbsten.cream.ksp.core.common.fullName
+import me.tbsten.cream.ksp.core.common.omitPackagesFor
 import me.tbsten.cream.ksp.core.common.reportCreamError
 import me.tbsten.cream.ksp.core.common.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.resolveToClassDeclaration
@@ -150,7 +151,7 @@ internal fun processCombineMapping(): List<KSAnnotated> =
                                 primarySource = primarySource,
                                 otherSources = otherSources,
                                 target = mapping.targetClass,
-                                omitPackages = listOf("kotlin", packageName.asString()),
+                                omitPackages = omitPackagesFor(packageName),
                                 generateSourceAnnotation =
                                     GenerateSourceAnnotation.CombineMapping(annotation = mapping.rawAnnotation),
                                 annotated = annotatedDeclaration,

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/combineTo/ProcessCombineTo.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/combineTo/ProcessCombineTo.kt
@@ -16,6 +16,7 @@ import me.tbsten.cream.ksp.core.common.asDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.createNewKotlinFile
 import me.tbsten.cream.ksp.core.common.fullName
 import me.tbsten.cream.ksp.core.common.funNameTemplate
+import me.tbsten.cream.ksp.core.common.omitPackagesFor
 import me.tbsten.cream.ksp.core.common.onInvalid
 import me.tbsten.cream.ksp.core.common.reportCreamError
 import me.tbsten.cream.ksp.core.common.resolveClassDeclarationOrReport
@@ -151,7 +152,7 @@ internal fun processCombineTo(): List<KSAnnotated> =
                             primarySource = sourceClass,
                             otherSources = otherSourceClasses,
                             target = targetClass,
-                            omitPackages = listOf("kotlin", sourceClass.packageName.asString()),
+                            omitPackages = omitPackagesFor(sourceClass.packageName),
                             generateSourceAnnotation = generateSourceAnnotation,
                         )
                     }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/copyFrom/ProcessCopyFrom.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/copyFrom/ProcessCopyFrom.kt
@@ -10,6 +10,7 @@ import me.tbsten.cream.ksp.core.common.annotationsOf
 import me.tbsten.cream.ksp.core.common.asDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.createNewKotlinFile
 import me.tbsten.cream.ksp.core.common.fullName
+import me.tbsten.cream.ksp.core.common.omitPackagesFor
 import me.tbsten.cream.ksp.core.common.onInvalid
 import me.tbsten.cream.ksp.core.common.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.resolveClassListOrReport
@@ -71,7 +72,7 @@ internal fun processCopyFrom(): List<KSAnnotated> =
                         it.appendCopyFunction(
                             source = sourceClass,
                             target = targetClass,
-                            omitPackages = listOf("kotlin", targetClass.packageName.asString()),
+                            omitPackages = omitPackagesFor(targetClass.packageName),
                             generateSourceAnnotation = generateSourceAnnotation,
                             annotated = targetDeclaration,
                         )

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/copyMapping/ProcessCopyMapping.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/copyMapping/ProcessCopyMapping.kt
@@ -17,6 +17,7 @@ import me.tbsten.cream.ksp.core.common.asClassDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.createNewKotlinFile
 import me.tbsten.cream.ksp.core.common.fullName
 import me.tbsten.cream.ksp.core.common.isValid
+import me.tbsten.cream.ksp.core.common.omitPackagesFor
 import me.tbsten.cream.ksp.core.common.reportCreamError
 import me.tbsten.cream.ksp.core.common.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.underPackageName
@@ -153,7 +154,7 @@ internal fun processCopyMapping(): List<KSAnnotated> =
                             it.appendCopyFunction(
                                 source = mapping.sourceClass,
                                 target = mapping.targetClass,
-                                omitPackages = listOf("kotlin", packageName.asString()),
+                                omitPackages = omitPackagesFor(packageName),
                                 generateSourceAnnotation =
                                     GenerateSourceAnnotation.CopyMapping(annotation = mapping.rawAnnotation),
                                 annotated = annotatedDeclaration,
@@ -165,7 +166,7 @@ internal fun processCopyMapping(): List<KSAnnotated> =
                                 it.appendCopyFunction(
                                     source = mapping.targetClass,
                                     target = mapping.sourceClass,
-                                    omitPackages = listOf("kotlin", packageName.asString()),
+                                    omitPackages = omitPackagesFor(packageName),
                                     generateSourceAnnotation =
                                         GenerateSourceAnnotation.CopyMapping(
                                             annotation = mapping.rawAnnotation,

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/copyTo/ProcessCopyTo.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/copyTo/ProcessCopyTo.kt
@@ -13,6 +13,7 @@ import me.tbsten.cream.ksp.core.common.annotationsOf
 import me.tbsten.cream.ksp.core.common.asDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.createNewKotlinFile
 import me.tbsten.cream.ksp.core.common.fullName
+import me.tbsten.cream.ksp.core.common.omitPackagesFor
 import me.tbsten.cream.ksp.core.common.onInvalid
 import me.tbsten.cream.ksp.core.common.resolveClassDeclarationOrReport
 import me.tbsten.cream.ksp.core.common.resolveClassListOrReport
@@ -75,7 +76,7 @@ internal fun processCopyTo(): List<KSAnnotated> =
                         it.appendCopyFunction(
                             source = sourceClass,
                             target = targetClass,
-                            omitPackages = listOf("kotlin", sourceClass.packageName.asString()),
+                            omitPackages = omitPackagesFor(sourceClass.packageName),
                             generateSourceAnnotation = generateSourceAnnotation,
                         )
                     }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/ProcessCopyToChildren.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/ProcessCopyToChildren.kt
@@ -14,6 +14,7 @@ import me.tbsten.cream.ksp.core.common.GenerateSourceAnnotation
 import me.tbsten.cream.ksp.core.common.annotationsOf
 import me.tbsten.cream.ksp.core.common.createNewKotlinFile
 import me.tbsten.cream.ksp.core.common.fullName
+import me.tbsten.cream.ksp.core.common.omitPackagesFor
 import me.tbsten.cream.ksp.core.common.reportCreamError
 import me.tbsten.cream.ksp.core.common.underPackageName
 import me.tbsten.cream.ksp.core.copyFun.appendCopyFunction
@@ -78,11 +79,7 @@ internal fun processCopyToChildren(): List<KSAnnotated> =
                         it.appendCopyFunction(
                             source = sourceSealedClass,
                             target = targetClass,
-                            omitPackages =
-                                listOf(
-                                    "kotlin",
-                                    sourceSealedClass.packageName.asString(),
-                                ),
+                            omitPackages = omitPackagesFor(sourceSealedClass.packageName),
                             generateSourceAnnotation = generateSourceAnnotation,
                         )
                     }

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/ProcessSealedCopy.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/sealedCopy/ProcessSealedCopy.kt
@@ -16,6 +16,7 @@ import me.tbsten.cream.ksp.core.common.annotationsOf
 import me.tbsten.cream.ksp.core.common.createNewKotlinFile
 import me.tbsten.cream.ksp.core.common.fullName
 import me.tbsten.cream.ksp.core.common.funNameTemplate
+import me.tbsten.cream.ksp.core.common.omitPackagesFor
 import me.tbsten.cream.ksp.core.common.reportCreamError
 import me.tbsten.cream.ksp.core.common.resolveSealedCopyFunName
 import me.tbsten.cream.ksp.core.common.underPackageName
@@ -124,7 +125,7 @@ internal fun processSealedCopy(): List<KSAnnotated> =
                             sealedClass = annotated,
                             funName = funName,
                             nonCopyableStrategy = nonCopyableStrategy,
-                            omitPackages = listOf("kotlin", annotated.packageName.asString()),
+                            omitPackages = omitPackagesFor(annotated.packageName),
                             generateSourceAnnotation = GenerateSourceAnnotation.SealedCopy(annotation = sealedAnnotation),
                         )
                     }


### PR DESCRIPTION
## 概要

各 feature processor に重複してハードコードされていた `omitPackages = listOf("kotlin", <基準 package>.asString())` を、`core/common` の 1 ヘルパに集約しました (SSoT)。Issue #136 の修正方針「案 1」(最も低リスク) を採用しています。

## 変更内容

- `core/common/OmitPackages.kt` を新規追加し、`omitPackagesFor(basePackage: KSName): List<String>` を定義 (`listOf("kotlin", basePackage.asString())` を返すだけの小ヘルパ)。
- 全 8 feature processor の 9 サイト (copyMapping のみ 2 箇所) を、この `omitPackagesFor(...)` 呼び出しに置き換え。`"kotlin"` リテラルと list 構築の重複を解消しました。
- 各 feature が渡す **基準 package の選択はそのまま** 維持しています:
  - copyTo → source
  - copyFrom → target
  - copyToChildren → sourceSealed
  - sealedCopy → annotated
  - combineTo → source
  - combineFrom → primarySource
  - copyMapping / combineMapping → packageName
- `core/sealedCopy/SealedCopyTypeRendering.kt` の「`omitPackages` is reserved for future trimming」な経路は **挙動を変えず** (今回は触れていません)。
- feature → core のレイヤリング (Konsist arch test) を維持 (ヘルパは `core/common` に配置)。

## behavior-preserving であることの確認

純粋なリファクタで生成出力は変わりません。以下を確認済みです:

- `:cream-ksp:compileKotlin` / `:cream-ksp:compileTestKotlin` 成功。
- `:cream-ksp:test` (スナップショット全件 + Konsist arch test) BUILD SUCCESSFUL。`cream-ksp/src/test/resources/snapshots/` 配下の golden は **1 件も変化なし** (スナップショット更新フラグは未使用)。
- `:cream-ksp:ktlintFormat` → `:cream-ksp:ktlintCheck` 成功。

## 備考

本 PR は 8 つの feature processor をすべて編集しているため、同じ processor を触る他の open PR とコンフリクトする可能性があります。マージ順によっては rebase が必要になることがあります。

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAiiB1gueBky3gV7M5DYpW