### PR TITLE
chore(claude): add rule to keep paired markdown in sync

### DIFF
--- a/.claude/rules/markdown.md
+++ b/.claude/rules/markdown.md
@@ -1,0 +1,7 @@
+---
+paths:
+    - "**/*.md"
+---
+
+markdown 付近の対応する .md ファイルも合わせて更新する。
+例えば README.md を更新したら README.ja.md も必ず更新する。


### PR DESCRIPTION
## 概要

Claude Code 用の path-scoped rule `.claude/rules/markdown.md` を追加します。

- `**/*.md` を編集するとき、対応する対の .md も合わせて更新する (例: README.md → README.ja.md)

## 背景

#166 / #167 / #168 のレビューで README.ja.md への反映もれが 3 回連続で指摘されたため、rule として明文化します。

なお、元ファイルの frontmatter で `"**/*.md"` が 2 回重複していたのは typo と判断し 1 つにしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)