### PR TITLE
fix(cream-ksp): accept annotation-class copy targets (#132)

### DIFF
--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/common/TargetValidation.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/common/TargetValidation.kt
@@ -11,7 +11,8 @@ import me.tbsten.cream.ksp.InvalidCreamUsageException
  * Why a class declaration cannot be used as the *target* of a generated copy / combine function.
  *
  * cream generates `Target(prop = ...)` to build the target, so a valid target must be a concrete
- * class (or object) whose primary constructor the generated code can call. `@CopyTo` / `@CopyFrom`
+ * class, annotation class, or object whose primary constructor the generated code can call (Kotlin
+ * allows instantiating an annotation class via its constructor since 1.6). `@CopyTo` / `@CopyFrom`
  * additionally accept a sealed type (interface or class), which is not rejected but fans out to its
  * concrete subclasses. The dispatcher ([me.tbsten.cream.ksp.core.copyFun.appendCopyFunction]) decides
  * which rejection applies per [com.google.devtools.ksp.symbol.ClassKind]; this enum is the single
@@ -36,10 +37,6 @@ internal enum class CopyTargetRejection(
     NON_SEALED_INTERFACE(
         message = "Unsupported target interface (%s). It must be a sealed interface.",
         solution = "Please make %s a sealed interface.",
-    ),
-    ANNOTATION_CLASS(
-        message = "Unsupported target annotation class (%s). An annotation class cannot be used as a target.",
-        solution = "Specify a class, object, or sealed interface as the target.",
     ),
     ENUM_CLASS(
         message = "Unsupported target enum class (%s). An enum entry cannot be constructed as a target.",
@@ -72,8 +69,9 @@ internal enum class CopyTargetRejection(
  * subclasses instead of rejecting it, so this function is only reached for non-sealed classes.
  * (A sealed class would otherwise be caught by the `abstract` case below, since `sealed` implies
  * `abstract`.) Checks `abstract`, then `inner`, and finally the primary constructor visibility for
- * an otherwise concrete class. Only applies to `ClassKind.CLASS`; other kinds (interface / enum /
- * object / annotation class) are routed by the dispatcher.
+ * an otherwise concrete class. Applies to `ClassKind.CLASS` and `ClassKind.ANNOTATION_CLASS` (an
+ * annotation class is never abstract / inner and its primary constructor is public, so it is always
+ * accepted as a target); other kinds (interface / enum / object) are routed by the dispatcher.
  */
 internal fun KSClassDeclaration.concreteClassRejection(): CopyTargetRejection? =
     when {

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/common/TargetValidation.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/common/TargetValidation.kt
@@ -11,8 +11,7 @@ import me.tbsten.cream.ksp.InvalidCreamUsageException
  * Why a class declaration cannot be used as the *target* of a generated copy / combine function.
  *
  * cream generates `Target(prop = ...)` to build the target, so a valid target must be a concrete
- * class, annotation class, or object whose primary constructor the generated code can call (Kotlin
- * allows instantiating an annotation class via its constructor since 1.6). `@CopyTo` / `@CopyFrom`
+ * class, annotation class, or object whose primary constructor the generated code can call. `@CopyTo` / `@CopyFrom`
  * additionally accept a sealed type (interface or class), which is not rejected but fans out to its
  * concrete subclasses. The dispatcher ([me.tbsten.cream.ksp.core.copyFun.appendCopyFunction]) decides
  * which rejection applies per [com.google.devtools.ksp.symbol.ClassKind]; this enum is the single

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/copyFun/Transform.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/copyFun/Transform.kt
@@ -48,10 +48,6 @@ internal fun BufferedWriter.appendCopyFunction(
             ?: false
 
     when (target.classKind) {
-        // A regular class and an annotation class share the same generation path: both are built by
-        // calling the primary constructor (`Target(prop = ...)`). Kotlin has allowed instantiating an
-        // annotation class via its constructor since 1.6, so the generated call compiles for both.
-        // See issue #132 — copy now accepts annotation-class targets, matching @CombineTo/@CombineFrom.
         ClassKind.CLASS,
         ClassKind.ANNOTATION_CLASS,
         ->

--- a/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/copyFun/Transform.kt
+++ b/cream-ksp/src/main/kotlin/me/tbsten/cream/ksp/core/copyFun/Transform.kt
@@ -48,11 +48,13 @@ internal fun BufferedWriter.appendCopyFunction(
             ?: false
 
     when (target.classKind) {
-        // An annotation class cannot currently be used as a copy target; it is rejected with a
-        // clean diagnostic.
-        ClassKind.ANNOTATION_CLASS -> reportRejection(CopyTargetRejection.ANNOTATION_CLASS, target)
-
-        ClassKind.CLASS ->
+        // A regular class and an annotation class share the same generation path: both are built by
+        // calling the primary constructor (`Target(prop = ...)`). Kotlin has allowed instantiating an
+        // annotation class via its constructor since 1.6, so the generated call compiles for both.
+        // See issue #132 — copy now accepts annotation-class targets, matching @CombineTo/@CombineFrom.
+        ClassKind.CLASS,
+        ClassKind.ANNOTATION_CLASS,
+        ->
             if (target.isSealed()) {
                 // A sealed class, like a sealed interface, cannot be instantiated directly; fan out
                 // to its concrete subclasses. The sealed check must come BEFORE concreteClassRejection()

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/scenario/TargetKind.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/feature/copyFrom/scenario/TargetKind.kt
@@ -92,5 +92,6 @@ internal fun targetKindScenarios(): Generator<SnapshotScenario> {
                 source,
             ),
         "privateConstructorTarget" to copyFrom(clazz("Target", Prop("name"), Prop("extra", INT), constructorVisibility = PRIVATE), source),
+        "annotationClassTarget" to copyFrom(TypeSpec.annotationBuilder("Target").build(), source),
     )
 }

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(defaultVisibility=INTERNAL)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(defaultVisibility=INTERNAL)/01--targetKind/annotationClassTarget.md
@@ -1,0 +1,75 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyFrom
+
+@CopyFrom(Source::class)
+public annotation class Target
+
+public data class Source(
+  public val name: String,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+    arg("defaultVisibility", "INTERNAL")
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyFrom__Target.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyFrom] annotation of [Target])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+internal fun  me.tbsten.cream.generated.Source.copyToTarget(
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
@@ -1,0 +1,75 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyFrom
+
+@CopyFrom(Source::class)
+public annotation class Target
+
+public data class Source(
+  public val name: String,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+    arg("defaultVisibility", "INHERIT" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyFrom__Target.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyFrom] annotation of [Target])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.Source.to_Target(
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
@@ -1,0 +1,75 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyFrom
+
+@CopyFrom(Source::class)
+public annotation class Target
+
+public data class Source(
+  public val name: String,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "to")
+    arg("copyFunNamingStrategy", "inner-name")
+    arg("escapeDot", "replace-to-underscore")
+    arg("notCopyToObject", "false" /* default */)
+    arg("defaultVisibility", "INHERIT" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyFrom__Target.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyFrom] annotation of [Target])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.Source.to_Target(
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/annotationClassTarget.md
@@ -1,0 +1,75 @@
+## Input:Input
+
+```kt
+package me.tbsten.cream.generated
+
+import kotlin.String
+import me.tbsten.cream.CopyFrom
+
+@CopyFrom(Source::class)
+public annotation class Target
+
+public data class Source(
+  public val name: String,
+)
+```
+
+## KSP options
+
+```kt
+ksp {
+    arg("copyFunNamePrefix", "copyTo" /* default */)
+    arg("copyFunNamingStrategy", "under-package" /* default */)
+    arg("escapeDot", "lower-camel-case" /* default */)
+    arg("notCopyToObject", "false" /* default */)
+    arg("defaultVisibility", "INHERIT" /* default */)
+}
+```
+
+## Output:ExitCode
+
+```kt
+OK
+```
+
+## Output:Console
+
+```kt
+
+```
+
+## Output:Generated sources
+
+````kt
+// file: CopyFrom__Target.kt
+package me.tbsten.cream.generated
+
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyFrom] annotation of [Target])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.Source.copyToTarget(
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(defaultVisibility=INTERNAL)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(defaultVisibility=INTERNAL)/01--targetKind/annotationClassTarget.md
@@ -29,21 +29,47 @@ ksp {
 ## Output:ExitCode
 
 ```kt
-COMPILATION_ERROR
+OK
 ```
 
 ## Output:Console
 
 ```kt
-e: Error occurred in KSP, check log for detail
-e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:11: Invalid cream usage: Unsupported target annotation class (me.tbsten.cream.generated.Target). An annotation class cannot be used as a target.
 
-Solution: 
-  Specify a class, object, or sealed interface as the target.
 ```
 
 ## Output:Generated sources
 
-```kt
+````kt
+// file: CopyTo__Source.kt
+package me.tbsten.cream.generated
 
-```
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [Source])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+internal fun  me.tbsten.cream.generated.Source.copyToTarget(
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
@@ -29,21 +29,47 @@ ksp {
 ## Output:ExitCode
 
 ```kt
-COMPILATION_ERROR
+OK
 ```
 
 ## Output:Console
 
 ```kt
-e: Error occurred in KSP, check log for detail
-e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:11: Invalid cream usage: Unsupported target annotation class (me.tbsten.cream.generated.Target). An annotation class cannot be used as a target.
 
-Solution: 
-  Specify a class, object, or sealed interface as the target.
 ```
 
 ## Output:Generated sources
 
-```kt
+````kt
+// file: CopyTo__Source.kt
+package me.tbsten.cream.generated
 
-```
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [Source])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.Source.to_Target(
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, strategy=inner-name, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
@@ -29,21 +29,47 @@ ksp {
 ## Output:ExitCode
 
 ```kt
-COMPILATION_ERROR
+OK
 ```
 
 ## Output:Console
 
 ```kt
-e: Error occurred in KSP, check log for detail
-e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:11: Invalid cream usage: Unsupported target annotation class (me.tbsten.cream.generated.Target). An annotation class cannot be used as a target.
 
-Solution: 
-  Specify a class, object, or sealed interface as the target.
 ```
 
 ## Output:Generated sources
 
-```kt
+````kt
+// file: CopyTo__Source.kt
+package me.tbsten.cream.generated
 
-```
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [Source])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.to_Target(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.Source.to_Target(
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+)
+````

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/annotationClassTarget.md
@@ -29,21 +29,47 @@ ksp {
 ## Output:ExitCode
 
 ```kt
-COMPILATION_ERROR
+OK
 ```
 
 ## Output:Console
 
 ```kt
-e: Error occurred in KSP, check log for detail
-e: [ksp] <TMPDIR>/Kotlin-Compilation<N>/sources/Input.kt:11: Invalid cream usage: Unsupported target annotation class (me.tbsten.cream.generated.Target). An annotation class cannot be used as a target.
 
-Solution: 
-  Specify a class, object, or sealed interface as the target.
 ```
 
 ## Output:Generated sources
 
-```kt
+````kt
+// file: CopyTo__Source.kt
+package me.tbsten.cream.generated
 
-```
+import me.tbsten.cream.*
+
+/**
+ * (Auto generate by @[CopyTo] annotation of [Source])
+ * 
+ * Source -> Target copy function.
+ * 
+ * # Example: Basic
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget()
+ * ```
+ * 
+ * # Example: Override property values
+ * 
+ * ```kt
+ * val source = Source(...)
+ * val target = source.copyToTarget(property = value)
+ * ```
+ * 
+ * 
+ * @see Source
+ * @see Target
+ */
+public fun  me.tbsten.cream.generated.Source.copyToTarget(
+) : me.tbsten.cream.generated.Target = me.tbsten.cream.generated.Target(
+)
+````

--- a/test/src/commonMain/kotlin/me/tbsten/cream/test/copyTo/AnnotationClassTarget.kt
+++ b/test/src/commonMain/kotlin/me/tbsten/cream/test/copyTo/AnnotationClassTarget.kt
@@ -1,0 +1,17 @@
+package me.tbsten.cream.test.copyTo
+
+import me.tbsten.cream.CopyTo
+
+// data class -> annotation class copy (issue #132).
+// Kotlin allows instantiating an annotation class via its constructor, so cream can build the
+// target the same way it builds a regular class.
+@CopyTo(AnnotationClassTarget::class)
+data class AnnotationClassSource(
+    val name: String,
+    val count: Int,
+)
+
+annotation class AnnotationClassTarget(
+    val name: String,
+    val count: Int,
+)

--- a/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/AnnotationClassTargetTest.kt
+++ b/test/src/commonTest/kotlin/me/tbsten/cream/test/copyTo/AnnotationClassTargetTest.kt
@@ -1,0 +1,25 @@
+package me.tbsten.cream.test.copyTo
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class AnnotationClassTargetTest :
+    FreeSpec({
+        "dataClassToAnnotationClass" {
+            val source = AnnotationClassSource(name = "hello", count = 3)
+
+            val target: AnnotationClassTarget = source.copyToAnnotationClassTarget()
+
+            target.name shouldBe "hello"
+            target.count shouldBe 3
+        }
+
+        "dataClassToAnnotationClassWithOverride" {
+            val source = AnnotationClassSource(name = "hello", count = 3)
+
+            val target = source.copyToAnnotationClassTarget(count = 99)
+
+            target.name shouldBe "hello"
+            target.count shouldBe 99
+        }
+    })


### PR DESCRIPTION
## 概要

`@CopyTo` / `@CopyFrom`（および `appendCopyFunction` を経由する copy 系アノテーション）は annotation class を target にすると `CopyTargetRejection.ANNOTATION_CLASS` で reject していました。一方 `@CombineTo` / `@CombineFrom` は既に accept しており、不整合がありました（issue #132）。

Kotlin は 1.6 以降アノテーションクラスをコンストラクタ経由でインスタンス化できるため、生成される `Target(prop = ...)` はコンパイル可能です。本 PR で copy 側も `ANNOTATION_CLASS` を `CLASS` と同じ生成パスにルーティングし、整合させます。

## 変更点

- `core/copyFun/Transform.kt`: `ANNOTATION_CLASS` を `CLASS` と同じ分岐へ（annotation class は abstract/inner にならず primary constructor は public なので `concreteClassRejection()` は常に通過）。
- `core/common/TargetValidation.kt`: 未使用になった `ANNOTATION_CLASS` rejection 定数を削除し、KDoc を更新。

## テスト

- `CopyToSnapshotTest` の `targetKind/annotationClassTarget` golden が「reject → 生成」に反転。
- `copyFrom` の `targetKind` に `annotationClassTarget` シナリオを追加（新規 golden）。
- マルチプラットフォーム統合テスト: プロパティを持つ annotation class への copy を実 runtime で検証。
- `:cream-ksp:test`（snapshot 再生成 + 決定性 verify）/ `:test:jvmTest` / `ktlintCheck` すべて green。

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxtfFqDZaJstiL82ZwZDq7