### PR TITLE
perf(cream-ksp): drop inheritClassPath in the test harness (#155)

### DIFF
--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/compile/CreamCompilation.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/compile/CreamCompilation.kt
@@ -103,14 +103,6 @@ private fun runCompilation(
     )
 }
 
-/**
- * Minimal compile classpath for cream test inputs (issue #155): the cream-runtime jar (the
- * `@CopyTo` / `@CopyFrom` / `@Combine*` / `@CopyMapping` annotations the inputs and generated code
- * reference) plus the Kotlin stdlib (`String`, `Int`, collections, ...). Both are already on the
- * test classpath, so we resolve their classpath roots from a known class in each — no build-script
- * plumbing needed. This replaces `inheritClassPath = true`, which dragged the entire test runtime
- * classpath into every compilation.
- */
 private val creamCompilationClasspath: List<File> =
     listOf(
         CopyTo::class.java, // cream-runtime

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/compile/CreamCompilation.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/compile/CreamCompilation.kt
@@ -85,10 +85,7 @@ private fun runCompilation(
     val tee = TeeOutputStream(System.out, captured)
     val compilation =
         KotlinCompilation().apply {
-            // issue #155: do NOT inheritClassPath. `inheritClassPath = true` adds the whole test
-            // runtime classpath (KSP, kctfork, kotest, mockk, kotlinpoet, konsist, ...) to every
-            // in-process compilation, which the compiler then scans on each run. Test inputs only
-            // reference the cream-runtime annotations and the Kotlin stdlib, so pass just those.
+            // For performance, limit the classpath to creamCompilationClasspath (issue #155).
             inheritClassPath = false
             classpaths = creamCompilationClasspath
             useKsp2()

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/compile/CreamCompilation.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/compile/CreamCompilation.kt
@@ -7,10 +7,12 @@ import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.kspProcessorOptions
 import com.tschuchort.compiletesting.symbolProcessorProviders
 import com.tschuchort.compiletesting.useKsp2
+import me.tbsten.cream.CopyTo
 import me.tbsten.cream.ksp.CreamSymbolProcessorProvider
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.OutputStream
 
 /**
@@ -83,7 +85,12 @@ private fun runCompilation(
     val tee = TeeOutputStream(System.out, captured)
     val compilation =
         KotlinCompilation().apply {
-            inheritClassPath = true
+            // issue #155: do NOT inheritClassPath. `inheritClassPath = true` adds the whole test
+            // runtime classpath (KSP, kctfork, kotest, mockk, kotlinpoet, konsist, ...) to every
+            // in-process compilation, which the compiler then scans on each run. Test inputs only
+            // reference the cream-runtime annotations and the Kotlin stdlib, so pass just those.
+            inheritClassPath = false
+            classpaths = creamCompilationClasspath
             useKsp2()
             symbolProcessorProviders += CreamSymbolProcessorProvider()
             if (options.isNotEmpty()) {
@@ -97,6 +104,28 @@ private fun runCompilation(
         compilation = compilation,
         compilerOutputBuffer = captured,
     )
+}
+
+/**
+ * Minimal compile classpath for cream test inputs (issue #155): the cream-runtime jar (the
+ * `@CopyTo` / `@CopyFrom` / `@Combine*` / `@CopyMapping` annotations the inputs and generated code
+ * reference) plus the Kotlin stdlib (`String`, `Int`, collections, ...). Both are already on the
+ * test classpath, so we resolve their classpath roots from a known class in each — no build-script
+ * plumbing needed. This replaces `inheritClassPath = true`, which dragged the entire test runtime
+ * classpath into every compilation.
+ */
+private val creamCompilationClasspath: List<File> =
+    listOf(
+        CopyTo::class.java, // cream-runtime
+        Unit::class.java, // kotlin-stdlib
+    ).map { it.classpathRoot() }.distinct()
+
+private fun Class<*>.classpathRoot(): File {
+    val location =
+        checkNotNull(protectionDomain?.codeSource?.location) {
+            "Cannot locate the classpath root for $name (codeSource is null)."
+        }
+    return File(location.toURI())
 }
 
 private class TeeOutputStream(


### PR DESCRIPTION
## 概要

kctfork ベースの `compileWithCream`（`CreamCompilation.kt`）は `inheritClassPath = true` を使っており、テスト JVM の **ランタイムクラスパス全体**（KSP / kctfork / kotest / mockk / kotlinpoet / konsist など）を **毎回の in-process コンパイル**に載せていました。各コンパイルでコンパイラがこの巨大なクラスパスを走査するため、テストハーネスが遅くなる原因になっていました（issue #155）。

テスト入力が参照するのは cream-runtime のアノテーション（`@CopyTo` / `@CopyFrom` / `@Combine*` / `@CopyMapping`）と Kotlin stdlib だけなので、その 2 つのクラスパスルートのみを渡し、`inheritClassPath` を無効化します。クラスパスルートは既にテストクラスパス上にある既知クラス（`me.tbsten.cream.CopyTo` / `kotlin.Unit`）から `codeSource` で解決するため、ビルドスクリプト側の追加配線は不要です。

## 測定（性能改善）

`CopyToSnapshotTest`（コンパイル多数・`--rerun-tasks`・warm daemon、同一マシン同一条件）:

| | 時間 |
|---|---|
| before (`inheritClassPath = true`) | **1m 36s** |
| after (最小クラスパス) | **54s** |
| 改善 | **約 44% 短縮（≈1.8x）** |

フルスイート `:cream-ksp:test` も green（4m 32s、全テスト pass、snapshot ドリフトなし）。

## 変更点

- `cream-ksp/src/test/.../testing/compile/CreamCompilation.kt`:
  - `inheritClassPath = false`
  - `classpaths = creamCompilationClasspath`（cream-runtime + kotlin-stdlib のみ）

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxtfFqDZaJstiL82ZwZDq7