### PR TITLE
fix: improve snapshot mismatch error message formatting and IDE integration

### DIFF
--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/snapshot/SnapshotAssertion.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/snapshot/SnapshotAssertion.kt
@@ -1,8 +1,10 @@
 package me.tbsten.cream.ksp.testing.snapshot
 
 import io.kotest.assertions.fail
+import io.kotest.assertions.withClue
 import io.kotest.core.test.TestScope
 import io.kotest.core.test.parents
+import io.kotest.matchers.shouldBe
 import java.io.File
 
 /**
@@ -88,12 +90,10 @@ internal fun assertMatchesSnapshot(
             return
         }
         fail(
-            """
-            Snapshot file not found: ${file.path}
-            Run with -Dcream.snapshot.update=true to create it.
-            Actual content:
-            $normalizedActual
-            """.trimIndent(),
+            "Snapshot file not found: ${file.path}\n" +
+                "Run with -Dcream.snapshot.update=true to create it.\n" +
+                "Actual content:\n" +
+                normalizedActual,
         )
     }
 
@@ -103,16 +103,12 @@ internal fun assertMatchesSnapshot(
             file.writeText(normalizedActual, Charsets.UTF_8)
             return
         }
-        fail(
-            """
-            Snapshot mismatch for ${file.path}
-            Run with -Dcream.snapshot.update=true to update.
-            --- Expected ---
-            $expected
-            --- Actual ---
-            $normalizedActual
-            """.trimIndent(),
-        )
+        withClue(
+            "Snapshot mismatch for ${file.path}\n" +
+                "Run with -Dcream.snapshot.update=true to update.",
+        ) {
+            normalizedActual shouldBe expected
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Snapshot 不一致時の失敗メッセージ表示形式を改善
- kotest の `shouldBe` と `withClue()` を組み合わせて IDE diff ビューア統合を実現
- Message template のインデント崩れを解決

## Changes

### Mismatch メッセージの改善

**問題**: 複数行の expected/actual をインデント付き raw string に補間してから `trimIndent()` していたため:
- テンプレート行（"Snapshot mismatch for ..."、"--- Expected ---" など）に 12 スペースの字下げが残った
- 本文がカラム 0 にあるという混在表示になった
- kotest の `fail()` は AssertionFailedError の expected/actual フィールドが持たないため、IntelliJ IDE で「Expected :null / Actual :null」と表示され、diff ビューアが開けなかった

**修正**: 
```kotlin
withClue(
    "Snapshot mismatch for ${file.path}\n" +
        "Run with -Dcream.snapshot.update=true to update.",
) {
    normalizedActual shouldBe expected
}
```

- `withClue()` でメッセージをプレフィックスし、左寄せで整形
- `shouldBe` で opentest4j の AssertionFailedError を生成（実際の expected/actual 値を保有）
- IDE の diff ビューア、行単位の部分一致ヒントが機能するように

### Not Found メッセージも同様に改善

単純なインデント付き raw string + `trimIndent()` の問題を避けるため、文字列連結に変更:
```kotlin
fail(
    "Snapshot file not found: ${file.path}\n" +
        "Run with -Dcream.snapshot.update=true to create it.\n" +
        "Actual content:\n" +
        normalizedActual,
)
```

## Test plan

- [x] `./gradlew :cream-ksp:ktlintCheck` — code formatting verified
- [x] `./gradlew :cream-ksp:test` — all unit tests pass (including smoke tests)
- [x] Temporary mismatch test で両分岐（mismatch / not found）のメッセージ形式を実際に確認
  - インデント崩れなし（メッセージ部分と expected/actual が正しく整形される）
  - opentest4j の expected/actual フィールドに実際の値が入る（IDE diff ビューア対応）

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TSond2CpUq8YVD6EdLWRX