### PR TITLE
ci(publish): trigger on `published` to cover pre-releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,11 @@
 name: Publish
 on:
   release:
-    types: [ released, prereleased ]
+    # Use `published` so the workflow fires for both full releases and
+    # pre-releases — including pre-releases published from a draft, where
+    # `prereleased` does NOT fire (GitHub spec). `released` alone never
+    # fires for pre-releases. See docs: events-that-trigger-workflows#release.
+    types: [ published ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 背景

v0.9.0-alpha01（初の pre-release）を GitHub Release から publish したが、Publish workflow が発火せず Maven Central に何も上がらなかった。

## 原因（GitHub 公式仕様）

Publish workflow のトリガーは `types: [ released, prereleased ]` だった。

- `released` は **pre-release では発火しない**（過去の通常リリース v0.1.0〜v0.8.1 は全てこれで発火していた）
- `prereleased` は **draft から publish された pre-release では発火しない**（[公式ドキュメント](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release): "The `prereleased` type will not trigger for pre-releases published from draft releases, but the `published` type will trigger."）
- v0.9.0-alpha01 は `created_at`(draft) → `published_at`(prerelease) と **draft 由来の pre-release** だったため、どちらにもマッチせず未発火

## 修正

トリガーを `types: [ published ]` に置換。`published` は通常リリースも pre-release も両方カバーする。

### 既存フローへの影響: なし
- 通常リリース: 現行も `released` で1回 → 変更後も `published` で1回（同一挙動）
- `published` 単独なので二重発火しない（`released` と併記すると通常リリースで2回走るため**置換**）
- draft 保存 / edit / 削除 では発火しない（従来どおり）

## 効果
- 今後の pre-release（draft 由来含む）が自動で publish される

> 注: 今回の v0.9.0-alpha01 は既に publish 済みで自動再発火しないため、別途 `workflow_dispatch` で手動 publish する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)