### PR TITLE
feat(cream-runtime): add funName template arg to @CopyToChildren

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -727,8 +727,8 @@ internal fun ServerState.copyToMergedState(
 デフォルトでは、生成される関数名はプロジェクト全体の命名オプション
 (`cream.copyFunNamePrefix` / `cream.copyFunNamingStrategy` / `cream.escapeDot`) から導出されます。
 特定の宣言だけ名前を上書きしたい場合は、copy/combine 系アノテーション (`@CopyTo` / `@CopyFrom` /
-`@CombineTo` / `@CombineFrom` / `@CopyMapping` / `@CombineMapping` / `@SealedCopy`) に `funName`
-を渡します。プロジェクト全体のオプションには影響しません。
+`@CopyToChildren` / `@CombineTo` / `@CombineFrom` / `@CopyMapping` / `@CombineMapping` /
+`@SealedCopy`) に `funName` を渡します。プロジェクト全体のオプションには影響しません。
 
 `funName` は **テンプレート** です。いくつかの `const` トークンが名前の一部に展開されるため、
 既定の名前に prefix/suffix を足したり、ゼロから名前を組み立てたりできます:
@@ -770,10 +770,6 @@ data class Source(/* ... */)
 ```kt
 @CopyTo(Target::class, funName = "`is`")   // 生成: fun Source.`is`(...)
 ```
-
-`@CopyToChildren` は `funName` を取りません — 常に子ごとに1関数を生成するため、単一の名前を適用できない
-からです。それらの名前はプロジェクトの命名オプション、または `@CopyTo` / `@CopyFrom` / `@SealedCopy`
-(これらは `funName` を取ります) で制御してください。
 
 ## 💻 4. 利用例
 

--- a/README.md
+++ b/README.md
@@ -737,9 +737,9 @@ Omitting `visibility` is fully backward compatible — it keeps the previously g
 
 By default cream derives the generated function name from the project-wide naming options
 (`cream.copyFunNamePrefix` / `cream.copyFunNamingStrategy` / `cream.escapeDot`). Pass `funName`
-to a copy/combine annotation (`@CopyTo`, `@CopyFrom`, `@CombineTo`, `@CombineFrom`,
-`@CopyMapping`, `@CombineMapping`, `@SealedCopy`) to override the name for that one declaration,
-without touching the project options.
+to a copy/combine annotation (`@CopyTo`, `@CopyFrom`, `@CopyToChildren`, `@CombineTo`,
+`@CombineFrom`, `@CopyMapping`, `@CombineMapping`, `@SealedCopy`) to override the name for that one
+declaration, without touching the project options.
 
 `funName` is a **template**: a few `const` tokens expand to pieces of the name, so you can keep
 the derived name and only add a prefix/suffix, or build a name from scratch:
@@ -783,10 +783,6 @@ won't compile (cream does not pre-validate the name; the Kotlin compiler reports
 ```kt
 @CopyTo(Target::class, funName = "`is`")   // generates: fun Source.`is`(...)
 ```
-
-`@CopyToChildren` does not take `funName` — it always generates one function per child, so a single
-name cannot apply. Control those names with the project naming options, or with `@CopyTo` /
-`@CopyFrom` / `@SealedCopy` (which do take `funName`).
 
 ## 💻 4. Usage Example
 

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/sealedCopy/SealedCopy.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/sealedCopy/SealedCopy.kt
@@ -10,6 +10,7 @@ import me.tbsten.cream.ksp.core.common.GenerateSourceAnnotation
 import me.tbsten.cream.ksp.core.common.annotationsOf
 import me.tbsten.cream.ksp.core.common.toModifierString
 import me.tbsten.cream.ksp.util.ksp.asString
+import me.tbsten.cream.ksp.util.ksp.collectConcreteSubclasses
 import java.io.BufferedWriter
 
 /**

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/sealedCopy/SealedCopyLeaf.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/sealedCopy/SealedCopyLeaf.kt
@@ -10,7 +10,6 @@ import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.Modifier
 import me.tbsten.cream.SealedCopy
 import me.tbsten.cream.ksp.core.common.annotationsOf
-import me.tbsten.cream.ksp.util.ksp.isSealed
 
 /**
  * A concrete leaf of a `@SealedCopy` hierarchy, classified purely by whether it is **copyable** —
@@ -33,20 +32,6 @@ internal fun KSClassDeclaration.collectAbstractProperties(): List<KSPropertyDecl
     getAllProperties()
         .filter { it.isAbstract() }
         .toList()
-
-/**
- * Walk the sealed hierarchy down to the leaves (data class / object / non-sealed class),
- * flattening intermediate sealed nodes. Lazy so callers can short-circuit and to mirror
- * KSP's own [KSClassDeclaration.getSealedSubclasses] shape.
- */
-internal fun KSClassDeclaration.collectConcreteSubclasses(): Sequence<KSClassDeclaration> =
-    getSealedSubclasses().flatMap { sub ->
-        if (sub.isSealed()) {
-            sub.collectConcreteSubclasses()
-        } else {
-            sequenceOf(sub)
-        }
-    }
 
 /**
  * A leaf is classified purely by whether it is **copyable** — whether there is a

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/ProcessCopyToChildren.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/ProcessCopyToChildren.kt
@@ -3,6 +3,7 @@ package me.tbsten.cream.ksp.feature.copyToChildren
 import com.google.devtools.ksp.isAbstract
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
@@ -15,9 +16,12 @@ import me.tbsten.cream.ksp.core.common.annotationsOf
 import me.tbsten.cream.ksp.core.common.createNewKotlinFile
 import me.tbsten.cream.ksp.core.common.fullName
 import me.tbsten.cream.ksp.core.common.omitPackagesFor
+import me.tbsten.cream.ksp.core.common.onInvalid
 import me.tbsten.cream.ksp.core.common.reportCreamError
 import me.tbsten.cream.ksp.core.common.underPackageName
+import me.tbsten.cream.ksp.core.common.validateFunName
 import me.tbsten.cream.ksp.core.copyFun.appendCopyFunction
+import me.tbsten.cream.ksp.util.ksp.collectConcreteSubclasses
 import me.tbsten.cream.ksp.util.ksp.isSealed
 import me.tbsten.cream.ksp.util.with
 
@@ -44,14 +48,37 @@ internal fun processCopyToChildren(): List<KSAnnotated> =
             }
 
             val sourceSealedClass = copyToChildren
+            val targetClasses = sourceSealedClass.getSealedSubclasses().toList()
+
             // GSA holds the raw annotation; its notCopyToObject getter reads the @CopyToChildren
             // argument (and appendCopyFunction falls back to the cream.notCopyToObject option when unset).
+            // Its funNameTemplate getter reads the @CopyToChildren funName argument, resolved per leaf.
             val generateSourceAnnotation =
                 GenerateSourceAnnotation.CopyToChildren(
                     annotation = sourceSealedClass.annotationsOf(CopyToChildren::class).firstOrNull() ?: return@forEach,
                 )
 
-            val targetClasses = sourceSealedClass.getSealedSubclasses()
+            // @CopyToChildren fans out to every *transitive* concrete leaf (recursing through
+            // intermediate sealed nodes), and object leaves are dropped when notCopyToObject is on.
+            // A plain-literal funName only collides when MORE THAN ONE of those leaves actually
+            // becomes a function, so look at the real generated set — mirroring the generation loop
+            // below — rather than the direct children (which would over-reject a hierarchy whose
+            // single sealed child has just one concrete leaf, or whose surplus leaves are all
+            // suppressed objects). drop(1).any() answers "are there at least two" by short-circuiting
+            // at the second generated leaf instead of counting them all.
+            val notCopyToObject = generateSourceAnnotation.notCopyToObject ?: processContext.options.notCopyToObject
+            val generatesMultipleFunctions =
+                sourceSealedClass
+                    .collectConcreteSubclasses()
+                    .filterNot { leaf -> notCopyToObject && leaf.classKind == ClassKind.OBJECT }
+                    .drop(1)
+                    .any()
+            generateSourceAnnotation
+                .validateFunName(
+                    generatesMultipleFunctions = generatesMultipleFunctions,
+                    declarationFullName = sourceSealedClass.fullName,
+                    ksNode = sourceSealedClass,
+                ).onInvalid { return@forEach }
 
             // Warn for @CopyToChildren.Exclude on non-abstract properties (no-op: not in generated copy functions)
             sourceSealedClass

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/ksp/SealedHierarchy.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/util/ksp/SealedHierarchy.kt
@@ -1,0 +1,18 @@
+package me.tbsten.cream.ksp.util.ksp
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+/**
+ * Walk the sealed hierarchy down to its concrete leaves (data class / object / non-sealed class),
+ * flattening every intermediate sealed node — the transitive analogue of KSP's own direct-children
+ * [KSClassDeclaration.getSealedSubclasses]. Lazy, so callers can short-circuit on the first few
+ * leaves.
+ */
+internal fun KSClassDeclaration.collectConcreteSubclasses(): Sequence<KSClassDeclaration> =
+    getSealedSubclasses().flatMap { sub ->
+        if (sub.isSealed()) {
+            sub.collectConcreteSubclasses()
+        } else {
+            sequenceOf(sub)
+        }
+    }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/CopyToChildrenSnapshotTest.kt
@@ -2,6 +2,7 @@ package me.tbsten.cream.ksp.feature.copyToChildren
 
 import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.feature.copyToChildren.scenario.excludeScenarios
+import me.tbsten.cream.ksp.feature.copyToChildren.scenario.funNameScenarios
 import me.tbsten.cream.ksp.feature.copyToChildren.scenario.genericsScenarios
 import me.tbsten.cream.ksp.feature.copyToChildren.scenario.hierarchyShapeScenarios
 import me.tbsten.cream.ksp.feature.copyToChildren.scenario.kdocScenarios
@@ -29,7 +30,7 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  *   representative reject (enum-child) suffices.
  * - non-data (plain) class leaf and `data object` vs plain `object` leaf — same constructor-call / OBJECT path
  *   as the covered data-class / object leaves (byte-identical).
- * - No `@Map` / `funName` / `@Repeatable` families — `@CopyToChildren` has none of those.
+ * - No `@Map` / `@Repeatable` families — `@CopyToChildren` has neither.
  * - `@CopyToChildren` + `@SealedCopy` on one type — cross-feature, belongs in `MultipleDiagnosticsTest`.
  */
 internal class CopyToChildrenSnapshotTest :
@@ -46,6 +47,7 @@ internal class CopyToChildrenSnapshotTest :
                         "kdoc" case kdocScenarios()
                         "visibility" case visibilityScenarios()
                         "notCopyToObject" case notCopyToObjectScenarios()
+                        "funName" case funNameScenarios()
                     }
                 },
                 Generator.validCreamOptions(),

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/scenario/FunName.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/scenario/FunName.kt
@@ -1,0 +1,105 @@
+package me.tbsten.cream.ksp.feature.copyToChildren.scenario
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.KModifier.SEALED
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.TypeSpec
+import me.tbsten.cream.ksp.testing.generator.Generator
+import me.tbsten.cream.ksp.testing.poet.Prop
+import me.tbsten.cream.ksp.testing.poet.SnapshotScenario
+import me.tbsten.cream.ksp.testing.poet.classNameOf
+import me.tbsten.cream.ksp.testing.poet.snapshotScenarios
+
+private val copyTargetSimpleName = MemberName("me.tbsten.cream", "CopyTargetSimpleName")
+private val defaultCopyFunctionName = MemberName("me.tbsten.cream", "DefaultCopyFunctionName")
+
+private fun literal(name: String): CodeBlock = CodeBlock.of("%S", name)
+
+private fun prefixedToken(prefix: String): CodeBlock = CodeBlock.of("%S + %M", prefix, copyTargetSimpleName)
+
+private fun suffixedDefault(suffix: String): CodeBlock = CodeBlock.of("%M + %S", defaultCopyFunctionName, suffix)
+
+/** sealed parent with two concrete leaves — fans out to more than one per-leaf copy function. */
+private fun twoLeafParent(): TypeSpec =
+    sealedInterfaceParent(
+        "Source",
+        abstractProps = listOf(Prop("id")),
+        children =
+            listOf(
+                childClass("Loading", classNameOf("Source"), overrides = listOf(Prop("id"))),
+                childClass("Done", classNameOf("Source"), overrides = listOf(Prop("id")), extras = listOf(Prop("data", STRING))),
+            ),
+    )
+
+/** sealed parent with exactly one concrete leaf — generates a single function, so a plain literal funName is fine. */
+private fun singleLeafParent(): TypeSpec =
+    sealedInterfaceParent(
+        "Source",
+        abstractProps = listOf(Prop("id")),
+        children = listOf(childClass("Only", classNameOf("Source"), overrides = listOf(Prop("id")))),
+    )
+
+/** sealed branch (itself sealed) under [parent], holding [leaves]. */
+private fun nestedSealedBranch(
+    name: String,
+    parent: ClassName,
+    vararg leaves: TypeSpec,
+): TypeSpec =
+    TypeSpec
+        .interfaceBuilder(name)
+        .addModifiers(SEALED)
+        .addSuperinterface(parent)
+        .apply { leaves.forEach { addType(it) } }
+        .build()
+
+/**
+ * sealed parent whose only direct child is itself sealed and has a single concrete leaf
+ * (Source -> Source.Branch -> Source.Branch.Only). Only one function is generated, so a plain
+ * literal funName does NOT collide — even though the direct child is sealed (the case the old
+ * per-direct-child check wrongly rejected).
+ */
+private fun singleTransitiveLeafParent(): TypeSpec =
+    sealedInterfaceParent(
+        "Source",
+        abstractProps = listOf(Prop("id")),
+        children =
+            listOf(
+                nestedSealedBranch(
+                    "Branch",
+                    classNameOf("Source"),
+                    childClass("Only", classNameOf("Source", "Branch"), overrides = listOf(Prop("id"))),
+                ),
+            ),
+    )
+
+/** sealed parent with one data leaf and one object leaf; notCopyToObject suppresses the object leaf. */
+private fun dataPlusObjectParent(): TypeSpec =
+    sealedInterfaceParent(
+        "Source",
+        children =
+            listOf(
+                childClass("DataChild", classNameOf("Source"), extras = listOf(Prop("a"))),
+                objectChild("ObjectChild", classNameOf("Source")),
+            ),
+    )
+
+internal fun funNameScenarios(): Generator<SnapshotScenario> =
+    Generator.snapshotScenarios(
+        // A per-target token renames every leaf's function uniquely (intoLoading / intoDone).
+        "tokenFunName" to copyToChildren(twoLeafParent(), funName = prefixedToken("into")),
+        // DefaultCopyFunctionName keeps cream's derived per-leaf name and only appends a suffix.
+        "defaultSuffixFunName" to copyToChildren(twoLeafParent(), funName = suffixedDefault("OrNull")),
+        // A plain literal on a multi-leaf parent would collide across leaves and is rejected.
+        "literalFunNameRejected" to copyToChildren(twoLeafParent(), funName = literal("toState")),
+        // A plain literal is allowed when only one function is generated (single direct leaf).
+        "singleLeafLiteralFunName" to copyToChildren(singleLeafParent(), funName = literal("toState")),
+        // A plain literal is allowed when the transitive concrete-leaf set is a single function, even
+        // though the direct child is sealed (one sealed child -> one concrete leaf).
+        "singleTransitiveLeafLiteralFunName" to copyToChildren(singleTransitiveLeafParent(), funName = literal("toState")),
+        // notCopyToObject suppresses the object leaf, leaving a single generated function, so a plain
+        // literal funName is fine even though two leaves exist.
+        "notCopyToObjectSingleLeafLiteralFunName" to
+            copyToChildren(dataPlusObjectParent(), funName = literal("toState"), notCopyToObject = true),
+    )

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/scenario/Utils.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyToChildren/scenario/Utils.kt
@@ -16,11 +16,12 @@ import me.tbsten.cream.CopyVisibility
 import me.tbsten.cream.ksp.testing.poet.Prop
 import me.tbsten.cream.ksp.testing.poet.SnapshotScenario
 
-/** [this] を sealed parent として `@CopyToChildren`（任意で `notCopyToObject` / `visibility` / `kdoc`）を付与する。 */
+/** [this] を sealed parent として `@CopyToChildren`（任意で `notCopyToObject` / `visibility` / `kdoc` / `funName`）を付与する。 */
 internal fun TypeSpec.withCopyToChildren(
     notCopyToObject: Boolean? = null,
     visibility: CopyVisibility? = null,
     kdoc: CodeBlock? = null,
+    funName: CodeBlock? = null,
 ): TypeSpec =
     toBuilder()
         .addAnnotation(
@@ -30,6 +31,7 @@ internal fun TypeSpec.withCopyToChildren(
                     if (notCopyToObject != null) addMember("%L = %L", CopyToChildren::notCopyToObject.name, notCopyToObject)
                     if (visibility != null) addMember("%L = %T.%L", CopyToChildren::visibility.name, CopyVisibility::class, visibility.name)
                     if (kdoc != null) addMember("%L = %L", CopyToChildren::kdoc.name, kdoc)
+                    if (funName != null) addMember("%L = %L", CopyToChildren::funName.name, funName)
                 }.build(),
         ).build()
 
@@ -43,9 +45,10 @@ internal fun copyToChildren(
     notCopyToObject: Boolean? = null,
     visibility: CopyVisibility? = null,
     kdoc: CodeBlock? = null,
+    funName: CodeBlock? = null,
 ): SnapshotScenario =
     SnapshotScenario(
-        listOf(sealedParent.withCopyToChildren(notCopyToObject, visibility, kdoc)) + additionalTopLevel,
+        listOf(sealedParent.withCopyToChildren(notCopyToObject, visibility, kdoc, funName)) + additionalTopLevel,
     )
 
 /** [abstractProps]（注釈/可視性も保持）を持ち [children] を入れ子にした sealed interface。 */

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/defaultSuffixFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/defaultSuffixFunName.md
@@ -1,0 +1,115 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+import me.tbsten.cream.DefaultCopyFunctionName
+
+@CopyToChildren(funName = DefaultCopyFunctionName + "OrNull")
+public sealed interface Source {
+  public val id: String
+
+  public data class Loading(
+    override val id: String,
+  ) : Source
+
+  public data class Done(
+    override val id: String,
+    public val `data`: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Done copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Source_DoneOrNull(data = data)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Source_DoneOrNull(data = data, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Done
+ */
+public fun  me.tbsten.cream.generated.Source.to_Source_DoneOrNull(
+    id: String = this.id,
+    data: String,
+) : me.tbsten.cream.generated.Source.Done = me.tbsten.cream.generated.Source.Done(
+    id = id,
+    data = data,
+)
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Loading copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Source_LoadingOrNull()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Source_LoadingOrNull(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Loading
+ */
+public fun  me.tbsten.cream.generated.Source.to_Source_LoadingOrNull(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Loading = me.tbsten.cream.generated.Source.Loading(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/literalFunNameRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/literalFunNameRejected.md
@@ -1,0 +1,59 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "toState")
+public sealed interface Source {
+  public val id: String
+
+  public data class Loading(
+    override val id: String,
+  ) : Source
+
+  public data class Done(
+    override val id: String,
+    public val `data`: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+COMPILATION_ERROR
+```
+
+## Output:Console
+
+```kt
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:7: Invalid cream usage: @CopyToChildren on me.tbsten.cream.generated.Source sets a fixed funName "toState",
+but it generates more than one function (multiple targets or sources, a sealed
+target, or a reversible mapping). Those functions would all share that name and collide.
+
+Solution: 
+  Include a naming token so each generated function gets a distinct name, e.g.
+    funName = "to" + CopyTargetSimpleName
+  or split the declaration into separate annotations.
+```
+
+## Output:Generated sources
+
+```kt
+
+```

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
@@ -1,0 +1,81 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(
+  notCopyToObject = true,
+  funName = "toState",
+)
+public sealed interface Source {
+  public data class DataChild(
+    public val a: String,
+  ) : Source
+
+  public object ObjectChild : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.DataChild copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(a = a)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(a = a, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.DataChild
+ */
+public fun  me.tbsten.cream.generated.Source.toState(
+    a: String,
+) : me.tbsten.cream.generated.Source.DataChild = me.tbsten.cream.generated.Source.DataChild(
+    a = a,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/singleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/singleLeafLiteralFunName.md
@@ -1,0 +1,78 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "toState")
+public sealed interface Source {
+  public val id: String
+
+  public data class Only(
+    override val id: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Only copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Only
+ */
+public fun  me.tbsten.cream.generated.Source.toState(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Only = me.tbsten.cream.generated.Source.Only(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/singleTransitiveLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/singleTransitiveLeafLiteralFunName.md
@@ -1,0 +1,80 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "toState")
+public sealed interface Source {
+  public val id: String
+
+  public sealed interface Branch : Source {
+    public data class Only(
+      override val id: String,
+    ) : Branch
+  }
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Branch.Only copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Branch.Only
+ */
+public fun  me.tbsten.cream.generated.Source.toState(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Branch.Only = me.tbsten.cream.generated.Source.Branch.Only(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/tokenFunName.md
@@ -1,0 +1,115 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyTargetSimpleName
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "into" + CopyTargetSimpleName)
+public sealed interface Source {
+  public val id: String
+
+  public data class Loading(
+    override val id: String,
+  ) : Source
+
+  public data class Done(
+    override val id: String,
+    public val `data`: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Done copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoDone(data = data)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoDone(data = data, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Done
+ */
+public fun  me.tbsten.cream.generated.Source.intoDone(
+    id: String = this.id,
+    data: String,
+) : me.tbsten.cream.generated.Source.Done = me.tbsten.cream.generated.Source.Done(
+    id = id,
+    data = data,
+)
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Loading copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoLoading()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoLoading(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Loading
+ */
+public fun  me.tbsten.cream.generated.Source.intoLoading(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Loading = me.tbsten.cream.generated.Source.Loading(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/defaultSuffixFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/defaultSuffixFunName.md
@@ -1,0 +1,115 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+import me.tbsten.cream.DefaultCopyFunctionName
+
+@CopyToChildren(funName = DefaultCopyFunctionName + "OrNull")
+public sealed interface Source {
+  public val id: String
+
+  public data class Loading(
+    override val id: String,
+  ) : Source
+
+  public data class Done(
+    override val id: String,
+    public val `data`: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "inner-name")
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Done copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_DoneOrNull(data = data)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_DoneOrNull(data = data, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Done
+ */
+public fun  me.tbsten.cream.generated.Source.to_DoneOrNull(
+    id: String = this.id,
+    data: String,
+) : me.tbsten.cream.generated.Source.Done = me.tbsten.cream.generated.Source.Done(
+    id = id,
+    data = data,
+)
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Loading copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_LoadingOrNull()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_LoadingOrNull(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Loading
+ */
+public fun  me.tbsten.cream.generated.Source.to_LoadingOrNull(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Loading = me.tbsten.cream.generated.Source.Loading(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/literalFunNameRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/literalFunNameRejected.md
@@ -1,0 +1,59 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "toState")
+public sealed interface Source {
+  public val id: String
+
+  public data class Loading(
+    override val id: String,
+  ) : Source
+
+  public data class Done(
+    override val id: String,
+    public val `data`: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "inner-name")
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+COMPILATION_ERROR
+```
+
+## Output:Console
+
+```kt
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:7: Invalid cream usage: @CopyToChildren on me.tbsten.cream.generated.Source sets a fixed funName "toState",
+but it generates more than one function (multiple targets or sources, a sealed
+target, or a reversible mapping). Those functions would all share that name and collide.
+
+Solution: 
+  Include a naming token so each generated function gets a distinct name, e.g.
+    funName = "to" + CopyTargetSimpleName
+  or split the declaration into separate annotations.
+```
+
+## Output:Generated sources
+
+```kt
+
+```

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
@@ -1,0 +1,81 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(
+  notCopyToObject = true,
+  funName = "toState",
+)
+public sealed interface Source {
+  public data class DataChild(
+    public val a: String,
+  ) : Source
+
+  public object ObjectChild : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "inner-name")
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.DataChild copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(a = a)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(a = a, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.DataChild
+ */
+public fun  me.tbsten.cream.generated.Source.toState(
+    a: String,
+) : me.tbsten.cream.generated.Source.DataChild = me.tbsten.cream.generated.Source.DataChild(
+    a = a,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/singleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/singleLeafLiteralFunName.md
@@ -1,0 +1,78 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "toState")
+public sealed interface Source {
+  public val id: String
+
+  public data class Only(
+    override val id: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "inner-name")
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Only copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Only
+ */
+public fun  me.tbsten.cream.generated.Source.toState(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Only = me.tbsten.cream.generated.Source.Only(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/singleTransitiveLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/singleTransitiveLeafLiteralFunName.md
@@ -1,0 +1,80 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "toState")
+public sealed interface Source {
+  public val id: String
+
+  public sealed interface Branch : Source {
+    public data class Only(
+      override val id: String,
+    ) : Branch
+  }
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "inner-name")
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Branch.Only copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Branch.Only
+ */
+public fun  me.tbsten.cream.generated.Source.toState(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Branch.Only = me.tbsten.cream.generated.Source.Branch.Only(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--funName/tokenFunName.md
@@ -1,0 +1,115 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyTargetSimpleName
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "into" + CopyTargetSimpleName)
+public sealed interface Source {
+  public val id: String
+
+  public data class Loading(
+    override val id: String,
+  ) : Source
+
+  public data class Done(
+    override val id: String,
+    public val `data`: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "inner-name")
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Done copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoDone(data = data)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoDone(data = data, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Done
+ */
+public fun  me.tbsten.cream.generated.Source.intoDone(
+    id: String = this.id,
+    data: String,
+) : me.tbsten.cream.generated.Source.Done = me.tbsten.cream.generated.Source.Done(
+    id = id,
+    data = data,
+)
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Loading copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoLoading()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoLoading(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Loading
+ */
+public fun  me.tbsten.cream.generated.Source.intoLoading(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Loading = me.tbsten.cream.generated.Source.Loading(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/defaultSuffixFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/defaultSuffixFunName.md
@@ -1,0 +1,115 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+import me.tbsten.cream.DefaultCopyFunctionName
+
+@CopyToChildren(funName = DefaultCopyFunctionName + "OrNull")
+public sealed interface Source {
+  public val id: String
+
+  public data class Loading(
+    override val id: String,
+  ) : Source
+
+  public data class Done(
+    override val id: String,
+    public val `data`: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Done copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToSourceDoneOrNull(data = data)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToSourceDoneOrNull(data = data, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Done
+ */
+public fun  me.tbsten.cream.generated.Source.copyToSourceDoneOrNull(
+    id: String = this.id,
+    data: String,
+) : me.tbsten.cream.generated.Source.Done = me.tbsten.cream.generated.Source.Done(
+    id = id,
+    data = data,
+)
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Loading copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToSourceLoadingOrNull()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToSourceLoadingOrNull(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Loading
+ */
+public fun  me.tbsten.cream.generated.Source.copyToSourceLoadingOrNull(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Loading = me.tbsten.cream.generated.Source.Loading(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/literalFunNameRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/literalFunNameRejected.md
@@ -1,0 +1,59 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "toState")
+public sealed interface Source {
+  public val id: String
+
+  public data class Loading(
+    override val id: String,
+  ) : Source
+
+  public data class Done(
+    override val id: String,
+    public val `data`: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+COMPILATION_ERROR
+```
+
+## Output:Console
+
+```kt
+e: Error occurred in KSP, check log for detail
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:7: Invalid cream usage: @CopyToChildren on me.tbsten.cream.generated.Source sets a fixed funName "toState",
+but it generates more than one function (multiple targets or sources, a sealed
+target, or a reversible mapping). Those functions would all share that name and collide.
+
+Solution: 
+  Include a naming token so each generated function gets a distinct name, e.g.
+    funName = "to" + CopyTargetSimpleName
+  or split the declaration into separate annotations.
+```
+
+## Output:Generated sources
+
+```kt
+
+```

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
@@ -1,0 +1,81 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(
+  notCopyToObject = true,
+  funName = "toState",
+)
+public sealed interface Source {
+  public data class DataChild(
+    public val a: String,
+  ) : Source
+
+  public object ObjectChild : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.DataChild copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(a = a)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(a = a, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.DataChild
+ */
+public fun  me.tbsten.cream.generated.Source.toState(
+    a: String,
+) : me.tbsten.cream.generated.Source.DataChild = me.tbsten.cream.generated.Source.DataChild(
+    a = a,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/singleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/singleLeafLiteralFunName.md
@@ -1,0 +1,78 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "toState")
+public sealed interface Source {
+  public val id: String
+
+  public data class Only(
+    override val id: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Only copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Only
+ */
+public fun  me.tbsten.cream.generated.Source.toState(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Only = me.tbsten.cream.generated.Source.Only(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/singleTransitiveLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/singleTransitiveLeafLiteralFunName.md
@@ -1,0 +1,80 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "toState")
+public sealed interface Source {
+  public val id: String
+
+  public sealed interface Branch : Source {
+    public data class Only(
+      override val id: String,
+    ) : Branch
+  }
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Branch.Only copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.toState(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Branch.Only
+ */
+public fun  me.tbsten.cream.generated.Source.toState(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Branch.Only = me.tbsten.cream.generated.Source.Branch.Only(
+    id = id,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/tokenFunName.md
@@ -1,0 +1,115 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyTargetSimpleName
+import me.tbsten.cream.CopyToChildren
+
+@CopyToChildren(funName = "into" + CopyTargetSimpleName)
+public sealed interface Source {
+  public val id: String
+
+  public data class Loading(
+    override val id: String,
+  ) : Source
+
+  public data class Done(
+    override val id: String,
+    public val `data`: String,
+  ) : Source
+}
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyToChildren__Source.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Done copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoDone(data = data)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoDone(data = data, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Done
+ */
+public fun  me.tbsten.cream.generated.Source.intoDone(
+    id: String = this.id,
+    data: String,
+) : me.tbsten.cream.generated.Source.Done = me.tbsten.cream.generated.Source.Done(
+    id = id,
+    data = data,
+)
+
+/**
+ * (Auto generate by @[CopyToChildren] annotation of [Source])
+ * 
+ * Source -> Source.Loading copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoLoading()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.intoLoading(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Source.Loading
+ */
+public fun  me.tbsten.cream.generated.Source.intoLoading(
+    id: String = this.id,
+) : me.tbsten.cream.generated.Source.Loading = me.tbsten.cream.generated.Source.Loading(
+    id = id,
+)
+````

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyToChildren.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyToChildren.kt
@@ -54,17 +54,26 @@ package me.tbsten.cream
  * @property visibility Visibility modifier applied to every generated per-child copy
  *   function. Defaults to [CopyVisibility.INHERIT], which keeps cream's existing behaviour
  *   (each function inherits its target child's visibility).
+ * @property funName Template for the generated function names. Defaults to
+ *   [DefaultCopyFunctionName] (cream's derived name). `@CopyToChildren` fans out to **every**
+ *   concrete leaf of the sealed hierarchy, so it usually generates more than one function — embed
+ *   a per-target token such as [CopyTargetSimpleName] so each leaf gets a distinct name, e.g.
+ *   `funName = "to" + CopyTargetSimpleName`. A plain literal (no token) would make every per-leaf
+ *   function share one name and collide, so it is rejected with a compilation error whenever more
+ *   than one function is generated. See `CopyFunctionNameToken.kt`.
  *
  * @see SealedCopy
  * @see CopyTo
  * @see CopyToChildren.Exclude
  * @see CopyVisibility
+ * @see DefaultCopyFunctionName
  */
 @Target(AnnotationTarget.CLASS)
 public annotation class CopyToChildren(
     val notCopyToObject: Boolean = false,
     val kdoc: KDoc = KDoc(),
     val visibility: CopyVisibility = CopyVisibility.INHERIT,
+    val funName: String = DefaultCopyFunctionName,
 ) {
     /**
      * Remove the auto-copy default from a sealed parent's property across **all**

--- a/test/src/commonMain/kotlin/me/tbsten/cream/test/copyToChildren/FunName.kt
+++ b/test/src/commonMain/kotlin/me/tbsten/cream/test/copyToChildren/FunName.kt
@@ -1,0 +1,37 @@
+package me.tbsten.cream.test.copyToChildren
+
+import me.tbsten.cream.CopyTargetSimpleName
+import me.tbsten.cream.CopyToChildren
+import me.tbsten.cream.DefaultCopyFunctionName
+
+// Token override: each per-leaf function name is built from its own leaf's simple name, so every
+// generated function stays unique across the sealed hierarchy's leaves.
+@CopyToChildren(funName = "into" + CopyTargetSimpleName)
+sealed interface FunNameState {
+    val id: String
+
+    data class Loading(
+        override val id: String,
+    ) : FunNameState
+
+    data class Success(
+        override val id: String,
+        val data: String,
+    ) : FunNameState
+}
+
+// DefaultCopyFunctionName + suffix: keep cream's derived per-leaf name and append a suffix. The
+// derived name already embeds the target, so each leaf's name stays unique.
+@CopyToChildren(funName = DefaultCopyFunctionName + "OrNull")
+sealed interface FunNameSuffixState {
+    val id: String
+
+    data class A(
+        override val id: String,
+    ) : FunNameSuffixState
+
+    data class B(
+        override val id: String,
+        val x: Int,
+    ) : FunNameSuffixState
+}

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/FunNameTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyToChildren/FunNameTest.kt
@@ -1,0 +1,19 @@
+package me.tbsten.cream.test.copyToChildren
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class FunNameTest :
+    FreeSpec({
+        "token funName names each per-leaf function from its own leaf" {
+            val state: FunNameState = FunNameState.Loading("s")
+            state.intoLoading() shouldBe FunNameState.Loading("s")
+            state.intoSuccess(data = "d") shouldBe FunNameState.Success("s", "d")
+        }
+
+        "DefaultCopyFunctionName + suffix keeps each derived per-leaf name unique" {
+            val state: FunNameSuffixState = FunNameSuffixState.A("s")
+            state.copyToFunNameSuffixStateAOrNull() shouldBe FunNameSuffixState.A("s")
+            state.copyToFunNameSuffixStateBOrNull(x = 7) shouldBe FunNameSuffixState.B("s", 7)
+        }
+    })


### PR DESCRIPTION
## 概要

`@CopyToChildren` には他の source アノテーションが持つ `funName`（命名テンプレート）引数が無く、生成される per-leaf コピー関数名をアノテーション単位で上書きできませんでした。本 PR で `funName: String = DefaultCopyFunctionName` を追加し、他アノテーションと揃えます。

Closes #138

## 変更点

- **runtime**: `@CopyToChildren` に `funName: String = DefaultCopyFunctionName` 引数と KDoc を追加（`@CopyTo` と同じデフォルトシンボル）。
- **ksp feature**: `ProcessCopyToChildren` で funName を core の copyFun ジェネレータへスルー。`GenerateSourceAnnotation.CopyToChildren` は基底 interface の `funNameTemplate` getter が raw annotation から `funName` を読むため **GSA 自体の変更は不要**。`appendCopyFunction` 系は元々 `resolveFunName(..., target = 各 leaf, ...)` で per-leaf に解決するので、生成側もそのまま動作。
- **collision 検証**: `validateFunName` を feature に追加し、複数関数を生成する場合（leaf が 2 つ以上、または直下 child が sealed）に純粋リテラルの funName を共有 diagnostic で reject。

## token のユニーク性

`@CopyToChildren` は sealed 階層の **すべて** の具象 leaf に fan-out し複数関数を生成するため、各関数名がユニークになるよう **`CopyTargetSimpleName` などの per-target token** を使う運用にしています（複数 target を持つ `@CopyTo` と同様）。token 解決は既存の `FunctionNameTemplate` / `CopyFunctionName`（`cream-ksp/shared`）を再利用。例: `funName = "into" + CopyTargetSimpleName` → `intoLoading` / `intoSuccess`。`DefaultCopyFunctionName + "OrNull"` も派生名が target を含むためユニーク。

## テスト

- `test/` 統合テスト `FunNameTest`: token override（`intoLoading` / `intoSuccess`）と `DefaultCopyFunctionName + "OrNull"`（`copyToFunNameSuffixStateAOrNull` 等）が呼べてユニークであることを検証。
- snapshot scenario family `funName` を `CopyToChildrenSnapshotTest` に追加（token / default+suffix / literal-collision-rejected / single-leaf-literal-allowed）。golden は新規 `08--funName/` のみ追加で既存 snapshot は不変（full cartesian product のため末尾追加は既存ペアを動かさない）。

## 検証（すべて green）

- `./gradlew :cream-runtime:compileKotlinJvm` / `:cream-runtime:compileKotlinMetadata`
- `./gradlew :cream-ksp:compileTestKotlin`
- `./gradlew :cream-ksp:test`（full suite, Konsist arch tests 含む）
- `./gradlew :test:jvmTest`
- `./gradlew ktlintFormat` → `ktlintCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAiiB1gueBky3gV7M5DYpW
