### PR TITLE
feat(copyMapping): add visibility argument to @CopyMapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,7 +705,9 @@ Each `examples` entry is rendered verbatim — provide your own `# heading` and
 By default the generated copy function inherits the visibility of the target (or sealed)
 declaration it is derived from. Pass `visibility = CopyVisibility.<...>` to the copy-generating
 annotations (`@CopyTo`, `@CopyFrom`, `@CopyToChildren`, `@SealedCopy`, `@CombineTo`,
-`@CombineFrom`) to force a specific visibility instead.
+`@CombineFrom`, `@CopyMapping`, `@CombineMapping`) to force a specific visibility instead. For a
+reversible (`canReverse`) `@CopyMapping`, the same visibility is applied to both the forward and
+reverse functions.
 
 ```kt
 @CopyTo(MergedState::class, visibility = CopyVisibility.INTERNAL)

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingSnapshotTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/CopyMappingSnapshotTest.kt
@@ -1,6 +1,6 @@
 package me.tbsten.cream.ksp.feature.copyMapping
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.FreeSpec
 import me.tbsten.cream.ksp.feature.copyMapping.scenario.canReverseScenarios
 import me.tbsten.cream.ksp.feature.copyMapping.scenario.constructorScenarios
 import me.tbsten.cream.ksp.feature.copyMapping.scenario.funNameScenarios
@@ -26,8 +26,6 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  *
  * Intentionally NOT covered as snapshot cases (and why):
  * - `@Exclude` — `@CopyMapping` has none (source/target are external classes you cannot annotate).
- * - visibility-override cases — `@CopyMapping` has NO `visibility` arg, so the generated fn inherits the TARGET
- *   class visibility; the `visibility` family is reduced to `internalTargetClass` + `propertyVisibilities`.
  * - `typealias` source/target — `SnapshotScenario` can't carry a `TypeAliasSpec`; covered by integration `TypeAliasTest`.
  * - cross-package `@Repeatable` multi-file fan-out (`groupBy { sourceClass.packageName }` → N files) — needs the
  *   multi-`FileSpec` overload (single `GENERATED_PACKAGE` here); `repeatable/multipleAnnotations` covers same-package.
@@ -39,8 +37,8 @@ import me.tbsten.cream.ksp.testing.poet.toFileSpec
  *   FROZEN as a known-quirk golden, not patched.
  */
 internal class CopyMappingSnapshotTest :
-    FunSpec({
-        context("All patterns") {
+    FreeSpec({
+        "All patterns" - {
             cartesian(
                 union {
                     withNumberPrefix(length = 2) {
@@ -65,7 +63,7 @@ internal class CopyMappingSnapshotTest :
                 .forEach { (testCaseName, value) ->
                     val (scenario, creamOptions) = value
 
-                    test(testCaseName!!) {
+                    testCaseName!! {
                         runCompileSnapshotTest(input = scenario.toFileSpec(), options = creamOptions)
                     }
                 }

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/scenario/Utils.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/scenario/Utils.kt
@@ -5,10 +5,11 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.TypeSpec
 import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
 import me.tbsten.cream.ksp.testing.poet.SnapshotScenario
 import me.tbsten.cream.ksp.testing.poet.classNameOf
 
-/** `@CopyMapping` を載せる holder。生成関数の可視性は holder ではなく target に従う。 */
+/** `@CopyMapping` を載せる holder。生成関数の可視性は visibility 引数（無ければ target）に従う。 */
 internal fun mappingHolder(): TypeSpec = TypeSpec.objectBuilder("Mapping").build()
 
 /** [this] を holder として `@CopyMapping([source], [target], …)` を付与する。 */
@@ -17,6 +18,7 @@ internal fun TypeSpec.withCopyMapping(
     target: ClassName,
     canReverse: Boolean = false,
     properties: List<Pair<String, String>> = emptyList(),
+    visibility: CopyVisibility? = null,
     kdoc: CodeBlock? = null,
     funName: CodeBlock? = null,
 ): TypeSpec =
@@ -29,6 +31,7 @@ internal fun TypeSpec.withCopyMapping(
                 .apply {
                     if (canReverse) addMember("%L = %L", CopyMapping::canReverse.name, true)
                     if (properties.isNotEmpty()) addMember("%L = %L", CopyMapping::properties.name, propertiesBlock(properties))
+                    if (visibility != null) addMember("${CopyMapping::visibility.name} = %T.%L", CopyVisibility::class, visibility.name)
                     if (kdoc != null) addMember("%L = %L", CopyMapping::kdoc.name, kdoc)
                     if (funName != null) addMember("%L = %L", CopyMapping::funName.name, funName)
                 }.build(),
@@ -44,11 +47,12 @@ internal fun copyMapping(
     target: TypeSpec,
     canReverse: Boolean = false,
     properties: List<Pair<String, String>> = emptyList(),
+    visibility: CopyVisibility? = null,
     kdoc: CodeBlock? = null,
     funName: CodeBlock? = null,
 ): SnapshotScenario =
     SnapshotScenario(
-        holder.withCopyMapping(classNameOf(source.name!!), classNameOf(target.name!!), canReverse, properties, kdoc, funName),
+        holder.withCopyMapping(classNameOf(source.name!!), classNameOf(target.name!!), canReverse, properties, visibility, kdoc, funName),
         source,
         target,
     )

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/scenario/Visibility.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyMapping/scenario/Visibility.kt
@@ -5,6 +5,7 @@ import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.KModifier.DATA
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.PRIVATE
+import me.tbsten.cream.CopyVisibility
 import me.tbsten.cream.ksp.testing.generator.Generator
 import me.tbsten.cream.ksp.testing.poet.Prop
 import me.tbsten.cream.ksp.testing.poet.SnapshotScenario
@@ -30,5 +31,28 @@ internal fun visibilityScenarios(): Generator<SnapshotScenario> =
                     Prop("privateProp", BOOLEAN, visibility = PRIVATE),
                 ),
                 dataClass("Target", Prop("publicProp"), Prop("extra")),
+            ),
+        "visibilityOverridePublic" to
+            copyMapping(
+                mappingHolder(),
+                dataClass("Source", Prop("name")),
+                dataClass("Target", Prop("name"), Prop("extra", INT)),
+                visibility = CopyVisibility.PUBLIC,
+            ),
+        "visibilityOverrideInternal" to
+            copyMapping(
+                mappingHolder(),
+                dataClass("Source", Prop("name")),
+                dataClass("Target", Prop("name"), Prop("extra", INT)),
+                visibility = CopyVisibility.INTERNAL,
+            ),
+        // canReverse + visibility: the same modifier must land on BOTH the forward and reverse functions.
+        "visibilityOverrideReversed" to
+            copyMapping(
+                mappingHolder(),
+                dataClass("Source", Prop("shared"), Prop("sourceOnly", INT)),
+                dataClass("Target", Prop("shared"), Prop("targetOnly", BOOLEAN)),
+                canReverse = true,
+                visibility = CopyVisibility.INTERNAL,
             ),
     )

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideInternal.md
@@ -1,0 +1,89 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.Int
+import kotlin.String
+import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
+
+@CopyMapping(
+  Source::class,
+  Target::class,
+  visibility = CopyVisibility.INTERNAL,
+)
+public object Mapping
+
+public data class Source(
+  public val name: String,
+)
+
+public data class Target(
+  public val name: String,
+  public val extra: Int,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyMapping__Mapping.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(extra = extra)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(extra = extra, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+internal fun  me.tbsten.cream.generated.Source.to_Target(
+    name: String = this.name,
+    extra: Int,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    name = name,
+    extra = extra,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverridePublic.md
@@ -1,0 +1,89 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.Int
+import kotlin.String
+import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
+
+@CopyMapping(
+  Source::class,
+  Target::class,
+  visibility = CopyVisibility.PUBLIC,
+)
+public object Mapping
+
+public data class Source(
+  public val name: String,
+)
+
+public data class Target(
+  public val name: String,
+  public val extra: Int,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyMapping__Mapping.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(extra = extra)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(extra = extra, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.Source.to_Target(
+    name: String = this.name,
+    extra: Int,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    name = name,
+    extra = extra,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideReversed.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideReversed.md
@@ -1,0 +1,123 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
+
+@CopyMapping(
+  Source::class,
+  Target::class,
+  canReverse = true,
+  visibility = CopyVisibility.INTERNAL,
+)
+public object Mapping
+
+public data class Source(
+  public val shared: String,
+  public val sourceOnly: Int,
+)
+
+public data class Target(
+  public val shared: String,
+  public val targetOnly: Boolean,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyMapping__Mapping.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(targetOnly = targetOnly)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(targetOnly = targetOnly, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+internal fun  me.tbsten.cream.generated.Source.to_Target(
+    shared: String = this.shared,
+    targetOnly: Boolean,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    shared = shared,
+    targetOnly = targetOnly,
+)
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Target -> Source copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Target(...)
+ * val target = source.to_Source(sourceOnly = sourceOnly)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Target(...)
+ * val target = source.to_Source(sourceOnly = sourceOnly, property = value)
+ * ```
+ * 
+ * 
+ * @see Target
+ * @see Source
+ */
+internal fun  me.tbsten.cream.generated.Target.to_Source(
+    shared: String = this.shared,
+    sourceOnly: Int,
+) : me.tbsten.cream.generated.Source = me.tbsten.cream.generated.Source(
+    shared = shared,
+    sourceOnly = sourceOnly,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideInternal.md
@@ -1,0 +1,89 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.Int
+import kotlin.String
+import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
+
+@CopyMapping(
+  Source::class,
+  Target::class,
+  visibility = CopyVisibility.INTERNAL,
+)
+public object Mapping
+
+public data class Source(
+  public val name: String,
+)
+
+public data class Target(
+  public val name: String,
+  public val extra: Int,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "inner-name")
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyMapping__Mapping.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(extra = extra)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(extra = extra, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+internal fun  me.tbsten.cream.generated.Source.to_Target(
+    name: String = this.name,
+    extra: Int,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    name = name,
+    extra = extra,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/10--visibility/visibilityOverridePublic.md
@@ -1,0 +1,89 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.Int
+import kotlin.String
+import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
+
+@CopyMapping(
+  Source::class,
+  Target::class,
+  visibility = CopyVisibility.PUBLIC,
+)
+public object Mapping
+
+public data class Source(
+  public val name: String,
+)
+
+public data class Target(
+  public val name: String,
+  public val extra: Int,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "inner-name")
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyMapping__Mapping.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(extra = extra)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(extra = extra, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.Source.to_Target(
+    name: String = this.name,
+    extra: Int,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    name = name,
+    extra = extra,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideReversed.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideReversed.md
@@ -1,0 +1,123 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
+
+@CopyMapping(
+  Source::class,
+  Target::class,
+  canReverse = true,
+  visibility = CopyVisibility.INTERNAL,
+)
+public object Mapping
+
+public data class Source(
+  public val shared: String,
+  public val sourceOnly: Int,
+)
+
+public data class Target(
+  public val shared: String,
+  public val targetOnly: Boolean,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "inner-name")
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyMapping__Mapping.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(targetOnly = targetOnly)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(targetOnly = targetOnly, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+internal fun  me.tbsten.cream.generated.Source.to_Target(
+    shared: String = this.shared,
+    targetOnly: Boolean,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    shared = shared,
+    targetOnly = targetOnly,
+)
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Target -> Source copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Target(...)
+ * val target = source.to_Source(sourceOnly = sourceOnly)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Target(...)
+ * val target = source.to_Source(sourceOnly = sourceOnly, property = value)
+ * ```
+ * 
+ * 
+ * @see Target
+ * @see Source
+ */
+internal fun  me.tbsten.cream.generated.Target.to_Source(
+    shared: String = this.shared,
+    sourceOnly: Int,
+) : me.tbsten.cream.generated.Source = me.tbsten.cream.generated.Source(
+    shared = shared,
+    sourceOnly = sourceOnly,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideInternal.md
@@ -1,0 +1,89 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.Int
+import kotlin.String
+import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
+
+@CopyMapping(
+  Source::class,
+  Target::class,
+  visibility = CopyVisibility.INTERNAL,
+)
+public object Mapping
+
+public data class Source(
+  public val name: String,
+)
+
+public data class Target(
+  public val name: String,
+  public val extra: Int,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyMapping__Mapping.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(extra = extra)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(extra = extra, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+internal fun  me.tbsten.cream.generated.Source.copyToTarget(
+    name: String = this.name,
+    extra: Int,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    name = name,
+    extra = extra,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverridePublic.md
@@ -1,0 +1,89 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.Int
+import kotlin.String
+import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
+
+@CopyMapping(
+  Source::class,
+  Target::class,
+  visibility = CopyVisibility.PUBLIC,
+)
+public object Mapping
+
+public data class Source(
+  public val name: String,
+)
+
+public data class Target(
+  public val name: String,
+  public val extra: Int,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyMapping__Mapping.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(extra = extra)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(extra = extra, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.Source.copyToTarget(
+    name: String = this.name,
+    extra: Int,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    name = name,
+    extra = extra,
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideReversed.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideReversed.md
@@ -1,0 +1,123 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
+
+@CopyMapping(
+  Source::class,
+  Target::class,
+  canReverse = true,
+  visibility = CopyVisibility.INTERNAL,
+)
+public object Mapping
+
+public data class Source(
+  public val shared: String,
+  public val sourceOnly: Int,
+)
+
+public data class Target(
+  public val shared: String,
+  public val targetOnly: Boolean,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyMapping__Mapping.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(targetOnly = targetOnly)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(targetOnly = targetOnly, property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+internal fun  me.tbsten.cream.generated.Source.copyToTarget(
+    shared: String = this.shared,
+    targetOnly: Boolean,
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+    shared = shared,
+    targetOnly = targetOnly,
+)
+
+/**
+ * (Auto generate by @[CopyMapping] annotation of [Mapping])
+ * 
+ * Target -> Source copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Target(...)
+ * val target = source.copyToSource(sourceOnly = sourceOnly)
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Target(...)
+ * val target = source.copyToSource(sourceOnly = sourceOnly, property = value)
+ * ```
+ * 
+ * 
+ * @see Target
+ * @see Source
+ */
+internal fun  me.tbsten.cream.generated.Target.copyToSource(
+    shared: String = this.shared,
+    sourceOnly: Int,
+) : me.tbsten.cream.generated.Source = me.tbsten.cream.generated.Source(
+    shared = shared,
+    sourceOnly = sourceOnly,
+)
+````

--- a/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyMapping.kt
+++ b/cream-runtime/src/commonMain/kotlin/me/tbsten/cream/CopyMapping.kt
@@ -89,9 +89,14 @@ import kotlin.reflect.KClass
  *   (cream's derived name). Embed naming tokens such as [CopyTargetSimpleName] to compose a name.
  *   When `canReverse` is true (or the target is sealed) use a token so the forward and reverse
  *   functions get distinct names. See `CopyFunctionNameToken.kt`.
+ * @param visibility Visibility modifier of the generated copy function. Defaults to
+ *   [CopyVisibility.INHERIT], which keeps cream's existing behaviour (the function inherits
+ *   the target class's visibility). When `canReverse` is true, the same visibility is applied
+ *   to both the forward and reverse functions.
  *
  * @see CopyTo
  * @see CopyFrom
+ * @see CopyVisibility
  * @see DefaultCopyFunctionName
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS)
@@ -104,6 +109,7 @@ public annotation class CopyMapping(
     val properties: Array<Map> = [],
     val kdoc: KDoc = KDoc(),
     val funName: String = DefaultCopyFunctionName,
+    val visibility: CopyVisibility = CopyVisibility.INHERIT,
 ) {
     /**
      * Defines a property name mapping between source and target classes.

--- a/test/src/commonMain/kotlin/me/tbsten/cream/test/copyMapping/CopyVisibility.kt
+++ b/test/src/commonMain/kotlin/me/tbsten/cream/test/copyMapping/CopyVisibility.kt
@@ -1,0 +1,27 @@
+package me.tbsten.cream.test.copyMapping
+
+import me.tbsten.cream.CopyMapping
+import me.tbsten.cream.CopyVisibility
+
+/**
+ * Library models whose generated copy functions are forced to `internal` via the `visibility`
+ * argument. With `canReverse = true`, the same visibility must be applied to BOTH the forward
+ * (`LibA -> LibB`) and reverse (`LibB -> LibA`) functions.
+ */
+data class InternalVisibilityLibA(
+    val shared: String,
+    val aProp: Int,
+)
+
+data class InternalVisibilityLibB(
+    val shared: String,
+    val bProp: Boolean,
+)
+
+@CopyMapping(
+    InternalVisibilityLibA::class,
+    InternalVisibilityLibB::class,
+    canReverse = true,
+    visibility = CopyVisibility.INTERNAL,
+)
+private object InternalVisibilityMapping

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/CopyVisibilityTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyMapping/CopyVisibilityTest.kt
@@ -1,0 +1,26 @@
+package me.tbsten.cream.test.copyMapping
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class CopyVisibilityTest :
+    FreeSpec({
+        // The `internal` visibility modifier itself is pinned by the snapshot tests (the golden
+        // output shows the `internal` keyword on the generated functions); callability alone cannot
+        // distinguish `internal` from `public`. This integration test instead covers the
+        // bidirectional generation and runtime behaviour of a `canReverse = true` mapping: both the
+        // forward and reverse functions are generated and produce the expected values.
+        "internalForwardCopyFunctionIsCallable" {
+            val source = InternalVisibilityLibA(shared = "value", aProp = 1)
+            val target: InternalVisibilityLibB = source.copyToInternalVisibilityLibB(bProp = true)
+
+            target shouldBe InternalVisibilityLibB("value", true)
+        }
+
+        "internalReverseCopyFunctionIsCallable" {
+            val source = InternalVisibilityLibB(shared = "value", bProp = false)
+            val target: InternalVisibilityLibA = source.copyToInternalVisibilityLibA(aProp = 7)
+
+            target shouldBe InternalVisibilityLibA("value", 7)
+        }
+    })


### PR DESCRIPTION
## 概要

`@CopyMapping` には `visibility` 引数が無く、対になる `@CombineMapping`（`visibility` あり）と非対称でした。本 PR で `@CopyMapping` にも `visibility: CopyVisibility = CopyVisibility.INHERIT` を追加し、両者を揃えます。

`canReverse = true` で順方向・逆方向の両関数を生成する場合は、両方に同じ visibility を適用します。

## 変更内容

- `cream-runtime`: `@CopyMapping` に `visibility: CopyVisibility = CopyVisibility.INHERIT` を追加（KDoc の `@param visibility` / `@see CopyVisibility` も `@CombineMapping` に合わせて追記）。
- 生成側のコード変更は不要。`GenerateSourceAnnotation` の既定 `visibility` getter が raw アノテーションから値を読むため、順方向・逆方向の両 GSA が同一の raw アノテーションを共有し、自動的に同じ visibility が適用される（`copyFun` は既に `generateSourceAnnotation.visibility.toModifierString(...)` を出力）。
- README の Visibility セクションの対応アノテーション一覧に `@CopyMapping` / `@CombineMapping` を追記。

## テスト

- snapshot（`cream-ksp`）: copyMapping の visibility シナリオに `visibilityOverridePublic` / `visibilityOverrideInternal` / `visibilityOverrideReversed` を追加。逆方向ゴールデンで順方向・逆方向の **両関数** が `internal` になることを確認（9 golden = 3 シナリオ × 3 option、差分は copyMapping の `10--visibility/` 配下のみ）。
- 結合テスト（`test/`）: `CopyVisibility(Test)` で `canReverse` + `visibility = INTERNAL` の mapping を両方向呼び出して検証。

## 検証（すべて green）

- `./gradlew :cream-ksp:compileTestKotlin`
- `./gradlew :cream-ksp:test`（フルスイート、BUILD SUCCESSFUL / 失敗 0）
- `./gradlew :cream-ksp:test --tests "*CopyMapping*"`
- `./gradlew :test:jvmTest`
- `./gradlew ktlintFormat` → `./gradlew ktlintCheck`

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAiiB1gueBky3gV7M5DYpW
