### PR TITLE
fix: generate one @CombineFrom function per occurrence instead of merging sources

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/common/GenerateSourceAnnotation.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/common/GenerateSourceAnnotation.kt
@@ -79,15 +79,12 @@ internal sealed interface GenerateSourceAnnotation {
     ) : GenerateSourceAnnotation
 
     /**
-     * `@CombineFrom` is `@Repeatable` and all occurrences are currently merged into ONE function,
-     * so [funNameTemplate] is the single explicit name agreed across occurrences (resolved with
-     * conflict detection in the feature processor) rather than any one occurrence's value — hence
-     * it is passed in rather than derived from [annotation]. KDoc / visibility still come from the
-     * first occurrence's [annotation]. See #134.
+     * `@CombineFrom` is `@Repeatable`; each occurrence generates its own combine function, so KDoc /
+     * visibility / funName all derive from *that* occurrence's raw [annotation] (no cross-occurrence
+     * merge).
      */
     data class CombineFrom(
         override val annotation: KSAnnotation,
-        override val funNameTemplate: String,
     ) : GenerateSourceAnnotation
 
     /**

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/combineFrom/ProcessCombineFrom.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/feature/combineFrom/ProcessCombineFrom.kt
@@ -3,11 +3,11 @@ package me.tbsten.cream.ksp.feature.combineFrom
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.validate
 import me.tbsten.cream.CombineFrom
-import me.tbsten.cream.DefaultCopyFunctionName
 import me.tbsten.cream.ksp.InvalidCreamUsageException
 import me.tbsten.cream.ksp.ProcessContext
 import me.tbsten.cream.ksp.core.combineFun.appendCombineToFunction
@@ -28,6 +28,27 @@ import me.tbsten.cream.ksp.util.with
 
 private val annotationName = CombineFrom::class.simpleName!!
 
+/**
+ * One resolved `@CombineFrom` occurrence: its raw [annotation], the (deduped) [sources] it combines
+ * ([primarySource] = the extension-function receiver), and the [funName] those resolve to.
+ * `@CombineFrom` is `@Repeatable` and every occurrence becomes its own combine function, so each is
+ * processed independently.
+ */
+private data class CombineFromOccurrence(
+    val annotation: KSAnnotation,
+    val sources: List<KSClassDeclaration>,
+    val primarySource: KSClassDeclaration,
+    val funName: String,
+) {
+    // Two occurrences collide as a redeclaration only when they emit the SAME overload: identical
+    // resolved funName AND identical ordered source list (the receiver = sources[0] and the leading
+    // parameter types = sources[1..] fix the signature; the target constructor params are constant).
+    // Different source sets coexist as overloads even under one name. Keyed on the source
+    // declarations themselves (not their full names) — the same equality the source dedupe relies on.
+    val overloadKey: Any
+        get() = funName to sources
+}
+
 context(processContext: ProcessContext)
 internal fun processCombineFrom(): List<KSAnnotated> =
     with(processContext.logger, processContext.options) {
@@ -46,82 +67,90 @@ internal fun processCombineFrom(): List<KSAnnotated> =
                     logger = processContext.logger,
                 ) ?: return@forEach
 
-            val combineFromAnnotations = target.annotationsOf(CombineFrom::class)
-
-            // @CombineFrom is @Repeatable; the sources of every occurrence are flattened into one
-            // merged copy function. Stacking it twice with the same source set (or simply repeating a
-            // class across occurrences) is an idempotent re-declaration, so dedupe the collected
-            // sources: keeping a duplicate would emit a function with two identically named parameters
-            // ("Conflicting declarations") and re-list the same source in KDoc (issue #101).
-            val sourceClasses =
-                combineFromAnnotations
-                    .resolveClassListOrReport("sources", annotationName, targetDeclaration)
-                    ?.distinct() ?: return@forEach
-
-            // Need at least one source class
-            if (sourceClasses.isEmpty()) {
-                processContext.logger.reportCombineFromNoSources(targetDeclaration)
+            val combineFromAnnotations = target.annotationsOf(CombineFrom::class).toList()
+            if (combineFromAnnotations.isEmpty()) {
+                // Defensive: getSymbolsWithAnnotation matched but no @CombineFrom occurrence could be
+                // resolved (e.g. a broken classpath entry).
                 return@forEach
             }
 
-            // First source class is the primary source (extension function receiver)
-            val primarySource = sourceClasses.firstOrNull() ?: return@forEach
-            val otherSources = sourceClasses.drop(1)
+            // Resolve every occurrence independently — sources are NOT flattened across occurrences.
+            // @CombineFrom is @Repeatable and each occurrence is its own combine function (a different
+            // source set yields different parameter types, so same-named functions coexist as
+            // overloads). Mirrors the per-occurrence @SealedCopy model.
+            val resolvedOccurrences =
+                combineFromAnnotations.map { annotation ->
+                    // Dedupe sources WITHIN one occurrence: @CombineFrom(A::class, A::class) would emit
+                    // two identically named parameters ("Conflicting declarations") and re-list the same
+                    // source in KDoc.
+                    val sources =
+                        sequenceOf(annotation)
+                            .resolveClassListOrReport("sources", annotationName, targetDeclaration)
+                            ?.distinct()
+                            ?: return@map null
+                    val primarySource = sources.firstOrNull()
+                    if (primarySource == null) {
+                        processContext.logger.reportCombineFromNoSources(targetDeclaration)
+                        return@map null
+                    }
+                    CombineFromOccurrence(
+                        annotation = annotation,
+                        sources = sources,
+                        primarySource = primarySource,
+                        funName =
+                            resolveFunName(
+                                funNameTemplate = annotation.funNameTemplate(),
+                                source = primarySource,
+                                target = targetClass,
+                                options = processContext.options,
+                            ),
+                    )
+                }
+            // Any occurrence that failed to resolve already reported a clean error; skip the whole
+            // target so no partial file is emitted.
+            if (resolvedOccurrences.any { it == null }) return@forEach
+            val occurrences = resolvedOccurrences.filterNotNull()
 
-            // @CombineFrom is @Repeatable and all occurrences are merged into ONE generated function,
-            // so the funName must be unambiguous. Reading it from only the first occurrence would
-            // silently drop a different funName set on a later one — instead, require the explicit
-            // funName values to agree.
-            val explicitFunNameTemplates =
-                combineFromAnnotations
-                    .map { it.funNameTemplate() }
-                    .filter { it != DefaultCopyFunctionName }
-                    .distinct()
-                    .toList()
-            // Compare the *resolved* names, not the raw (KSP-folded) templates: the occurrences are
-            // merged into one function that takes a single name, so they are only ambiguous when they
-            // resolve to different names. Resolving also keeps the diagnostic readable — it shows
-            // "toFoo" rather than the internal "to{{cream:CopyTargetSimpleName}}" placeholder form.
-            val explicitFunNames =
-                explicitFunNameTemplates
-                    .map { resolveFunName(it, primarySource, targetClass, processContext.options) }
-                    .distinct()
-            if (explicitFunNames.size > 1) {
-                processContext.logger.reportCombineFromConflictingFunNames(
+            // All occurrences are written to one file, so two that would emit the same overload
+            // (same resolved funName + same sources) are a redeclaration — reject with a clean cream
+            // error rather than letting it fail at the user's compiler. Mirrors @SealedCopy's
+            // duplicate-funName guard.
+            val duplicateOverload =
+                occurrences
+                    .groupBy { it.overloadKey }
+                    .values
+                    .firstOrNull { it.size > 1 }
+                    ?.first()
+            if (duplicateOverload != null) {
+                processContext.logger.reportCombineFromDuplicateOverload(
                     targetDeclaration,
                     targetClass,
-                    explicitFunNames,
+                    duplicateOverload,
                 )
                 return@forEach
             }
-            val funNameTemplate = explicitFunNameTemplates.firstOrNull() ?: DefaultCopyFunctionName
-
-            // All occurrences are merged into one function. GSA derives kdoc/visibility from the first
-            // occurrence's raw annotation; funNameTemplate is the cross-occurrence merge result
-            // (resolved above with conflict detection) and so is passed explicitly. See #134.
-            val combineFromAnnotation =
-                combineFromAnnotations.firstOrNull() ?: return@forEach
-
-            val generateSourceAnnotation =
-                GenerateSourceAnnotation.CombineFrom(
-                    annotation = combineFromAnnotation,
-                    funNameTemplate = funNameTemplate,
-                )
 
             processContext.codeGenerator
                 .createNewKotlinFile(
                     dependencies = Dependencies(aggregating = true, targetDeclaration.containingFile!!),
                     packageName = targetClass.packageName,
-                    fileName = "CombineFrom__${primarySource.underPackageName}__${targetClass.underPackageName}",
+                    fileName = "CombineFrom__${targetClass.underPackageName}",
                 ) {
-                    // Generate combine function with multiple sources
-                    it.appendCombineToFunction(
-                        primarySource = primarySource,
-                        otherSources = otherSources,
-                        target = targetClass,
-                        omitPackages = omitPackagesFor(primarySource.packageName),
-                        generateSourceAnnotation = generateSourceAnnotation,
-                    )
+                    occurrences.forEach { occurrence ->
+                        val primarySource = occurrence.primarySource
+                        val otherSources = occurrence.sources.drop(1)
+
+                        // Pass the raw per-occurrence annotation: @CombineFrom is @Repeatable and each
+                        // occurrence is its own combine function, so GSA must read kdoc / visibility /
+                        // funName from *this* occurrence rather than a cross-occurrence merge.
+                        it.appendCombineToFunction(
+                            primarySource = primarySource,
+                            otherSources = otherSources,
+                            target = targetClass,
+                            omitPackages = omitPackagesFor(primarySource.packageName),
+                            generateSourceAnnotation = GenerateSourceAnnotation.CombineFrom(annotation = occurrence.annotation),
+                        )
+                    }
                 }
         }
 
@@ -142,22 +171,30 @@ private fun KSPLogger.reportCombineFromNoSources(targetDeclaration: KSDeclaratio
     )
 }
 
-private fun KSPLogger.reportCombineFromConflictingFunNames(
+private fun KSPLogger.reportCombineFromDuplicateOverload(
     targetDeclaration: KSDeclaration,
     targetClass: KSClassDeclaration,
-    conflictingNames: List<String>,
+    duplicate: CombineFromOccurrence,
 ) {
+    // Spell out the colliding overload so the user can see WHICH function is duplicated: the
+    // extension receiver (sources[0]) and the leading parameter types (sources[1..]).
+    val receiver =
+        duplicate.sources
+            .first()
+            .simpleName
+            .asString()
+    val parameterTypes = duplicate.sources.drop(1).joinToString { it.simpleName.asString() }
+    val overload = "$receiver.${duplicate.funName}($parameterTypes)"
     reportCreamError(
         InvalidCreamUsageException(
             message =
                 lines(
-                    "@$annotationName on ${targetClass.fullName} is repeated with conflicting funName values:",
-                    conflictingNames.joinToString(", ") { "\"$it\"" },
-                    "Stacked @$annotationName annotations are merged into a single generated function, so funName must be unambiguous.",
+                    "@$annotationName on ${targetClass.fullName} generates the same overload more than once: $overload.",
+                    "Stacked @$annotationName annotations are written to one file, so each must produce a distinct overload.",
                 ),
             solution =
                 lines(
-                    "Set the same funName on every @$annotationName of ${targetClass.fullName}, or set it on only one.",
+                    "Give one of the duplicate @$annotationName a distinct funName, or change its sources.",
                 ),
         ),
         targetDeclaration,

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromEdgeUsageTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromEdgeUsageTest.kt
@@ -1,9 +1,87 @@
 package me.tbsten.cream.ksp.feature.combineFrom
 
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import me.tbsten.cream.ksp.testing.compile.compileWithCream
+import me.tbsten.cream.ksp.testing.compile.generatedSourceText
 
-// TODO(#127): reimplement — レアケース ＋ @Map / @Exclude 等の意味的ケース。
+/**
+ * Rare/semantic `@CombineFrom` cases. `@CombineFrom` is `@Repeatable`, so stacking it produces one
+ * combine function per occurrence (issue #134); the snapshot suite pins the exact generated source,
+ * while these example-based cases pin the observable semantics — the stacked functions coexist and
+ * the whole unit compiles.
+ *
+ * TODO(#127): also cover the remaining semantic cases (@Map / @Exclude across sources).
+ */
 internal class CombineFromEdgeUsageTest :
     FreeSpec({
-        "TODO(#127): not yet reimplemented".config(enabled = false) {}
+        "stacked @CombineFrom sharing a primary source generates one overload per occurrence" {
+            // Both occurrences share the receiver (Loading) but combine a different second source, so
+            // they emit two `copyToState` overloads distinguished by their leading parameter type.
+            // Compiling proves they coexist (a redeclaration would fail to compile).
+            val result =
+                compileWithCream(
+                    """
+                    package edge
+
+                    import me.tbsten.cream.CombineFrom
+
+                    data class Loading(val message: String)
+                    data class Success(val successData: String)
+                    data class Special(val specialData: Int)
+
+                    @CombineFrom(Loading::class, Success::class)
+                    @CombineFrom(Loading::class, Special::class)
+                    data class State(
+                        val message: String,
+                        val successData: String,
+                        val specialData: Int,
+                    )
+                    """.trimIndent(),
+                )
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("Generated:\n$generated") {
+                // one overload takes Success, the other takes Special — both named copyToState
+                generated shouldContain "Success"
+                generated shouldContain "Special"
+                Regex("""fun [^\n]*\.copyToState\(""").findAll(generated).count() shouldBe 2
+            }
+        }
+
+        "stacked @CombineFrom with distinct funNames generates each separately named function" {
+            val result =
+                compileWithCream(
+                    """
+                    package edge
+
+                    import me.tbsten.cream.CombineFrom
+
+                    data class Left(val left: String)
+                    data class Right(val right: Int)
+
+                    @CombineFrom(Left::class, funName = "fromLeft")
+                    @CombineFrom(Right::class, funName = "fromRight")
+                    data class LeftRight(
+                        val left: String,
+                        val right: Int,
+                    )
+                    """.trimIndent(),
+                )
+
+            withClue(result.messages) {
+                result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            }
+            val generated = result.generatedSourceText()
+            withClue("Generated:\n$generated") {
+                generated shouldContain "fromLeft"
+                generated shouldContain "fromRight"
+            }
+        }
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/CombineFromSnapshotTest.kt
@@ -27,10 +27,14 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  * Most families combine from 2 sources (SourceA = receiver, SourceB = leading param) to show the real
  * N→1 combine shape; `multiSource/singleSource` pins the degenerate 1-source path (= copyFrom).
  *
+ * `@CombineFrom` is `@Repeatable` and generates one combine function PER occurrence (a different source
+ * set yields different parameter types, so same-named functions coexist as overloads; see #134). The
+ * `repeatable` family pins this: same-named overloads (`stackedAnnotations` / `stackedAnnotationsSameFunName`),
+ * distinct funNames (`stackedAnnotationsDistinctFunNames`), the within-occurrence source dedupe
+ * (`duplicateSourceWithinOccurrence`), and the genuine overload-clash reject
+ * (`duplicateOccurrenceRejected`, two occurrences with the same funName + sources).
+ *
  * Intentionally NOT covered as snapshot cases (and why):
- * - multi-target `funName` reject — `@CombineFrom` always emits ONE merged function, so no multi-target name
- *   collision exists; cross-occurrence funName agreement is covered by `repeatable/{stackedAnnotationsSameFunName,
- *   conflictingFunNamesRejected}`.
  * - nesting / multi-constructor target — redundant with the shared combine/copy core.
  * - `generics` is intentionally single-source (it isolates the type-param-MERGE axis on the receiver); the
  *   2-generic-source combine lives in `multiSource/multiSourceGenerics` (a 2nd source with an unconsumed type
@@ -40,7 +44,7 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  *   combine ACCEPTS + compiles it (Kotlin 1.6+), copy REJECTS it. The still-uncompilable #132 cases are
  *   abstract/inner/private-ctor.
  * - `typealias` source/target — `SnapshotScenario` can't carry a `TypeAliasSpec` → integration / EdgeUsage.
- * - #132 + #134 (stacked occurrences merge into one fn) are FROZEN as `// TODO(#132)` / `// TODO(#134)` goldens.
+ * - #132 (combine emits uncompilable code for abstract/inner/private-ctor targets) is FROZEN as `// TODO(#132)` goldens.
  */
 internal class CombineFromSnapshotTest :
     FreeSpec({

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/scenario/Repeatable.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/combineFrom/scenario/Repeatable.kt
@@ -1,6 +1,5 @@
 package me.tbsten.cream.ksp.feature.combineFrom.scenario
 
-import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.INT
 import me.tbsten.cream.ksp.testing.generator.Generator
@@ -13,22 +12,12 @@ import me.tbsten.cream.ksp.testing.poet.snapshotScenarios
 internal fun repeatableScenarios(): Generator<SnapshotScenario> {
     val sourceA = dataClass("SourceA", Prop("propertyA"))
     val sourceB = dataClass("SourceB", Prop("propertyB", INT))
+    val sourceC = dataClass("SourceC", Prop("propertyC"))
+    val sourceD = dataClass("SourceD", Prop("propertyD", INT))
     return Generator.snapshotScenarios(
-        // TODO(#134): stacked @CombineFrom occurrences are currently MERGED into one function (sources
-        // flattened + deduped). This golden freezes that behavior; #134 proposes one function per
-        // occurrence instead. Capture-and-report — do not change the generator.
         "stackedAnnotations" to
             SnapshotScenario(
-                dataClass("Target", Prop("propertyA"), Prop("propertyB", INT), Prop("propertyC", BOOLEAN))
-                    .withCombineFrom(classNameOf("SourceA"))
-                    .withCombineFrom(classNameOf("SourceB")),
-                sourceA,
-                sourceB,
-            ),
-        "duplicateSourceDeduped" to
-            SnapshotScenario(
-                dataClass("Target", Prop("propertyA"), Prop("propertyB", INT), Prop("propertyC", BOOLEAN))
-                    .withCombineFrom(classNameOf("SourceA"))
+                dataClass("Target", Prop("propertyA"), Prop("propertyB", INT))
                     .withCombineFrom(classNameOf("SourceA"))
                     .withCombineFrom(classNameOf("SourceB")),
                 sourceA,
@@ -42,13 +31,35 @@ internal fun repeatableScenarios(): Generator<SnapshotScenario> {
                 sourceA,
                 sourceB,
             ),
-        "conflictingFunNamesRejected" to
+        // Each stacked occurrence combines a DISTINCT pair of sources under its own funName, so the
+        // two generated functions are independent combines (not just single-source overloads).
+        "stackedAnnotationsDistinctFunNames" to
             SnapshotScenario(
-                dataClass("Target", Prop("propertyA"), Prop("propertyB", INT))
-                    .withCombineFrom(classNameOf("SourceA"), funName = CodeBlock.of("%S", "toFoo"))
-                    .withCombineFrom(classNameOf("SourceB"), funName = CodeBlock.of("%S", "toBar")),
+                dataClass(
+                    "Target",
+                    Prop("propertyA"),
+                    Prop("propertyB", INT),
+                    Prop("propertyC"),
+                    Prop("propertyD", INT),
+                ).withCombineFrom(classNameOf("SourceA"), classNameOf("SourceB"), funName = CodeBlock.of("%S", "toFoo"))
+                    .withCombineFrom(classNameOf("SourceC"), classNameOf("SourceD"), funName = CodeBlock.of("%S", "toBar")),
                 sourceA,
                 sourceB,
+                sourceC,
+                sourceD,
+            ),
+        "duplicateOccurrenceRejected" to
+            SnapshotScenario(
+                dataClass("Target", Prop("propertyA"), Prop("propertyB", INT))
+                    .withCombineFrom(classNameOf("SourceA"))
+                    .withCombineFrom(classNameOf("SourceA")),
+                sourceA,
+            ),
+        "duplicateSourceWithinOccurrence" to
+            SnapshotScenario(
+                dataClass("Target", Prop("propertyA"), Prop("propertyB", INT))
+                    .withCombineFrom(classNameOf("SourceA"), classNameOf("SourceA")),
+                sourceA,
             ),
     )
 }

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
@@ -38,13 +38,13 @@ COMPILATION_ERROR
 ## Output:Console
 
 ```kt
-e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Source__Target.kt:31:40 Cannot create an instance of an abstract class.
+e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Target.kt:31:40 Cannot create an instance of an abstract class.
 ```
 
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
@@ -38,13 +38,13 @@ COMPILATION_ERROR
 ## Output:Console
 
 ```kt
-e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Source__Outer.Target.kt:30:78 Constructor of the inner class 'inner class Target : Any' can only be called with a receiver of the containing class.
+e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Outer.Target.kt:30:78 Constructor of the inner class 'inner class Target : Any' can only be called with a receiver of the containing class.
 ```
 
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Outer.Target.kt
+// file: CombineFrom__Outer.Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
@@ -40,7 +40,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
@@ -38,13 +38,13 @@ COMPILATION_ERROR
 ## Output:Console
 
 ```kt
-e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Source__Target.kt:31:66 Cannot access 'constructor(name: String, extra: Int): Target': it is private in 'me.tbsten.cream.generated.Target'.
+e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Target.kt:31:66 Cannot access 'constructor(name: String, extra: Int): Target': it is private in 'me.tbsten.cream.generated.Target'.
 ```
 
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/excludeOverlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/excludeOverlappingProperty.md
@@ -56,7 +56,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/mapAcrossSources.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/multiSourceGenerics.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/multiSourceGenerics.md
@@ -49,7 +49,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/overlappingProperty.md
@@ -55,7 +55,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/singleSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/singleSource.md
@@ -45,7 +45,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/threeSources.md
@@ -60,7 +60,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/twoSources.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
@@ -42,7 +42,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
@@ -41,7 +41,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
@@ -42,7 +42,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
@@ -43,7 +43,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/collectionProp.md
@@ -52,7 +52,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/customTypeProp.md
@@ -55,7 +55,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/mixedPrimitives.md
@@ -57,7 +57,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/nullableProp.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/stringProp.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/zeroProps.md
@@ -42,7 +42,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--matching/typeIncompatible.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/multipleMappings.md
@@ -55,7 +55,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/singleMapping.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludeNoEffect.md
@@ -53,7 +53,7 @@ w: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:14: @Exclude on 'target
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludedProperty.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/description.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/descriptionAndExamples.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/internalTargetClass.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/propertyVisibilities.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverrideInternal.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverridePublic.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/literalFunName.md
@@ -52,7 +52,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/tokenFunName.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/duplicateOccurrenceRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/duplicateOccurrenceRejected.md
@@ -7,14 +7,8 @@ import kotlin.Int
 import kotlin.String
 import me.tbsten.cream.CombineFrom
 
-@CombineFrom(
-  SourceA::class,
-  funName = "toFoo",
-)
-@CombineFrom(
-  SourceB::class,
-  funName = "toBar",
-)
+@CombineFrom(SourceA::class)
+@CombineFrom(SourceA::class)
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
@@ -22,10 +16,6 @@ public data class Target(
 
 public data class SourceA(
   public val propertyA: String,
-)
-
-public data class SourceB(
-  public val propertyB: Int,
 )
 ```
 
@@ -50,12 +40,11 @@ COMPILATION_ERROR
 
 ```kt
 e: Error occurred in KSP, check log for detail
-e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:15: Invalid cream usage: @CombineFrom on me.tbsten.cream.generated.Target is repeated with conflicting funName values:
-"toFoo", "toBar"
-Stacked @CombineFrom annotations are merged into a single generated function, so funName must be unambiguous.
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:9: Invalid cream usage: @CombineFrom on me.tbsten.cream.generated.Target generates the same overload more than once: SourceA.to_Target().
+Stacked @CombineFrom annotations are written to one file, so each must produce a distinct overload.
 
 Solution: 
-  Set the same funName on every @CombineFrom of me.tbsten.cream.generated.Target, or set it on only one.
+  Give one of the duplicate @CombineFrom a distinct funName, or change its sources.
 ```
 
 ## Output:Generated sources

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/duplicateSourceWithinOccurrence.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/duplicateSourceWithinOccurrence.md
@@ -3,26 +3,21 @@
 ```kt
 package me.tbsten.cream.generated
 
-import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import me.tbsten.cream.CombineFrom
 
-@CombineFrom(SourceA::class)
-@CombineFrom(SourceA::class)
-@CombineFrom(SourceB::class)
+@CombineFrom(
+  SourceA::class,
+  SourceA::class,
+)
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
-  public val propertyC: Boolean,
 )
 
 public data class SourceA(
   public val propertyA: String,
-)
-
-public data class SourceB(
-  public val propertyB: Int,
 )
 ```
 
@@ -30,9 +25,9 @@ public data class SourceB(
 
 ```kt
 ksp {
-    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamePrefix", "to")
     arg("copyFunNamingStrategy", "under-package" /* default */)
-    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
 }
 ```
@@ -52,7 +47,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*
@@ -60,37 +55,31 @@ import me.tbsten.cream.*
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceA] + [SourceB] -> [Target] copy function.
+ * [SourceA] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.copyToTarget(sourceB = SourceB(...), propertyC = propertyC)
+ * val target = sourceA.to_Target(propertyB = propertyB)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.copyToTarget(sourceB = SourceB(...), propertyC = propertyC, property = value)
+ * val target = sourceA.to_Target(propertyB = propertyB, property = value)
  * ```
  * 
  * 
  * @see SourceA
- * @see SourceB
  * @see Target
  */
-public fun  me.tbsten.cream.generated.SourceA.copyToTarget(
-    sourceB: me.tbsten.cream.generated.SourceB,
+public fun  me.tbsten.cream.generated.SourceA.to_Target(
     propertyA: String = this.propertyA,
-    propertyB: Int = sourceB.propertyB,
-    propertyC: Boolean,
+    propertyB: Int,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
-    propertyC = propertyC,
 )
 ````

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotations.md
@@ -3,7 +3,6 @@
 ```kt
 package me.tbsten.cream.generated
 
-import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import me.tbsten.cream.CombineFrom
@@ -13,7 +12,6 @@ import me.tbsten.cream.CombineFrom
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
-  public val propertyC: Boolean,
 )
 
 public data class SourceA(
@@ -51,7 +49,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*
@@ -59,37 +57,62 @@ import me.tbsten.cream.*
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceA] + [SourceB] -> [Target] copy function.
+ * [SourceA] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.to_Target(sourceB = SourceB(...), propertyC = propertyC)
+ * val target = sourceA.to_Target(propertyB = propertyB)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.to_Target(sourceB = SourceB(...), propertyC = propertyC, property = value)
+ * val target = sourceA.to_Target(propertyB = propertyB, property = value)
  * ```
  * 
  * 
  * @see SourceA
- * @see SourceB
  * @see Target
  */
 public fun  me.tbsten.cream.generated.SourceA.to_Target(
-    sourceB: me.tbsten.cream.generated.SourceB,
     propertyA: String = this.propertyA,
-    propertyB: Int = sourceB.propertyB,
-    propertyC: Boolean,
+    propertyB: Int,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
-    propertyC = propertyC,
+)
+
+/**
+ * (Auto generate by @[CombineFrom] annotation of [Target])
+ * 
+ * [SourceB] -> [Target] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val sourceB = SourceB(...)
+ * val target = sourceB.to_Target(propertyA = propertyA)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val sourceB = SourceB(...)
+ * val target = sourceB.to_Target(propertyA = propertyA, property = value)
+ * ```
+ * 
+ * 
+ * @see SourceB
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.SourceB.to_Target(
+    propertyA: String,
+    propertyB: Int = this.propertyB,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    propertyA = propertyA,
+    propertyB = propertyB,
 )
 ````

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotationsDistinctFunNames.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotationsDistinctFunNames.md
@@ -9,15 +9,19 @@ import me.tbsten.cream.CombineFrom
 
 @CombineFrom(
   SourceA::class,
-  funName = "toTarget",
+  SourceB::class,
+  funName = "toFoo",
 )
 @CombineFrom(
-  SourceB::class,
-  funName = "toTarget",
+  SourceC::class,
+  SourceD::class,
+  funName = "toBar",
 )
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
+  public val propertyC: String,
+  public val propertyD: Int,
 )
 
 public data class SourceA(
@@ -26,6 +30,14 @@ public data class SourceA(
 
 public data class SourceB(
   public val propertyB: Int,
+)
+
+public data class SourceC(
+  public val propertyC: String,
+)
+
+public data class SourceD(
+  public val propertyD: Int,
 )
 ```
 
@@ -63,62 +75,78 @@ import me.tbsten.cream.*
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceA] -> [Target] copy function.
+ * [SourceA] + [SourceB] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val target = sourceA.toTarget(propertyB = propertyB)
+ * val sourceB = SourceB(...)
+ * val target = sourceA.toFoo(sourceB = SourceB(...), propertyC = propertyC, propertyD = propertyD)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val target = sourceA.toTarget(propertyB = propertyB, property = value)
+ * val sourceB = SourceB(...)
+ * val target = sourceA.toFoo(sourceB = SourceB(...), propertyC = propertyC, propertyD = propertyD, property = value)
  * ```
  * 
  * 
  * @see SourceA
+ * @see SourceB
  * @see Target
  */
-public fun  me.tbsten.cream.generated.SourceA.toTarget(
+public fun  me.tbsten.cream.generated.SourceA.toFoo(
+    sourceB: me.tbsten.cream.generated.SourceB,
     propertyA: String = this.propertyA,
-    propertyB: Int,
+    propertyB: Int = sourceB.propertyB,
+    propertyC: String,
+    propertyD: Int,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
+    propertyC = propertyC,
+    propertyD = propertyD,
 )
 
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceB] -> [Target] copy function.
+ * [SourceC] + [SourceD] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
- * val sourceB = SourceB(...)
- * val target = sourceB.toTarget(propertyA = propertyA)
+ * val sourceC = SourceC(...)
+ * val sourceD = SourceD(...)
+ * val target = sourceC.toBar(sourceD = SourceD(...), propertyA = propertyA, propertyB = propertyB)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
- * val sourceB = SourceB(...)
- * val target = sourceB.toTarget(propertyA = propertyA, property = value)
+ * val sourceC = SourceC(...)
+ * val sourceD = SourceD(...)
+ * val target = sourceC.toBar(sourceD = SourceD(...), propertyA = propertyA, propertyB = propertyB, property = value)
  * ```
  * 
  * 
- * @see SourceB
+ * @see SourceC
+ * @see SourceD
  * @see Target
  */
-public fun  me.tbsten.cream.generated.SourceB.toTarget(
+public fun  me.tbsten.cream.generated.SourceC.toBar(
+    sourceD: me.tbsten.cream.generated.SourceD,
     propertyA: String,
-    propertyB: Int = this.propertyB,
+    propertyB: Int,
+    propertyC: String = this.propertyC,
+    propertyD: Int = sourceD.propertyD,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
+    propertyC = propertyC,
+    propertyD = propertyD,
 )
 ````

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
@@ -38,13 +38,13 @@ COMPILATION_ERROR
 ## Output:Console
 
 ```kt
-e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Source__Target.kt:31:40 Cannot create an instance of an abstract class.
+e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Target.kt:31:40 Cannot create an instance of an abstract class.
 ```
 
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
@@ -38,13 +38,13 @@ COMPILATION_ERROR
 ## Output:Console
 
 ```kt
-e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Source__Outer.Target.kt:30:78 Constructor of the inner class 'inner class Target : Any' can only be called with a receiver of the containing class.
+e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Outer.Target.kt:30:78 Constructor of the inner class 'inner class Target : Any' can only be called with a receiver of the containing class.
 ```
 
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Outer.Target.kt
+// file: CombineFrom__Outer.Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
@@ -40,7 +40,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
@@ -38,13 +38,13 @@ COMPILATION_ERROR
 ## Output:Console
 
 ```kt
-e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Source__Target.kt:31:66 Cannot access 'constructor(name: String, extra: Int): Target': it is private in 'me.tbsten.cream.generated.Target'.
+e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Target.kt:31:66 Cannot access 'constructor(name: String, extra: Int): Target': it is private in 'me.tbsten.cream.generated.Target'.
 ```
 
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/excludeOverlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/excludeOverlappingProperty.md
@@ -56,7 +56,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/mapAcrossSources.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/multiSourceGenerics.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/multiSourceGenerics.md
@@ -49,7 +49,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/overlappingProperty.md
@@ -55,7 +55,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/singleSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/singleSource.md
@@ -45,7 +45,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/threeSources.md
@@ -60,7 +60,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/02--multiSource/twoSources.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
@@ -42,7 +42,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
@@ -41,7 +41,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
@@ -42,7 +42,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
@@ -43,7 +43,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/collectionProp.md
@@ -52,7 +52,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/customTypeProp.md
@@ -55,7 +55,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/mixedPrimitives.md
@@ -57,7 +57,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/nullableProp.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/stringProp.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/04--propertyShape/zeroProps.md
@@ -42,7 +42,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/05--matching/typeIncompatible.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/06--map/multipleMappings.md
@@ -55,7 +55,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/06--map/singleMapping.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/07--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/07--exclude/excludeNoEffect.md
@@ -53,7 +53,7 @@ w: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:14: @Exclude on 'target
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/07--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/07--exclude/excludedProperty.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--kdoc/description.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/08--kdoc/descriptionAndExamples.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/09--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/09--visibility/internalTargetClass.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/09--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/09--visibility/propertyVisibilities.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/09--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/09--visibility/visibilityOverrideInternal.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/09--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/09--visibility/visibilityOverridePublic.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/10--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/10--funName/literalFunName.md
@@ -52,7 +52,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/10--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/10--funName/tokenFunName.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/11--repeatable/duplicateOccurrenceRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/11--repeatable/duplicateOccurrenceRejected.md
@@ -7,14 +7,8 @@ import kotlin.Int
 import kotlin.String
 import me.tbsten.cream.CombineFrom
 
-@CombineFrom(
-  SourceA::class,
-  funName = "toFoo",
-)
-@CombineFrom(
-  SourceB::class,
-  funName = "toBar",
-)
+@CombineFrom(SourceA::class)
+@CombineFrom(SourceA::class)
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
@@ -22,10 +16,6 @@ public data class Target(
 
 public data class SourceA(
   public val propertyA: String,
-)
-
-public data class SourceB(
-  public val propertyB: Int,
 )
 ```
 
@@ -50,12 +40,11 @@ COMPILATION_ERROR
 
 ```kt
 e: Error occurred in KSP, check log for detail
-e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:15: Invalid cream usage: @CombineFrom on me.tbsten.cream.generated.Target is repeated with conflicting funName values:
-"toFoo", "toBar"
-Stacked @CombineFrom annotations are merged into a single generated function, so funName must be unambiguous.
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:9: Invalid cream usage: @CombineFrom on me.tbsten.cream.generated.Target generates the same overload more than once: SourceA.to_Target().
+Stacked @CombineFrom annotations are written to one file, so each must produce a distinct overload.
 
 Solution: 
-  Set the same funName on every @CombineFrom of me.tbsten.cream.generated.Target, or set it on only one.
+  Give one of the duplicate @CombineFrom a distinct funName, or change its sources.
 ```
 
 ## Output:Generated sources

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/11--repeatable/duplicateSourceWithinOccurrence.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/11--repeatable/duplicateSourceWithinOccurrence.md
@@ -3,26 +3,21 @@
 ```kt
 package me.tbsten.cream.generated
 
-import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import me.tbsten.cream.CombineFrom
 
-@CombineFrom(SourceA::class)
-@CombineFrom(SourceA::class)
-@CombineFrom(SourceB::class)
+@CombineFrom(
+  SourceA::class,
+  SourceA::class,
+)
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
-  public val propertyC: Boolean,
 )
 
 public data class SourceA(
   public val propertyA: String,
-)
-
-public data class SourceB(
-  public val propertyB: Int,
 )
 ```
 
@@ -31,7 +26,7 @@ public data class SourceB(
 ```kt
 ksp {
     arg("copyFunNamePrefix", "to")
-    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("copyFunNamingStrategy", "inner-name")
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
 }
@@ -52,7 +47,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*
@@ -60,37 +55,31 @@ import me.tbsten.cream.*
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceA] + [SourceB] -> [Target] copy function.
+ * [SourceA] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.to_Target(sourceB = SourceB(...), propertyC = propertyC)
+ * val target = sourceA.to_Target(propertyB = propertyB)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.to_Target(sourceB = SourceB(...), propertyC = propertyC, property = value)
+ * val target = sourceA.to_Target(propertyB = propertyB, property = value)
  * ```
  * 
  * 
  * @see SourceA
- * @see SourceB
  * @see Target
  */
 public fun  me.tbsten.cream.generated.SourceA.to_Target(
-    sourceB: me.tbsten.cream.generated.SourceB,
     propertyA: String = this.propertyA,
-    propertyB: Int = sourceB.propertyB,
-    propertyC: Boolean,
+    propertyB: Int,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
-    propertyC = propertyC,
 )
 ````

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotations.md
@@ -3,7 +3,6 @@
 ```kt
 package me.tbsten.cream.generated
 
-import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import me.tbsten.cream.CombineFrom
@@ -13,7 +12,6 @@ import me.tbsten.cream.CombineFrom
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
-  public val propertyC: Boolean,
 )
 
 public data class SourceA(
@@ -51,7 +49,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*
@@ -59,37 +57,62 @@ import me.tbsten.cream.*
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceA] + [SourceB] -> [Target] copy function.
+ * [SourceA] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.to_Target(sourceB = SourceB(...), propertyC = propertyC)
+ * val target = sourceA.to_Target(propertyB = propertyB)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.to_Target(sourceB = SourceB(...), propertyC = propertyC, property = value)
+ * val target = sourceA.to_Target(propertyB = propertyB, property = value)
  * ```
  * 
  * 
  * @see SourceA
- * @see SourceB
  * @see Target
  */
 public fun  me.tbsten.cream.generated.SourceA.to_Target(
-    sourceB: me.tbsten.cream.generated.SourceB,
     propertyA: String = this.propertyA,
-    propertyB: Int = sourceB.propertyB,
-    propertyC: Boolean,
+    propertyB: Int,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
-    propertyC = propertyC,
+)
+
+/**
+ * (Auto generate by @[CombineFrom] annotation of [Target])
+ * 
+ * [SourceB] -> [Target] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val sourceB = SourceB(...)
+ * val target = sourceB.to_Target(propertyA = propertyA)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val sourceB = SourceB(...)
+ * val target = sourceB.to_Target(propertyA = propertyA, property = value)
+ * ```
+ * 
+ * 
+ * @see SourceB
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.SourceB.to_Target(
+    propertyA: String,
+    propertyB: Int = this.propertyB,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    propertyA = propertyA,
+    propertyB = propertyB,
 )
 ````

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotationsDistinctFunNames.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotationsDistinctFunNames.md
@@ -9,15 +9,19 @@ import me.tbsten.cream.CombineFrom
 
 @CombineFrom(
   SourceA::class,
-  funName = "toTarget",
+  SourceB::class,
+  funName = "toFoo",
 )
 @CombineFrom(
-  SourceB::class,
-  funName = "toTarget",
+  SourceC::class,
+  SourceD::class,
+  funName = "toBar",
 )
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
+  public val propertyC: String,
+  public val propertyD: Int,
 )
 
 public data class SourceA(
@@ -26,6 +30,14 @@ public data class SourceA(
 
 public data class SourceB(
   public val propertyB: Int,
+)
+
+public data class SourceC(
+  public val propertyC: String,
+)
+
+public data class SourceD(
+  public val propertyD: Int,
 )
 ```
 
@@ -63,62 +75,78 @@ import me.tbsten.cream.*
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceA] -> [Target] copy function.
+ * [SourceA] + [SourceB] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val target = sourceA.toTarget(propertyB = propertyB)
+ * val sourceB = SourceB(...)
+ * val target = sourceA.toFoo(sourceB = SourceB(...), propertyC = propertyC, propertyD = propertyD)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val target = sourceA.toTarget(propertyB = propertyB, property = value)
+ * val sourceB = SourceB(...)
+ * val target = sourceA.toFoo(sourceB = SourceB(...), propertyC = propertyC, propertyD = propertyD, property = value)
  * ```
  * 
  * 
  * @see SourceA
+ * @see SourceB
  * @see Target
  */
-public fun  me.tbsten.cream.generated.SourceA.toTarget(
+public fun  me.tbsten.cream.generated.SourceA.toFoo(
+    sourceB: me.tbsten.cream.generated.SourceB,
     propertyA: String = this.propertyA,
-    propertyB: Int,
+    propertyB: Int = sourceB.propertyB,
+    propertyC: String,
+    propertyD: Int,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
+    propertyC = propertyC,
+    propertyD = propertyD,
 )
 
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceB] -> [Target] copy function.
+ * [SourceC] + [SourceD] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
- * val sourceB = SourceB(...)
- * val target = sourceB.toTarget(propertyA = propertyA)
+ * val sourceC = SourceC(...)
+ * val sourceD = SourceD(...)
+ * val target = sourceC.toBar(sourceD = SourceD(...), propertyA = propertyA, propertyB = propertyB)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
- * val sourceB = SourceB(...)
- * val target = sourceB.toTarget(propertyA = propertyA, property = value)
+ * val sourceC = SourceC(...)
+ * val sourceD = SourceD(...)
+ * val target = sourceC.toBar(sourceD = SourceD(...), propertyA = propertyA, propertyB = propertyB, property = value)
  * ```
  * 
  * 
- * @see SourceB
+ * @see SourceC
+ * @see SourceD
  * @see Target
  */
-public fun  me.tbsten.cream.generated.SourceB.toTarget(
+public fun  me.tbsten.cream.generated.SourceC.toBar(
+    sourceD: me.tbsten.cream.generated.SourceD,
     propertyA: String,
-    propertyB: Int = this.propertyB,
+    propertyB: Int,
+    propertyC: String = this.propertyC,
+    propertyD: Int = sourceD.propertyD,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
+    propertyC = propertyC,
+    propertyD = propertyD,
 )
 ````

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
@@ -38,13 +38,13 @@ COMPILATION_ERROR
 ## Output:Console
 
 ```kt
-e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Source__Target.kt:31:40 Cannot create an instance of an abstract class.
+e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Target.kt:31:40 Cannot create an instance of an abstract class.
 ```
 
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
@@ -38,13 +38,13 @@ COMPILATION_ERROR
 ## Output:Console
 
 ```kt
-e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Source__Outer.Target.kt:30:78 Constructor of the inner class 'inner class Target : Any' can only be called with a receiver of the containing class.
+e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Outer.Target.kt:30:78 Constructor of the inner class 'inner class Target : Any' can only be called with a receiver of the containing class.
 ```
 
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Outer.Target.kt
+// file: CombineFrom__Outer.Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
@@ -40,7 +40,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
@@ -38,13 +38,13 @@ COMPILATION_ERROR
 ## Output:Console
 
 ```kt
-e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Source__Target.kt:31:66 Cannot access 'constructor(name: String, extra: Int): Target': it is private in 'me.tbsten.cream.generated.Target'.
+e: file://<TMPDIR>/Kotlin-Compilation<N>/ksp/sources/kotlin/me/tbsten/cream/generated/CombineFrom__Target.kt:31:66 Cannot access 'constructor(name: String, extra: Int): Target': it is private in 'me.tbsten.cream.generated.Target'.
 ```
 
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/excludeOverlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/excludeOverlappingProperty.md
@@ -56,7 +56,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/mapAcrossSources.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/multiSourceGenerics.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/multiSourceGenerics.md
@@ -49,7 +49,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/overlappingProperty.md
@@ -55,7 +55,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/singleSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/singleSource.md
@@ -45,7 +45,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/threeSources.md
@@ -60,7 +60,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/twoSources.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
@@ -42,7 +42,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
@@ -41,7 +41,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
@@ -42,7 +42,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
@@ -43,7 +43,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__Source__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/collectionProp.md
@@ -52,7 +52,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/customTypeProp.md
@@ -55,7 +55,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/mixedPrimitives.md
@@ -57,7 +57,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/nullableProp.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/stringProp.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/zeroProps.md
@@ -42,7 +42,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/05--matching/typeIncompatible.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/06--map/multipleMappings.md
@@ -55,7 +55,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/06--map/singleMapping.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/07--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/07--exclude/excludeNoEffect.md
@@ -53,7 +53,7 @@ w: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:14: @Exclude on 'target
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/07--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/07--exclude/excludedProperty.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/08--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/08--kdoc/description.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/08--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/08--kdoc/descriptionAndExamples.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/internalTargetClass.md
@@ -51,7 +51,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/propertyVisibilities.md
@@ -54,7 +54,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverrideInternal.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverridePublic.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/10--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/10--funName/literalFunName.md
@@ -52,7 +52,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/10--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/10--funName/tokenFunName.md
@@ -53,7 +53,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/duplicateOccurrenceRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/duplicateOccurrenceRejected.md
@@ -7,14 +7,8 @@ import kotlin.Int
 import kotlin.String
 import me.tbsten.cream.CombineFrom
 
-@CombineFrom(
-  SourceA::class,
-  funName = "toFoo",
-)
-@CombineFrom(
-  SourceB::class,
-  funName = "toBar",
-)
+@CombineFrom(SourceA::class)
+@CombineFrom(SourceA::class)
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
@@ -22,10 +16,6 @@ public data class Target(
 
 public data class SourceA(
   public val propertyA: String,
-)
-
-public data class SourceB(
-  public val propertyB: Int,
 )
 ```
 
@@ -50,12 +40,11 @@ COMPILATION_ERROR
 
 ```kt
 e: Error occurred in KSP, check log for detail
-e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:15: Invalid cream usage: @CombineFrom on me.tbsten.cream.generated.Target is repeated with conflicting funName values:
-"toFoo", "toBar"
-Stacked @CombineFrom annotations are merged into a single generated function, so funName must be unambiguous.
+e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:9: Invalid cream usage: @CombineFrom on me.tbsten.cream.generated.Target generates the same overload more than once: SourceA.copyToTarget().
+Stacked @CombineFrom annotations are written to one file, so each must produce a distinct overload.
 
 Solution: 
-  Set the same funName on every @CombineFrom of me.tbsten.cream.generated.Target, or set it on only one.
+  Give one of the duplicate @CombineFrom a distinct funName, or change its sources.
 ```
 
 ## Output:Generated sources

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/duplicateSourceWithinOccurrence.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/duplicateSourceWithinOccurrence.md
@@ -3,26 +3,21 @@
 ```kt
 package me.tbsten.cream.generated
 
-import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import me.tbsten.cream.CombineFrom
 
-@CombineFrom(SourceA::class)
-@CombineFrom(SourceA::class)
-@CombineFrom(SourceB::class)
+@CombineFrom(
+  SourceA::class,
+  SourceA::class,
+)
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
-  public val propertyC: Boolean,
 )
 
 public data class SourceA(
   public val propertyA: String,
-)
-
-public data class SourceB(
-  public val propertyB: Int,
 )
 ```
 
@@ -30,9 +25,9 @@ public data class SourceB(
 
 ```kt
 ksp {
-    arg("copyFunNamePrefix", "to")
-    arg("copyFunNamingStrategy", "inner-name")
-    arg("escapeDot", "replace-to-underscore")
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
 }
 ```
@@ -52,7 +47,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*
@@ -60,37 +55,31 @@ import me.tbsten.cream.*
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceA] + [SourceB] -> [Target] copy function.
+ * [SourceA] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.to_Target(sourceB = SourceB(...), propertyC = propertyC)
+ * val target = sourceA.copyToTarget(propertyB = propertyB)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.to_Target(sourceB = SourceB(...), propertyC = propertyC, property = value)
+ * val target = sourceA.copyToTarget(propertyB = propertyB, property = value)
  * ```
  * 
  * 
  * @see SourceA
- * @see SourceB
  * @see Target
  */
-public fun  me.tbsten.cream.generated.SourceA.to_Target(
-    sourceB: me.tbsten.cream.generated.SourceB,
+public fun  me.tbsten.cream.generated.SourceA.copyToTarget(
     propertyA: String = this.propertyA,
-    propertyB: Int = sourceB.propertyB,
-    propertyC: Boolean,
+    propertyB: Int,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
-    propertyC = propertyC,
 )
 ````

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/stackedAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/stackedAnnotations.md
@@ -3,7 +3,6 @@
 ```kt
 package me.tbsten.cream.generated
 
-import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import me.tbsten.cream.CombineFrom
@@ -13,7 +12,6 @@ import me.tbsten.cream.CombineFrom
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
-  public val propertyC: Boolean,
 )
 
 public data class SourceA(
@@ -51,7 +49,7 @@ OK
 ## Output:Generated sources
 
 ````kt
-// file: CombineFrom__SourceA__Target.kt
+// file: CombineFrom__Target.kt
 package me.tbsten.cream.generated
 
 import me.tbsten.cream.*
@@ -59,37 +57,62 @@ import me.tbsten.cream.*
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceA] + [SourceB] -> [Target] copy function.
+ * [SourceA] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.copyToTarget(sourceB = SourceB(...), propertyC = propertyC)
+ * val target = sourceA.copyToTarget(propertyB = propertyB)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val sourceB = SourceB(...)
- * val target = sourceA.copyToTarget(sourceB = SourceB(...), propertyC = propertyC, property = value)
+ * val target = sourceA.copyToTarget(propertyB = propertyB, property = value)
  * ```
  * 
  * 
  * @see SourceA
- * @see SourceB
  * @see Target
  */
 public fun  me.tbsten.cream.generated.SourceA.copyToTarget(
-    sourceB: me.tbsten.cream.generated.SourceB,
     propertyA: String = this.propertyA,
-    propertyB: Int = sourceB.propertyB,
-    propertyC: Boolean,
+    propertyB: Int,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
-    propertyC = propertyC,
+)
+
+/**
+ * (Auto generate by @[CombineFrom] annotation of [Target])
+ * 
+ * [SourceB] -> [Target] copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val sourceB = SourceB(...)
+ * val target = sourceB.copyToTarget(propertyA = propertyA)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val sourceB = SourceB(...)
+ * val target = sourceB.copyToTarget(propertyA = propertyA, property = value)
+ * ```
+ * 
+ * 
+ * @see SourceB
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.SourceB.copyToTarget(
+    propertyA: String,
+    propertyB: Int = this.propertyB,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    propertyA = propertyA,
+    propertyB = propertyB,
 )
 ````

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/stackedAnnotationsDistinctFunNames.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/stackedAnnotationsDistinctFunNames.md
@@ -9,15 +9,19 @@ import me.tbsten.cream.CombineFrom
 
 @CombineFrom(
   SourceA::class,
-  funName = "toTarget",
+  SourceB::class,
+  funName = "toFoo",
 )
 @CombineFrom(
-  SourceB::class,
-  funName = "toTarget",
+  SourceC::class,
+  SourceD::class,
+  funName = "toBar",
 )
 public data class Target(
   public val propertyA: String,
   public val propertyB: Int,
+  public val propertyC: String,
+  public val propertyD: Int,
 )
 
 public data class SourceA(
@@ -26,6 +30,14 @@ public data class SourceA(
 
 public data class SourceB(
   public val propertyB: Int,
+)
+
+public data class SourceC(
+  public val propertyC: String,
+)
+
+public data class SourceD(
+  public val propertyD: Int,
 )
 ```
 
@@ -63,62 +75,78 @@ import me.tbsten.cream.*
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceA] -> [Target] copy function.
+ * [SourceA] + [SourceB] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val target = sourceA.toTarget(propertyB = propertyB)
+ * val sourceB = SourceB(...)
+ * val target = sourceA.toFoo(sourceB = SourceB(...), propertyC = propertyC, propertyD = propertyD)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
  * val sourceA = SourceA(...)
- * val target = sourceA.toTarget(propertyB = propertyB, property = value)
+ * val sourceB = SourceB(...)
+ * val target = sourceA.toFoo(sourceB = SourceB(...), propertyC = propertyC, propertyD = propertyD, property = value)
  * ```
  * 
  * 
  * @see SourceA
+ * @see SourceB
  * @see Target
  */
-public fun  me.tbsten.cream.generated.SourceA.toTarget(
+public fun  me.tbsten.cream.generated.SourceA.toFoo(
+    sourceB: me.tbsten.cream.generated.SourceB,
     propertyA: String = this.propertyA,
-    propertyB: Int,
+    propertyB: Int = sourceB.propertyB,
+    propertyC: String,
+    propertyD: Int,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
+    propertyC = propertyC,
+    propertyD = propertyD,
 )
 
 /**
  * (Auto generate by @[CombineFrom] annotation of [Target])
  * 
- * [SourceB] -> [Target] copy function.
+ * [SourceC] + [SourceD] -> [Target] copy function.
  * 
  * # Example: Basic
  * 
  * ```kt
- * val sourceB = SourceB(...)
- * val target = sourceB.toTarget(propertyA = propertyA)
+ * val sourceC = SourceC(...)
+ * val sourceD = SourceD(...)
+ * val target = sourceC.toBar(sourceD = SourceD(...), propertyA = propertyA, propertyB = propertyB)
  * ```
  * 
  * # Example: Override property values
  * 
  * ```kt
- * val sourceB = SourceB(...)
- * val target = sourceB.toTarget(propertyA = propertyA, property = value)
+ * val sourceC = SourceC(...)
+ * val sourceD = SourceD(...)
+ * val target = sourceC.toBar(sourceD = SourceD(...), propertyA = propertyA, propertyB = propertyB, property = value)
  * ```
  * 
  * 
- * @see SourceB
+ * @see SourceC
+ * @see SourceD
  * @see Target
  */
-public fun  me.tbsten.cream.generated.SourceB.toTarget(
+public fun  me.tbsten.cream.generated.SourceC.toBar(
+    sourceD: me.tbsten.cream.generated.SourceD,
     propertyA: String,
-    propertyB: Int = this.propertyB,
+    propertyB: Int,
+    propertyC: String = this.propertyC,
+    propertyD: Int = sourceD.propertyD,
 ) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
     propertyA = propertyA,
     propertyB = propertyB,
+    propertyC = propertyC,
+    propertyD = propertyD,
 )
 ````


### PR DESCRIPTION
## 概要

`@CombineFrom` は `@Repeatable` ですが、これまでは**重ねた全 occurrence の `sources` を 1 つにフラット化（dedup）して 1 個の combine 関数にマージ**していました。本 PR で **occurrence ごとに別々の combine 関数を生成**するよう修正します（`@SealedCopy` の per-occurrence モデルと同じ形）。source 集合が異なれば引数型が異なるため、同名でもオーバーロードとして両立します。

Closes #134

## 旧挙動 → 新挙動

```kotlin
@CombineFrom(LoadingState::class, SuccessAction::class)
@CombineFrom(LoadingState::class, SpecialSuccessAction::class)
data class SuccessState(/* ... */)
```

- **旧**: 全 occurrence の sources（`LoadingState`, `SuccessAction`, `SpecialSuccessAction`）をフラット化し、**1 個**の combine 関数を生成。さらに 2 つの occurrence が異なる `funName` を指定すると conflict としてコンパイルエラーにしていた。
- **新**: occurrence ごとに **2 個**の combine 関数を生成。

```kotlin
fun LoadingState.copyToSuccessState(successAction: SuccessAction, /* ... */): SuccessState
fun LoadingState.copyToSuccessState(specialSuccessAction: SpecialSuccessAction, /* ... */): SuccessState
```

## funName / conflict 判定の変更

- `funName` は **occurrence 単位**で解決する。
- conflict 検出は「全 occurrence を横断した funName の不一致」ではなく、**同名関数のオーバーロード衝突**（resolve 後の funName と ordered な source 一覧がともに一致）に対してのみ行う（`@SealedCopy` の duplicate-funName 検出と同様）。
  - **異なる source 集合**に**異なる funName**を付けても**エラーにならない**（両方生成）。
  - **同一 source 集合 × 同一 funName** の occurrence が 2 つ以上ある場合のみ、redeclaration として clean なコンパイルエラー（`duplicateOccurrenceRejected`）。
- 1 occurrence 内の重複 source（`@CombineFrom(A::class, A::class)`）は従来どおり dedup（#101）。

## 出力ファイル / GSA

- ある target の全 occurrence を 1 ファイル（`CombineFrom__<Target>.kt`）に、1 つの `Dependencies` でまとめて出力する。各関数の KDoc `@see` は occurrence 単位。occurrence が同じ primary source を共有しても衝突しない（issue の例がまさにこのケース）。
- 付随する GSA リファクタ: `GenerateSourceAnnotation.CombineFrom.funNameTemplate` のコンストラクタ引数を削除し、各 occurrence の GSA が自分の生 `KSAnnotation` から funName/KDoc/visibility を導出するようにした（raw `KSAnnotation` 保持への移行の総仕上げ）。

## golden 再生成のスコープ

`./gradlew :cream-ksp:test -Dcream.snapshot.update=true` で再生成。

- **構造的なケース**（single-occurrence）: 生成関数の本体は byte 一致のまま。差分は `// file:` 行のみ（`CombineFrom__SourceA__Target.kt` → `CombineFrom__Target.kt`）。
- **`repeatable` ファミリ**: per-occurrence の関数を表示するよう変化（=これが本修正）。
  - `stackedAnnotations` / `stackedAnnotationsSameFunName`: 同名 2 オーバーロード。
  - `stackedAnnotationsDistinctFunNames`（新規 / 旧 `conflictingFunNamesRejected`）: 別名 2 関数（旧挙動ではコンパイルエラーだった）。
  - `duplicateOccurrenceRejected`（新規 / 旧 `duplicateSourceDeduped` を改題）: 同一 source × 同一 funName の 2 occurrence → COMPILATION_ERROR。
  - `duplicateSourceWithinOccurrence`（新規）: 1 occurrence 内の重複 source dedup（#101）。

## テスト

- 統合テスト `test/.../combineFrom/Repeatable*`: 同一 primary source を共有する複数 occurrence がオーバーロード combine 関数を生成して両方呼べること、別 funName が別名関数として両方生成されることを検証。
- snapshot: 上記 `repeatable` ファミリを再設計し golden を再生成。
- diagnostic: `duplicateOccurrenceRejected` golden で genuine な overload 衝突が COMPILATION_ERROR になることを固定。

## 検証

以下を worktree 上で実行し green を確認:

- `./gradlew :cream-ksp:compileTestKotlin`
- `./gradlew :cream-ksp:test`（golden 再生成後、フラグ無しで output-preserving を確認）
- `./gradlew :test:jvmTest`
- `./gradlew :cream-ksp:ktlintMainSourceSetFormat :cream-ksp:ktlintTestSourceSetFormat :test:ktlintCommonMainSourceSetFormat :test:ktlintCommonTestSourceSetFormat` → 対応する `*Check` も pass

（ルート `ktlintFormat` / `ktlintCheck` は本 worktree に Android SDK 未設定のため `:test` の Android KSP タスクで失敗する。これは環境要因で、変更したソースセットには scoped な ktlint タスクで対応済み。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAiiB1gueBky3gV7M5DYpW
