### PR TITLE
feat(options): add the cream.autoValueClassMapping option (#21)

### DIFF
--- a/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/options/CreamOptions.kt
+++ b/cream-ksp/shared/src/commonMain/kotlin/me/tbsten/cream/ksp/options/CreamOptions.kt
@@ -15,6 +15,7 @@ public data class CreamOptions(
     val escapeDot: EscapeDot,
     val notCopyToObject: Boolean,
     val defaultVisibility: CopyVisibility,
+    val autoValueClassMapping: Boolean,
 ) {
     public companion object {
         public val default: CreamOptions =
@@ -24,6 +25,7 @@ public data class CreamOptions(
                 escapeDot = EscapeDot.default,
                 notCopyToObject = false,
                 defaultVisibility = CopyVisibility.INHERIT,
+                autoValueClassMapping = true,
             )
 
         public val properties: List<KProperty1<CreamOptions, *>> =
@@ -33,6 +35,7 @@ public data class CreamOptions(
                 CreamOptions::escapeDot,
                 CreamOptions::notCopyToObject,
                 CreamOptions::defaultVisibility,
+                CreamOptions::autoValueClassMapping,
             )
     }
 }
@@ -79,6 +82,10 @@ public fun Map<String, String>.toCreamOptions(): CreamOptions =
                     )
                 }
             } ?: CreamOptions.default.defaultVisibility,
+        // Default true (issue #21): only an explicit "false" disables the automatic value class
+        // mapping, mirroring notCopyToObject's lenient boolean parsing (no invalid-value error).
+        autoValueClassMapping =
+            this["cream.autoValueClassMapping"]?.lowercase() != "false",
     )
 
 @OptIn(InternalCreamApi::class)

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/core/common/CopyFunctionNameTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/core/common/CopyFunctionNameTest.kt
@@ -28,6 +28,7 @@ private fun options(
         escapeDot = escapeDot,
         notCopyToObject = false,
         defaultVisibility = CreamOptions.default.defaultVisibility,
+        autoValueClassMapping = CreamOptions.default.autoValueClassMapping,
     )
 
 private fun name(

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/core/common/FunctionNameTemplateTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/core/common/FunctionNameTemplateTest.kt
@@ -81,6 +81,7 @@ internal class FunctionNameTemplateTest :
                     escapeDot = EscapeDot.`replace-to-underscore`,
                     notCopyToObject = false,
                     defaultVisibility = CreamOptions.default.defaultVisibility,
+                    autoValueClassMapping = CreamOptions.default.autoValueClassMapping,
                 )
             // fixed rendering, unaffected by options
             resolve(CopyTargetUnderPackage, nonDefault) shouldBe "UiStateSuccess"

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/CreamOptionsParsingTest.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/options/CreamOptionsParsingTest.kt
@@ -56,4 +56,17 @@ internal class CreamOptionsParsingTest :
             // unrelated options keep their defaults
             options.copyFunNamePrefix shouldBe CreamOptions.default.copyFunNamePrefix
         }
+
+        "autoValueClassMapping defaults to true when the option is absent" {
+            emptyMap<String, String>().toCreamOptions().autoValueClassMapping shouldBe true
+            CreamOptions.default.autoValueClassMapping shouldBe true
+        }
+
+        "autoValueClassMapping is disabled only by an explicit false (case-insensitive)" {
+            mapOf("cream.autoValueClassMapping" to "false").toCreamOptions().autoValueClassMapping shouldBe false
+            mapOf("cream.autoValueClassMapping" to "FALSE").toCreamOptions().autoValueClassMapping shouldBe false
+            mapOf("cream.autoValueClassMapping" to "true").toCreamOptions().autoValueClassMapping shouldBe true
+            // lenient boolean parsing, mirroring notCopyToObject: any non-"false" value keeps it on
+            mapOf("cream.autoValueClassMapping" to "yes").toCreamOptions().autoValueClassMapping shouldBe true
+        }
     })

--- a/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/generator/cream/CreamOptionsGenerator.kt
+++ b/cream-ksp/src/test/kotlin/me/tbsten/cream/ksp/testing/generator/cream/CreamOptionsGenerator.kt
@@ -49,6 +49,9 @@ internal fun Generator.Companion.validCreamOptions(
             escapeDot = escape,
             notCopyToObject = notCopyObject,
             defaultVisibility = visibility,
+            // Pinned to the default: varying it here would multiply every snapshot family's
+            // compile count, so the option gets a targeted test of its own instead.
+            autoValueClassMapping = CreamOptions.default.autoValueClassMapping,
         )
     }.withRepresentativeValues {
         listOf(
@@ -161,6 +164,7 @@ private fun creamOptionsLabel(options: CreamOptions): String {
             if (options.escapeDot != default.escapeDot) add("escapeDot=${options.escapeDot.name}")
             if (options.notCopyToObject != default.notCopyToObject) add("notCopyToObject=${options.notCopyToObject}")
             if (options.defaultVisibility != default.defaultVisibility) add("defaultVisibility=${options.defaultVisibility.name}")
+            if (options.autoValueClassMapping != default.autoValueClassMapping) add("autoValueClassMapping=${options.autoValueClassMapping}")
         }
     return if (parts.isEmpty()) "Default" else parts.joinToString(separator = ", ", prefix = "(", postfix = ")")
 }

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedClassParent.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedClassParent.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedInterfaceParent.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedInterfaceParent.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/leafPropertiesSweep.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/leafPropertiesSweep.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/mergedSameNameLeafProps.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/mergedSameNameLeafProps.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/transitiveNestedLeaves.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/transitiveNestedLeaves.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/bodyPropertiesIncluded.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/bodyPropertiesIncluded.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/extensionPropertiesSkippedSilently.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/extensionPropertiesSkippedSilently.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/parentVisiblePropertiesSkipped.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/parentVisiblePropertiesSkipped.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/privateChildClassSkippedSilently.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/privateChildClassSkippedSilently.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/privatePropertiesSkippedSilently.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/privatePropertiesSkippedSilently.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/unpinnedGenericPropertySkippedWithWarning.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--propertyFiltering/unpinnedGenericPropertySkippedWithWarning.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--parentOptionalInterop/intermediateSealedOwnProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--parentOptionalInterop/intermediateSealedOwnProperty.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--parentOptionalInterop/overrideRenameOnParentVisibleProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--parentOptionalInterop/overrideRenameOnParentVisibleProperty.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--parentOptionalInterop/ownershipSplitAcrossAncestors.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--parentOptionalInterop/ownershipSplitAcrossAncestors.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--parentOptionalInterop/parentOptionalRenameRespected.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--parentOptionalInterop/parentOptionalRenameRespected.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--kdoc/description.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--kdoc/descriptionAndExamples.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--visibility/internalChildClass.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--visibility/internalChildClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--visibility/visibilityOverrideInternal.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/allContributorsExcludedNoAccessor.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/allContributorsExcludedNoAccessor.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/excludeNoEffectWarns.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/excludeNoEffectWarns.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/excludedContributorDroppedFromMerge.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/excludedContributorDroppedFromMerge.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/parentOptionalOverridesExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/parentOptionalOverridesExclude.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/singleExcludedPropertySkipped.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/singleExcludedPropertySkipped.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--propertyName/bareParentOptionalInheritsSweepArguments.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--propertyName/bareParentOptionalInheritsSweepArguments.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--propertyName/propertyOverridesSweepTemplate.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--propertyName/propertyOverridesSweepTemplate.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--propertyName/sweepWideTemplate.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--propertyName/sweepWideTemplate.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--propertyName/templateRenamesAwayFromParentMember.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--propertyName/templateRenamesAwayFromParentMember.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedClassParent.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedClassParent.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedInterfaceParent.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedInterfaceParent.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/01--hierarchyShape/leafPropertiesSweep.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/01--hierarchyShape/leafPropertiesSweep.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/01--hierarchyShape/mergedSameNameLeafProps.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/01--hierarchyShape/mergedSameNameLeafProps.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/01--hierarchyShape/transitiveNestedLeaves.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/01--hierarchyShape/transitiveNestedLeaves.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/bodyPropertiesIncluded.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/bodyPropertiesIncluded.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/extensionPropertiesSkippedSilently.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/extensionPropertiesSkippedSilently.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/parentVisiblePropertiesSkipped.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/parentVisiblePropertiesSkipped.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/privateChildClassSkippedSilently.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/privateChildClassSkippedSilently.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/privatePropertiesSkippedSilently.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/privatePropertiesSkippedSilently.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/unpinnedGenericPropertySkippedWithWarning.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/02--propertyFiltering/unpinnedGenericPropertySkippedWithWarning.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/03--parentOptionalInterop/intermediateSealedOwnProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/03--parentOptionalInterop/intermediateSealedOwnProperty.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/03--parentOptionalInterop/overrideRenameOnParentVisibleProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/03--parentOptionalInterop/overrideRenameOnParentVisibleProperty.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/03--parentOptionalInterop/ownershipSplitAcrossAncestors.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/03--parentOptionalInterop/ownershipSplitAcrossAncestors.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/03--parentOptionalInterop/parentOptionalRenameRespected.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/03--parentOptionalInterop/parentOptionalRenameRespected.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/04--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/04--kdoc/description.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/04--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/04--kdoc/descriptionAndExamples.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/05--visibility/internalChildClass.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/05--visibility/internalChildClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/05--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/05--visibility/visibilityOverrideInternal.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/06--exclude/allContributorsExcludedNoAccessor.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/06--exclude/allContributorsExcludedNoAccessor.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/06--exclude/excludeNoEffectWarns.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/06--exclude/excludeNoEffectWarns.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/06--exclude/excludedContributorDroppedFromMerge.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/06--exclude/excludedContributorDroppedFromMerge.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/06--exclude/parentOptionalOverridesExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/06--exclude/parentOptionalOverridesExclude.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/06--exclude/singleExcludedPropertySkipped.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/06--exclude/singleExcludedPropertySkipped.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/07--propertyName/bareParentOptionalInheritsSweepArguments.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/07--propertyName/bareParentOptionalInheritsSweepArguments.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/07--propertyName/propertyOverridesSweepTemplate.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/07--propertyName/propertyOverridesSweepTemplate.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/07--propertyName/sweepWideTemplate.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/07--propertyName/sweepWideTemplate.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/07--propertyName/templateRenamesAwayFromParentMember.md
+++ b/cream-ksp/src/test/resources/snapshots/ChildOptionalsSnapshotTest/All patterns/option=Default/07--propertyName/templateRenamesAwayFromParentMember.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/excludeOverlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/excludeOverlappingProperty.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/mapAcrossSources.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/multiSourceGenerics.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/multiSourceGenerics.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/noSourcesRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/noSourcesRejected.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/overlappingProperty.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/singleSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/singleSource.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/threeSources.md
@@ -43,6 +43,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/twoSources.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/collectionProp.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/customTypeProp.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/mixedPrimitives.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/nullableProp.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/stringProp.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/zeroProps.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--matching/typeIncompatible.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/multipleMappings.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/singleMapping.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludeNoEffect.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludedProperty.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/description.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/descriptionAndExamples.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/internalTargetClass.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/propertyVisibilities.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverrideInternal.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverridePublic.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/literalFunName.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/tokenFunName.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/duplicateOccurrenceRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/duplicateOccurrenceRejected.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/duplicateSourceWithinOccurrence.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/duplicateSourceWithinOccurrence.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotations.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotationsDistinctFunNames.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotationsDistinctFunNames.md
@@ -50,6 +50,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotationsSameFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--repeatable/stackedAnnotationsSameFunName.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/sealedInterfaceSource.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/excludeOverlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/excludeOverlappingProperty.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/mapAcrossSources.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/multiSourceGenerics.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/multiSourceGenerics.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/noSourcesRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/noSourcesRejected.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/overlappingProperty.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/singleSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/singleSource.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/threeSources.md
@@ -43,6 +43,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/twoSources.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/collectionProp.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/customTypeProp.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/mixedPrimitives.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/nullableProp.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/stringProp.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/zeroProps.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--matching/typeIncompatible.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/multipleMappings.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/singleMapping.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--exclude/excludeNoEffect.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--exclude/excludedProperty.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--kdoc/description.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--kdoc/descriptionAndExamples.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/internalTargetClass.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/propertyVisibilities.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/visibilityOverrideInternal.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/visibilityOverridePublic.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/literalFunName.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/tokenFunName.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--repeatable/duplicateOccurrenceRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--repeatable/duplicateOccurrenceRejected.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--repeatable/duplicateSourceWithinOccurrence.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--repeatable/duplicateSourceWithinOccurrence.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--repeatable/stackedAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--repeatable/stackedAnnotations.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--repeatable/stackedAnnotationsDistinctFunNames.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--repeatable/stackedAnnotationsDistinctFunNames.md
@@ -50,6 +50,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--repeatable/stackedAnnotationsSameFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--repeatable/stackedAnnotationsSameFunName.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/excludeOverlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/excludeOverlappingProperty.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/mapAcrossSources.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/multiSourceGenerics.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/multiSourceGenerics.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/noSourcesRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/noSourcesRejected.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/overlappingProperty.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/singleSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/singleSource.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/threeSources.md
@@ -43,6 +43,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/02--multiSource/twoSources.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/collectionProp.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/customTypeProp.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/mixedPrimitives.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/nullableProp.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/stringProp.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/04--propertyShape/zeroProps.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/05--matching/typeIncompatible.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/06--map/multipleMappings.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/06--map/singleMapping.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/07--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/07--exclude/excludeNoEffect.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/07--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/07--exclude/excludedProperty.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/08--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/08--kdoc/description.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/08--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/08--kdoc/descriptionAndExamples.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/internalTargetClass.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/propertyVisibilities.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverrideInternal.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverridePublic.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/10--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/10--funName/literalFunName.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/10--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/10--funName/tokenFunName.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/duplicateOccurrenceRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/duplicateOccurrenceRejected.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/duplicateSourceWithinOccurrence.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/duplicateSourceWithinOccurrence.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/stackedAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/stackedAnnotations.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/stackedAnnotationsDistinctFunNames.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/stackedAnnotationsDistinctFunNames.md
@@ -50,6 +50,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/stackedAnnotationsSameFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineFromSnapshotTest/All patterns/option=Default/11--repeatable/stackedAnnotationsSameFunName.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/annotationClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/annotationClassSource.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/mapAcrossSources.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/overlappingProperty.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/threeSources.md
@@ -44,6 +44,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/twoSources.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/collectionProp.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/customTypeProp.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/mixedPrimitives.md
@@ -44,6 +44,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/nullableProp.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/stringProp.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--matching/typeIncompatible.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/mapOverridesNameMatch.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/mapToNonexistentProperty.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/multipleMappings.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/singleMapping.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--kdoc/description.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--kdoc/descriptionAndExamples.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--visibility/internalTargetClass.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--visibility/propertyVisibilities.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--visibility/visibilityOverrideInternal.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--visibility/visibilityOverridePublic.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--funName/literalFunName.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--funName/tokenFunName.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--repeatable/multipleAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--repeatable/multipleAnnotations.md
@@ -48,6 +48,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--sourceKindValidation/insufficientSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--sourceKindValidation/insufficientSources.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--sourceKindValidation/nonClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--sourceKindValidation/nonClassSource.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--excludes/excludeMappedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--excludes/excludeMappedProperty.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--excludes/excludeSharedProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--excludes/excludeSharedProp.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--excludes/excludeUnmatchedName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--excludes/excludeUnmatchedName.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/annotationClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/annotationClassSource.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/mapAcrossSources.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/overlappingProperty.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/threeSources.md
@@ -44,6 +44,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/twoSources.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/collectionProp.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/customTypeProp.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/mixedPrimitives.md
@@ -44,6 +44,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/nullableProp.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/stringProp.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--matching/typeIncompatible.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/mapOverridesNameMatch.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/mapToNonexistentProperty.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/multipleMappings.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/singleMapping.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--kdoc/description.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--kdoc/descriptionAndExamples.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/internalTargetClass.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/propertyVisibilities.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/visibilityOverrideInternal.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/visibilityOverridePublic.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--funName/literalFunName.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--funName/tokenFunName.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--repeatable/multipleAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--repeatable/multipleAnnotations.md
@@ -48,6 +48,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--sourceKindValidation/insufficientSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--sourceKindValidation/insufficientSources.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--sourceKindValidation/nonClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--sourceKindValidation/nonClassSource.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--excludes/excludeMappedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--excludes/excludeMappedProperty.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--excludes/excludeSharedProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--excludes/excludeSharedProp.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--excludes/excludeUnmatchedName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--excludes/excludeUnmatchedName.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/00--sourceKind/annotationClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/00--sourceKind/annotationClassSource.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/02--multiSource/mapAcrossSources.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/02--multiSource/overlappingProperty.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/02--multiSource/threeSources.md
@@ -44,6 +44,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/02--multiSource/twoSources.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/04--propertyShape/collectionProp.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/04--propertyShape/customTypeProp.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/04--propertyShape/mixedPrimitives.md
@@ -44,6 +44,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/04--propertyShape/nullableProp.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/04--propertyShape/stringProp.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/05--matching/typeIncompatible.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/06--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/06--map/mapOverridesNameMatch.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/06--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/06--map/mapToNonexistentProperty.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/06--map/multipleMappings.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/06--map/singleMapping.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/07--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/07--kdoc/description.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/07--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/07--kdoc/descriptionAndExamples.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/08--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/08--visibility/internalTargetClass.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/08--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/08--visibility/propertyVisibilities.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/08--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/08--visibility/visibilityOverrideInternal.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/08--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/08--visibility/visibilityOverridePublic.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/09--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/09--funName/literalFunName.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/09--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/09--funName/tokenFunName.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/10--repeatable/multipleAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/10--repeatable/multipleAnnotations.md
@@ -48,6 +48,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/11--sourceKindValidation/insufficientSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/11--sourceKindValidation/insufficientSources.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/11--sourceKindValidation/nonClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/11--sourceKindValidation/nonClassSource.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/12--excludes/excludeMappedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/12--excludes/excludeMappedProperty.md
@@ -40,6 +40,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/12--excludes/excludeSharedProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/12--excludes/excludeSharedProp.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/12--excludes/excludeUnmatchedName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineMappingSnapshotTest/All patterns/option=Default/12--excludes/excludeUnmatchedName.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/duplicateTargetRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/duplicateTargetRejected.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/excludeSuppressesAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/excludeSuppressesAcrossSources.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/mapAcrossSources.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/multiSourceGenerics.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/multiSourceGenerics.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/overlappingProperty.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/singleSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/singleSource.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/threeSources.md
@@ -41,6 +41,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--multiSource/twoSources.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/collectionProp.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/customTypeProp.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/mixedPrimitives.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/nullableProp.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/stringProp.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--propertyShape/zeroProps.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--matching/typeIncompatible.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/multipleMappings.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--map/singleMapping.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludeNoEffect.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--exclude/excludedProperty.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/description.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--kdoc/descriptionAndExamples.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/internalTargetClass.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/propertyVisibilities.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverrideInternal.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--visibility/visibilityOverridePublic.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/literalFunName.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/literalFunNameMultiTargetRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/literalFunNameMultiTargetRejected.md
@@ -45,6 +45,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/tokenFunName.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/tokenFunNameMultiTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--funName/tokenFunNameMultiTarget.md
@@ -46,6 +46,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--deprecated/perSourcePrecedence.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--deprecated/perSourcePrecedence.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/sealedInterfaceSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/annotationClassTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/duplicateTargetRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/duplicateTargetRejected.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/excludeSuppressesAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/excludeSuppressesAcrossSources.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/mapAcrossSources.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/multiSourceGenerics.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/multiSourceGenerics.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/overlappingProperty.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/singleSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/singleSource.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/threeSources.md
@@ -41,6 +41,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--multiSource/twoSources.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/collectionProp.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/customTypeProp.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/mixedPrimitives.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/nullableProp.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/stringProp.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/zeroProps.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--matching/typeIncompatible.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/multipleMappings.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--map/singleMapping.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--exclude/excludeNoEffect.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--exclude/excludedProperty.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--kdoc/description.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--kdoc/descriptionAndExamples.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/internalTargetClass.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/propertyVisibilities.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/visibilityOverrideInternal.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--visibility/visibilityOverridePublic.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/literalFunName.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/literalFunNameMultiTargetRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/literalFunNameMultiTargetRejected.md
@@ -45,6 +45,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/tokenFunName.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/tokenFunNameMultiTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--funName/tokenFunNameMultiTarget.md
@@ -46,6 +46,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--deprecated/perSourcePrecedence.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--deprecated/perSourcePrecedence.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/annotationClassTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/duplicateTargetRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/duplicateTargetRejected.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/excludeSuppressesAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/excludeSuppressesAcrossSources.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/mapAcrossSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/mapAcrossSources.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/multiSourceGenerics.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/multiSourceGenerics.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/overlappingProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/overlappingProperty.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/singleSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/singleSource.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/threeSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/threeSources.md
@@ -41,6 +41,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/twoSources.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/02--multiSource/twoSources.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/collectionProp.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/customTypeProp.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/mixedPrimitives.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/nullableProp.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/stringProp.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/04--propertyShape/zeroProps.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/05--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/05--matching/typeIncompatible.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/06--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/06--map/multipleMappings.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/06--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/06--map/singleMapping.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/07--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/07--exclude/excludeNoEffect.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/07--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/07--exclude/excludedProperty.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/08--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/08--kdoc/description.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/08--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/08--kdoc/descriptionAndExamples.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/09--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/09--visibility/internalTargetClass.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/09--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/09--visibility/propertyVisibilities.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverrideInternal.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/09--visibility/visibilityOverridePublic.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/10--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/10--funName/literalFunName.md
@@ -38,6 +38,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/10--funName/literalFunNameMultiTargetRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/10--funName/literalFunNameMultiTargetRejected.md
@@ -45,6 +45,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/10--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/10--funName/tokenFunName.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/10--funName/tokenFunNameMultiTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/10--funName/tokenFunNameMultiTarget.md
@@ -46,6 +46,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/11--deprecated/perSourcePrecedence.md
+++ b/cream-ksp/src/test/resources/snapshots/CombineToSnapshotTest/All patterns/option=Default/11--deprecated/perSourcePrecedence.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/bothNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/bothNestedInOuter.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/sourceNestedInTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/sourceNestedInTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/sourceNestedTwoLevelsInNestedTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/sourceNestedTwoLevelsInNestedTarget.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/sourceNestedTwoLevelsInTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/sourceNestedTwoLevelsInTarget.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/targetNestedInSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/targetNestedInSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/multipleConstructors.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/multipleConstructors.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargMatchedPrimitiveArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargMatchedPrimitiveArray.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargParameter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargParameter.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/mixedPrimitives.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/stringProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/zeroProps.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--matching/typeIncompatible.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/copyToMapOnSourceDoesNotApply.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/copyToMapOnSourceDoesNotApply.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapOverridesNameMatch.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapToNonexistentProperty.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/propertyMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/propertyMapping.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/excludeNoEffect.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/excludedProperty.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/mapAndExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/mapAndExclude.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/description.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/descriptionAndExamples.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/internalTargetClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/propertyVisibilities.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideInternal.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverridePublic.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunName.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunNameSealedRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunNameSealedRejected.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/tokenFunName.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/sealedInterfaceSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/annotationClassTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/bothNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/bothNestedInOuter.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/sourceNestedInTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/sourceNestedInTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/sourceNestedTwoLevelsInNestedTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/sourceNestedTwoLevelsInNestedTarget.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/sourceNestedTwoLevelsInTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/sourceNestedTwoLevelsInTarget.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/targetNestedInSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/targetNestedInSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/multipleConstructors.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/multipleConstructors.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargMatchedPrimitiveArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargMatchedPrimitiveArray.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargParameter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargParameter.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/mixedPrimitives.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/stringProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/zeroProps.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--matching/typeIncompatible.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/copyToMapOnSourceDoesNotApply.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/copyToMapOnSourceDoesNotApply.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapOverridesNameMatch.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapToNonexistentProperty.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/propertyMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/propertyMapping.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/excludeNoEffect.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/excludedProperty.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/mapAndExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/mapAndExclude.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/description.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/descriptionAndExamples.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/internalTargetClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/propertyVisibilities.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverrideInternal.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverridePublic.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunName.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunNameSealedRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunNameSealedRejected.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/tokenFunName.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/annotationClassTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/02--nesting/bothNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/02--nesting/bothNestedInOuter.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/02--nesting/sourceNestedInTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/02--nesting/sourceNestedInTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/02--nesting/sourceNestedTwoLevelsInNestedTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/02--nesting/sourceNestedTwoLevelsInNestedTarget.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/02--nesting/sourceNestedTwoLevelsInTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/02--nesting/sourceNestedTwoLevelsInTarget.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/02--nesting/targetNestedInSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/02--nesting/targetNestedInSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/04--constructor/multipleConstructors.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/04--constructor/multipleConstructors.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/04--constructor/varargMatchedPrimitiveArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/04--constructor/varargMatchedPrimitiveArray.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/04--constructor/varargParameter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/04--constructor/varargParameter.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/mixedPrimitives.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/stringProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/05--propertyShape/zeroProps.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/06--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/06--matching/typeIncompatible.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/07--map/copyToMapOnSourceDoesNotApply.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/07--map/copyToMapOnSourceDoesNotApply.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/07--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/07--map/mapOverridesNameMatch.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/07--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/07--map/mapToNonexistentProperty.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/07--map/propertyMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/07--map/propertyMapping.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/08--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/08--exclude/excludeNoEffect.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/08--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/08--exclude/excludedProperty.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/08--exclude/mapAndExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/08--exclude/mapAndExclude.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/09--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/09--kdoc/description.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/09--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/09--kdoc/descriptionAndExamples.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/10--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/10--visibility/internalTargetClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/10--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/10--visibility/propertyVisibilities.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideInternal.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverridePublic.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/11--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/11--funName/literalFunName.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/11--funName/literalFunNameSealedRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/11--funName/literalFunNameSealedRejected.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/11--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/All patterns/option=Default/11--funName/tokenFunName.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/UseCase/ItemDetailUiState transitions declared on targets.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyFromSnapshotTest/UseCase/ItemDetailUiState transitions declared on targets.md
@@ -51,6 +51,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
@@ -44,6 +44,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/bothNestedInSameOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/bothNestedInSameOuter.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/sourceNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/sourceNestedInOuter.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/targetNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/targetNestedInOuter.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/multipleConstructors.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/multipleConstructors.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargMatchedPrimitiveArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargMatchedPrimitiveArray.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargParameter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargParameter.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/collectionProp.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/customTypeProp.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/mixedPrimitives.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/nullableProp.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/stringProp.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/zeroProps.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--matching/typeIncompatible.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapOverridesNameMatch.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapToNonexistentProperty.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/multipleMappings.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/singleMapping.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--canReverse/bidirectional.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--canReverse/bidirectional.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--canReverse/bidirectionalWithMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--canReverse/bidirectionalWithMapping.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/description.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/descriptionAndExamples.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/internalTargetClass.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/propertyVisibilities.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideInternal.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverridePublic.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideReversed.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideReversed.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunName.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunNameReversibleRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunNameReversibleRejected.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/tokenFunName.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/tokenFunNameReversible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/tokenFunNameReversible.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--repeatable/multipleAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--repeatable/multipleAnnotations.md
@@ -42,6 +42,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeMappedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeMappedProperty.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeMappedPropertyWithCanReverse.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeMappedPropertyWithCanReverse.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeSharedProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeSharedProp.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeSharedPropWithCanReverse.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeSharedPropWithCanReverse.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeUnmatchedName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeUnmatchedName.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeUnmatchedNameWithCanReverse.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--excludes/excludeUnmatchedNameWithCanReverse.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/sealedInterfaceSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
@@ -44,6 +44,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/bothNestedInSameOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/bothNestedInSameOuter.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/sourceNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/sourceNestedInOuter.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/targetNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/targetNestedInOuter.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/multipleConstructors.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/multipleConstructors.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargMatchedPrimitiveArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargMatchedPrimitiveArray.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargParameter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargParameter.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/collectionProp.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/customTypeProp.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/mixedPrimitives.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/nullableProp.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/stringProp.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/zeroProps.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--matching/typeIncompatible.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapOverridesNameMatch.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapToNonexistentProperty.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/multipleMappings.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/singleMapping.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--canReverse/bidirectional.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--canReverse/bidirectional.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--canReverse/bidirectionalWithMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--canReverse/bidirectionalWithMapping.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/description.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/descriptionAndExamples.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/internalTargetClass.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/propertyVisibilities.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverrideInternal.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverridePublic.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverrideReversed.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverrideReversed.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunName.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunNameReversibleRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunNameReversibleRejected.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/tokenFunName.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/tokenFunNameReversible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/tokenFunNameReversible.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--repeatable/multipleAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--repeatable/multipleAnnotations.md
@@ -42,6 +42,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeMappedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeMappedProperty.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeMappedPropertyWithCanReverse.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeMappedPropertyWithCanReverse.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeSharedProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeSharedProp.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeSharedPropWithCanReverse.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeSharedPropWithCanReverse.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeUnmatchedName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeUnmatchedName.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeUnmatchedNameWithCanReverse.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--excludes/excludeUnmatchedNameWithCanReverse.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
@@ -44,6 +44,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/02--nesting/bothNestedInSameOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/02--nesting/bothNestedInSameOuter.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/02--nesting/sourceNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/02--nesting/sourceNestedInOuter.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/02--nesting/targetNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/02--nesting/targetNestedInOuter.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/04--constructor/multipleConstructors.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/04--constructor/multipleConstructors.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/04--constructor/varargMatchedPrimitiveArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/04--constructor/varargMatchedPrimitiveArray.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/04--constructor/varargParameter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/04--constructor/varargParameter.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/collectionProp.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/customTypeProp.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/mixedPrimitives.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/nullableProp.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/stringProp.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/05--propertyShape/zeroProps.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/06--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/06--matching/typeIncompatible.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/07--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/07--map/mapOverridesNameMatch.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/07--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/07--map/mapToNonexistentProperty.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/07--map/multipleMappings.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/07--map/multipleMappings.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/07--map/singleMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/07--map/singleMapping.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/08--canReverse/bidirectional.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/08--canReverse/bidirectional.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/08--canReverse/bidirectionalWithMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/08--canReverse/bidirectionalWithMapping.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/09--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/09--kdoc/description.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/09--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/09--kdoc/descriptionAndExamples.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/internalTargetClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/internalTargetClass.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/propertyVisibilities.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideInternal.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverridePublic.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideReversed.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideReversed.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/11--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/11--funName/literalFunName.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/11--funName/literalFunNameReversibleRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/11--funName/literalFunNameReversibleRejected.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/11--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/11--funName/tokenFunName.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/11--funName/tokenFunNameReversible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/11--funName/tokenFunNameReversible.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/12--repeatable/multipleAnnotations.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/12--repeatable/multipleAnnotations.md
@@ -42,6 +42,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeMappedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeMappedProperty.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeMappedPropertyWithCanReverse.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeMappedPropertyWithCanReverse.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeSharedProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeSharedProp.md
@@ -35,6 +35,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeSharedPropWithCanReverse.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeSharedPropWithCanReverse.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeUnmatchedName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeUnmatchedName.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeUnmatchedNameWithCanReverse.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/All patterns/option=Default/13--excludes/excludeUnmatchedNameWithCanReverse.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/UseCase/GetItemApiResponse Item to domain Item mapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyMappingSnapshotTest/UseCase/GetItemApiResponse Item to domain Item mapping.md
@@ -55,6 +55,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sealedParentKind/nonSealedParentRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sealedParentKind/nonSealedParentRejected.md
@@ -21,6 +21,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sealedParentKind/sealedClassParent.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sealedParentKind/sealedClassParent.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sealedParentKind/sealedInterfaceParent.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sealedParentKind/sealedInterfaceParent.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/dataClassChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/dataClassChildren.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/enumChildRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/enumChildRejected.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/mixedChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/mixedChildren.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/nestedSealedChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/nestedSealedChildren.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/noChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/noChildren.md
@@ -18,6 +18,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/objectChild.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/objectChild.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/sharedPropsDirectChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/sharedPropsDirectChildren.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/transitiveSharedProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--hierarchyShape/transitiveSharedProps.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--propertyShape/mixedPrimitives.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--propertyShape/zeroProps.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--exclude/excludeNoEffect.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--exclude/excludedAbstractProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--exclude/excludedAbstractProperty.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--kdoc/description.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--kdoc/descriptionAndExamples.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--visibility/internalChildClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--visibility/internalChildClass.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--visibility/visibilityOverrideInternal.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--visibility/visibilityOverridePublic.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--notCopyToObject/allObjectsSuppressedEmptyFile.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--notCopyToObject/allObjectsSuppressedEmptyFile.md
@@ -22,6 +22,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--notCopyToObject/objectChildKept.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--notCopyToObject/objectChildKept.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--notCopyToObject/objectChildSuppressed.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--notCopyToObject/objectChildSuppressed.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/defaultSuffixFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/defaultSuffixFunName.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/literalFunNameRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/literalFunNameRejected.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/singleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/singleLeafLiteralFunName.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/singleTransitiveLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/singleTransitiveLeafLiteralFunName.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--funName/tokenFunName.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--map/mapAndExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--map/mapAndExclude.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--map/mapOverridesNameMatch.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--map/mapToDifferentNamePerChild.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--map/mapToDifferentNamePerChild.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--map/mapToNonexistentProperty.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--map/propertyMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--map/propertyMapping.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/nonSealedParentRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/nonSealedParentRejected.md
@@ -21,6 +21,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedClassParent.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedClassParent.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedInterfaceParent.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedInterfaceParent.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/dataClassChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/dataClassChildren.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/enumChildRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/enumChildRejected.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/mixedChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/mixedChildren.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/nestedSealedChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/nestedSealedChildren.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/noChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/noChildren.md
@@ -18,6 +18,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/objectChild.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/objectChild.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/sharedPropsDirectChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/sharedPropsDirectChildren.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/transitiveSharedProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/transitiveSharedProps.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/mixedPrimitives.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/zeroProps.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--exclude/excludeNoEffect.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--exclude/excludedAbstractProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--exclude/excludedAbstractProperty.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--kdoc/description.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--kdoc/descriptionAndExamples.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--visibility/internalChildClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--visibility/internalChildClass.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--visibility/visibilityOverrideInternal.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--visibility/visibilityOverridePublic.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--notCopyToObject/allObjectsSuppressedEmptyFile.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--notCopyToObject/allObjectsSuppressedEmptyFile.md
@@ -22,6 +22,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--notCopyToObject/objectChildKept.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--notCopyToObject/objectChildKept.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--notCopyToObject/objectChildSuppressed.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--notCopyToObject/objectChildSuppressed.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/defaultSuffixFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/defaultSuffixFunName.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/literalFunNameRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/literalFunNameRejected.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/singleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/singleLeafLiteralFunName.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/singleTransitiveLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/singleTransitiveLeafLiteralFunName.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--funName/tokenFunName.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--map/mapAndExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--map/mapAndExclude.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--map/mapOverridesNameMatch.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--map/mapToDifferentNamePerChild.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--map/mapToDifferentNamePerChild.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--map/mapToNonexistentProperty.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--map/propertyMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--map/propertyMapping.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/00--sealedParentKind/nonSealedParentRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/00--sealedParentKind/nonSealedParentRejected.md
@@ -21,6 +21,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedClassParent.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedClassParent.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedInterfaceParent.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedInterfaceParent.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/dataClassChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/dataClassChildren.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/enumChildRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/enumChildRejected.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/mixedChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/mixedChildren.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/nestedSealedChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/nestedSealedChildren.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/noChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/noChildren.md
@@ -18,6 +18,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/objectChild.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/objectChild.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/sharedPropsDirectChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/sharedPropsDirectChildren.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/transitiveSharedProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/01--hierarchyShape/transitiveSharedProps.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/02--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/02--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/02--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/02--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/03--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/03--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/03--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/03--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/03--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/03--propertyShape/mixedPrimitives.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/03--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/03--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/03--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/03--propertyShape/zeroProps.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/04--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/04--exclude/excludeNoEffect.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/04--exclude/excludedAbstractProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/04--exclude/excludedAbstractProperty.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/05--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/05--kdoc/description.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/05--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/05--kdoc/descriptionAndExamples.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/06--visibility/internalChildClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/06--visibility/internalChildClass.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/06--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/06--visibility/visibilityOverrideInternal.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/06--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/06--visibility/visibilityOverridePublic.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/07--notCopyToObject/allObjectsSuppressedEmptyFile.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/07--notCopyToObject/allObjectsSuppressedEmptyFile.md
@@ -22,6 +22,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/07--notCopyToObject/objectChildKept.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/07--notCopyToObject/objectChildKept.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/07--notCopyToObject/objectChildSuppressed.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/07--notCopyToObject/objectChildSuppressed.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/defaultSuffixFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/defaultSuffixFunName.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/literalFunNameRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/literalFunNameRejected.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/notCopyToObjectSingleLeafLiteralFunName.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/singleLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/singleLeafLiteralFunName.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/singleTransitiveLeafLiteralFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/singleTransitiveLeafLiteralFunName.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/08--funName/tokenFunName.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/09--map/mapAndExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/09--map/mapAndExclude.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/09--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/09--map/mapOverridesNameMatch.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/09--map/mapToDifferentNamePerChild.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/09--map/mapToDifferentNamePerChild.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/09--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/09--map/mapToNonexistentProperty.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/09--map/propertyMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/All patterns/option=Default/09--map/propertyMapping.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/UseCase/CheckoutUiState nested state machine (notCopyToObject).md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/UseCase/CheckoutUiState nested state machine (notCopyToObject).md
@@ -79,6 +79,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/UseCase/CheckoutUiState nested state machine.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/UseCase/CheckoutUiState nested state machine.md
@@ -79,6 +79,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/UseCase/CounterUiState MVI reducer transitions.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/UseCase/CounterUiState MVI reducer transitions.md
@@ -42,6 +42,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/UseCase/SearchState Koma store.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToChildrenSnapshotTest/UseCase/SearchState Koma store.md
@@ -57,6 +57,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/plainClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/sealedInterfaceSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/00--sourceKind/valueClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/annotationClassTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/protectedConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/protectedConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/01--targetKind/sealedInterfaceTarget.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/bothNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/bothNestedInOuter.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/sourceNestedInTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/sourceNestedInTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/targetNestedInSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/targetNestedInSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/targetNestedTwoLevelsInNestedSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/targetNestedTwoLevelsInNestedSource.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/targetNestedTwoLevelsInSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/02--nesting/targetNestedTwoLevelsInSource.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/multipleConstructors.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/multipleConstructors.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargInMiddle.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargInMiddle.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargMatchedObjectArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargMatchedObjectArray.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargMatchedPrimitiveArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargMatchedPrimitiveArray.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargNullableArrayRequired.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargNullableArrayRequired.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargParameter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/04--constructor/varargParameter.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/mixedPrimitives.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/stringProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/05--propertyShape/zeroProps.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/06--matching/typeIncompatible.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapOverridesNameMatch.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/mapToNonexistentProperty.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/propertyMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/07--map/propertyMapping.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/allParamsExcluded.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/allParamsExcluded.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/excludeNoEffect.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/excludedProperty.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/genericExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/genericExclude.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/mapAndExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/mapAndExclude.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/nullableExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/08--exclude/nullableExclude.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/description.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/descriptionAndExamples.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/examplesOnly.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/examplesOnly.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/multilineDescription.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/multilineDescription.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/multipleExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/09--kdoc/multipleExamples.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/internalSourceClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/internalSourceClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/propertyVisibilities.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverrideInternal.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/10--visibility/visibilityOverridePublic.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunName.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunNameSealedRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/literalFunNameSealedRejected.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/11--funName/tokenFunName.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--deprecated/deprecatedSourceClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--deprecated/deprecatedSourceClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--deprecated/deprecatedSourceProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--deprecated/deprecatedSourceProperty.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--deprecated/deprecationLevelError.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/12--deprecated/deprecationLevelError.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--escaping/keywordProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--escaping/keywordProperty.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--escaping/nonAsciiProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--escaping/nonAsciiProperty.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--escaping/spaceInName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(prefix=to, escapeDot=replace-to-underscore)/13--escaping/spaceInName.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "replace-to-underscore")
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/plainClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/sealedInterfaceSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/00--sourceKind/valueClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/annotationClassTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/protectedConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/protectedConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/01--targetKind/sealedInterfaceTarget.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/bothNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/bothNestedInOuter.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/sourceNestedInTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/sourceNestedInTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/targetNestedInSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/targetNestedInSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/targetNestedTwoLevelsInNestedSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/targetNestedTwoLevelsInNestedSource.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/targetNestedTwoLevelsInSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/02--nesting/targetNestedTwoLevelsInSource.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/multipleConstructors.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/multipleConstructors.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargInMiddle.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargInMiddle.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargMatchedObjectArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargMatchedObjectArray.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargMatchedPrimitiveArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargMatchedPrimitiveArray.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargNullableArrayRequired.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargNullableArrayRequired.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargParameter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/04--constructor/varargParameter.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/mixedPrimitives.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/stringProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/05--propertyShape/zeroProps.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/06--matching/typeIncompatible.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapOverridesNameMatch.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/mapToNonexistentProperty.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/propertyMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/07--map/propertyMapping.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/allParamsExcluded.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/allParamsExcluded.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/excludeNoEffect.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/excludedProperty.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/genericExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/genericExclude.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/mapAndExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/mapAndExclude.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/nullableExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/08--exclude/nullableExclude.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/description.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/descriptionAndExamples.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/examplesOnly.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/examplesOnly.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/multilineDescription.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/multilineDescription.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/multipleExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/09--kdoc/multipleExamples.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/internalSourceClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/internalSourceClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/propertyVisibilities.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverrideInternal.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/10--visibility/visibilityOverridePublic.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunName.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunNameSealedRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/literalFunNameSealedRejected.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/11--funName/tokenFunName.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--deprecated/deprecatedSourceClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--deprecated/deprecatedSourceClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--deprecated/deprecatedSourceProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--deprecated/deprecatedSourceProperty.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--deprecated/deprecationLevelError.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/12--deprecated/deprecationLevelError.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--escaping/keywordProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--escaping/keywordProperty.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--escaping/nonAsciiProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--escaping/nonAsciiProperty.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--escaping/spaceInName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=(strategy=inner-name, notCopyToObject=true, defaultVisibility=INTERNAL)/13--escaping/spaceInName.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/00--sourceKind/plainClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/00--sourceKind/sealedInterfaceSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/00--sourceKind/valueClassSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/abstractTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/annotationClassTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/annotationClassTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/enumTarget.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/innerTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/nonSealedInterfaceTarget.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/objectTarget.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/privateConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/protectedConstructorTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/protectedConstructorTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/01--targetKind/sealedInterfaceTarget.md
@@ -39,6 +39,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/02--nesting/bothNestedInOuter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/02--nesting/bothNestedInOuter.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/02--nesting/sourceNestedInTarget.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/02--nesting/sourceNestedInTarget.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/02--nesting/targetNestedInSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/02--nesting/targetNestedInSource.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/02--nesting/targetNestedTwoLevelsInNestedSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/02--nesting/targetNestedTwoLevelsInNestedSource.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/02--nesting/targetNestedTwoLevelsInSource.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/02--nesting/targetNestedTwoLevelsInSource.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/03--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/03--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/03--generics/sourceOnlyTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/03--generics/targetOnlyTypeParam.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/multipleConstructors.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/multipleConstructors.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/varargInMiddle.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/varargInMiddle.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/varargMatchedObjectArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/varargMatchedObjectArray.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/varargMatchedPrimitiveArray.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/varargMatchedPrimitiveArray.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/varargNullableArrayRequired.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/varargNullableArrayRequired.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/varargParameter.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/04--constructor/varargParameter.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/mixedPrimitives.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/stringProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/zeroProps.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/05--propertyShape/zeroProps.md
@@ -20,6 +20,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/06--matching/typeIncompatible.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/06--matching/typeIncompatible.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/07--map/mapOverridesNameMatch.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/07--map/mapOverridesNameMatch.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/07--map/mapToNonexistentProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/07--map/mapToNonexistentProperty.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/07--map/propertyMapping.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/07--map/propertyMapping.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/allParamsExcluded.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/allParamsExcluded.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/excludeNoEffect.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/excludedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/excludedProperty.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/genericExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/genericExclude.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/mapAndExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/mapAndExclude.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/nullableExclude.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/08--exclude/nullableExclude.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/09--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/09--kdoc/description.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/09--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/09--kdoc/descriptionAndExamples.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/09--kdoc/examplesOnly.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/09--kdoc/examplesOnly.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/09--kdoc/multilineDescription.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/09--kdoc/multilineDescription.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/09--kdoc/multipleExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/09--kdoc/multipleExamples.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/10--visibility/internalSourceClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/10--visibility/internalSourceClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/10--visibility/propertyVisibilities.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/10--visibility/propertyVisibilities.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverrideInternal.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/10--visibility/visibilityOverridePublic.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/11--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/11--funName/literalFunName.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/11--funName/literalFunNameSealedRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/11--funName/literalFunNameSealedRejected.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/11--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/11--funName/tokenFunName.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/12--deprecated/deprecatedSourceClass.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/12--deprecated/deprecatedSourceClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/12--deprecated/deprecatedSourceProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/12--deprecated/deprecatedSourceProperty.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/12--deprecated/deprecationLevelError.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/12--deprecated/deprecationLevelError.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/13--escaping/keywordProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/13--escaping/keywordProperty.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/13--escaping/nonAsciiProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/13--escaping/nonAsciiProperty.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/13--escaping/spaceInName.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/All patterns/option=Default/13--escaping/spaceInName.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/UseCase/ItemDetailUiState transitions from Loading.md
+++ b/cream-ksp/src/test/resources/snapshots/CopyToSnapshotTest/UseCase/ItemDetailUiState transitions from Loading.md
@@ -53,6 +53,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedClassParent.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedClassParent.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedInterfaceParent.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedInterfaceParent.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/intermediateSealedAncestors.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/intermediateSealedAncestors.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/multipleAccessorsOnOneParent.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/multipleAccessorsOnOneParent.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/siblingsWithoutAnnotation.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/siblingsWithoutAnnotation.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--merge/diamondChildOfTwoSealedInterfaces.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--merge/diamondChildOfTwoSealedInterfaces.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--merge/mergeAcrossIntermediateAncestors.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--merge/mergeAcrossIntermediateAncestors.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--merge/subtypeChildrenMostDerivedFirst.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--merge/subtypeChildrenMostDerivedFirst.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--merge/twoChildrenMerged.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--merge/twoChildrenMerged.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyName/derivedFromDefaultToken.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyName/derivedFromDefaultToken.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyName/renameAvoidsMerge.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyName/renameAvoidsMerge.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyName/renamedAccessor.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyName/renamedAccessor.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/customTypeProp.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/delegatedProp.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/delegatedProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/hardKeywordPropertyName.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/hardKeywordPropertyName.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/lateinitVarProp.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/lateinitVarProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/mixedPrimitives.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/objectChildProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/objectChildProperty.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/typealiasPreserved.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--propertyShape/typealiasPreserved.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--generics/boundedTypeParam.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--generics/chainedTypeParamRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--generics/chainedTypeParamRejected.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--generics/directPinnedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--generics/directPinnedTypeParam.md
@@ -22,6 +22,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--generics/genericLeafUnderIndirectAncestor.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--generics/genericLeafUnderIndirectAncestor.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--generics/multiBoundWhereClause.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--generics/multiBoundWhereClause.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--kdoc/description.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--kdoc/descriptionAndExamples.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--kdoc/mergedKdocUsesFirstEntry.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--kdoc/mergedKdocUsesFirstEntry.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/internalChildClass.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/internalChildClass.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/internalProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/internalProperty.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/mergedNarrowestAnnotationWins.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/mergedNarrowestAnnotationWins.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/visibilityOverrideInternal.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/visibilityOverridePublicOnInternalChild.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/visibilityOverridePublicOnInternalChild.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/visibilityOverridePublicOnInternalProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--visibility/visibilityOverridePublicOnInternalProperty.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--deprecated/deprecatedChildClass.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--deprecated/deprecatedChildClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--deprecated/deprecatedLevelError.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--deprecated/deprecatedLevelError.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--deprecated/deprecatedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--deprecated/deprecatedProperty.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--deprecated/mergedFirstDeprecationWins.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--deprecated/mergedFirstDeprecationWins.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedClassParent.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedClassParent.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedInterfaceParent.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedInterfaceParent.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/01--hierarchyShape/intermediateSealedAncestors.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/01--hierarchyShape/intermediateSealedAncestors.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/01--hierarchyShape/multipleAccessorsOnOneParent.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/01--hierarchyShape/multipleAccessorsOnOneParent.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/01--hierarchyShape/siblingsWithoutAnnotation.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/01--hierarchyShape/siblingsWithoutAnnotation.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/02--merge/diamondChildOfTwoSealedInterfaces.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/02--merge/diamondChildOfTwoSealedInterfaces.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/02--merge/mergeAcrossIntermediateAncestors.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/02--merge/mergeAcrossIntermediateAncestors.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/02--merge/subtypeChildrenMostDerivedFirst.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/02--merge/subtypeChildrenMostDerivedFirst.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/02--merge/twoChildrenMerged.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/02--merge/twoChildrenMerged.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/03--propertyName/derivedFromDefaultToken.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/03--propertyName/derivedFromDefaultToken.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/03--propertyName/renameAvoidsMerge.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/03--propertyName/renameAvoidsMerge.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/03--propertyName/renamedAccessor.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/03--propertyName/renamedAccessor.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/customTypeProp.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/delegatedProp.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/delegatedProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/hardKeywordPropertyName.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/hardKeywordPropertyName.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/lateinitVarProp.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/lateinitVarProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/mixedPrimitives.md
@@ -34,6 +34,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/objectChildProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/objectChildProperty.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/typealiasPreserved.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/04--propertyShape/typealiasPreserved.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/05--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/05--generics/boundedTypeParam.md
@@ -23,6 +23,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/05--generics/chainedTypeParamRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/05--generics/chainedTypeParamRejected.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/05--generics/directPinnedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/05--generics/directPinnedTypeParam.md
@@ -22,6 +22,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/05--generics/genericLeafUnderIndirectAncestor.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/05--generics/genericLeafUnderIndirectAncestor.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/05--generics/multiBoundWhereClause.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/05--generics/multiBoundWhereClause.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/06--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/06--kdoc/description.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/06--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/06--kdoc/descriptionAndExamples.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/06--kdoc/mergedKdocUsesFirstEntry.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/06--kdoc/mergedKdocUsesFirstEntry.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/internalChildClass.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/internalChildClass.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/internalProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/internalProperty.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/mergedNarrowestAnnotationWins.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/mergedNarrowestAnnotationWins.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/visibilityOverrideInternal.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/visibilityOverridePublicOnInternalChild.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/visibilityOverridePublicOnInternalChild.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/visibilityOverridePublicOnInternalProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/07--visibility/visibilityOverridePublicOnInternalProperty.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/08--deprecated/deprecatedChildClass.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/08--deprecated/deprecatedChildClass.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/08--deprecated/deprecatedLevelError.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/08--deprecated/deprecatedLevelError.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/08--deprecated/deprecatedProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/08--deprecated/deprecatedProperty.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/08--deprecated/mergedFirstDeprecationWins.md
+++ b/cream-ksp/src/test/resources/snapshots/ParentOptionalSnapshotTest/All patterns/option=Default/08--deprecated/mergedFirstDeprecationWins.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/RunCompileSnapshotTestSmokeTest/compiles a @CopyTo FileSpec, exposes the result to assertions, and returns it.md
+++ b/cream-ksp/src/test/resources/snapshots/RunCompileSnapshotTestSmokeTest/compiles a @CopyTo FileSpec, exposes the result to assertions, and returns it.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/nonSealedParentRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/nonSealedParentRejected.md
@@ -21,6 +21,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedClassParent.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedClassParent.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedInterfaceParent.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/00--sealedParentKind/sealedInterfaceParent.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/dataClassChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/dataClassChildren.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/noAbstractProperties.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/noAbstractProperties.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/nonDataClassWithCopyMember.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/nonDataClassWithCopyMember.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/transitiveNestedSealed.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/01--hierarchyShape/transitiveNestedSealed.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/concreteFixedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/concreteFixedTypeParam.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/extraTypeParamStarProjected.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/extraTypeParamStarProjected.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/multiTypeParamParent.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/multiTypeParamParent.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/multipleBoundsWhere.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/multipleBoundsWhere.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/varianceOutTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/02--generics/varianceOutTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/mixedPrimitives.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/03--propertyShape/stringProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--nonCopyableStrategy/errorRejectsObject.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--nonCopyableStrategy/errorRejectsObject.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--nonCopyableStrategy/mixedNonCopyableRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--nonCopyableStrategy/mixedNonCopyableRejected.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--nonCopyableStrategy/nonDataClassRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--nonCopyableStrategy/nonDataClassRejected.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--nonCopyableStrategy/returnAsIsObject.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--nonCopyableStrategy/returnAsIsObject.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--nonCopyableStrategy/returnNullObject.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/04--nonCopyableStrategy/returnNullObject.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--map/mappedAmongDataChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--map/mappedAmongDataChildren.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--map/mappedNonDataChild.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--map/mappedNonDataChild.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--map/mappedRenamedSubsetChild.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/05--map/mappedRenamedSubsetChild.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/excludeNoEffect.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/excludedAbstractProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/06--exclude/excludedAbstractProperty.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--kdoc/description.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/07--kdoc/descriptionAndExamples.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/internalSealedParent.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/internalSealedParent.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/visibilityOverrideInternal.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/08--visibility/visibilityOverridePublic.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/09--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/09--funName/literalFunName.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/09--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/09--funName/tokenFunName.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/10--repeatable/duplicateFunNameRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/10--repeatable/duplicateFunNameRejected.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/10--repeatable/stackedVariants.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=(notCopyToObject=true, defaultVisibility=INTERNAL)/10--repeatable/stackedVariants.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "true")
     arg("defaultVisibility", "INTERNAL")
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/00--sealedParentKind/nonSealedParentRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/00--sealedParentKind/nonSealedParentRejected.md
@@ -21,6 +21,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedClassParent.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedClassParent.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedInterfaceParent.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/00--sealedParentKind/sealedInterfaceParent.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/01--hierarchyShape/dataClassChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/01--hierarchyShape/dataClassChildren.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/01--hierarchyShape/noAbstractProperties.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/01--hierarchyShape/noAbstractProperties.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/01--hierarchyShape/nonDataClassWithCopyMember.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/01--hierarchyShape/nonDataClassWithCopyMember.md
@@ -31,6 +31,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/01--hierarchyShape/transitiveNestedSealed.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/01--hierarchyShape/transitiveNestedSealed.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/boundedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/boundedTypeParam.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/concreteFixedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/concreteFixedTypeParam.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/extraTypeParamStarProjected.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/extraTypeParamStarProjected.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/multiTypeParamParent.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/multiTypeParamParent.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/multipleBoundsWhere.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/multipleBoundsWhere.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/sharedTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/sharedTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/varianceOutTypeParam.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/02--generics/varianceOutTypeParam.md
@@ -24,6 +24,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/03--propertyShape/collectionProp.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/03--propertyShape/collectionProp.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/03--propertyShape/customTypeProp.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/03--propertyShape/customTypeProp.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/03--propertyShape/mixedPrimitives.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/03--propertyShape/mixedPrimitives.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/03--propertyShape/nullableProp.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/03--propertyShape/nullableProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/03--propertyShape/stringProp.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/03--propertyShape/stringProp.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/04--nonCopyableStrategy/errorRejectsObject.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/04--nonCopyableStrategy/errorRejectsObject.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/04--nonCopyableStrategy/mixedNonCopyableRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/04--nonCopyableStrategy/mixedNonCopyableRejected.md
@@ -33,6 +33,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/04--nonCopyableStrategy/nonDataClassRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/04--nonCopyableStrategy/nonDataClassRejected.md
@@ -29,6 +29,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/04--nonCopyableStrategy/returnAsIsObject.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/04--nonCopyableStrategy/returnAsIsObject.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/04--nonCopyableStrategy/returnNullObject.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/04--nonCopyableStrategy/returnNullObject.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/05--map/mappedAmongDataChildren.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/05--map/mappedAmongDataChildren.md
@@ -32,6 +32,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/05--map/mappedNonDataChild.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/05--map/mappedNonDataChild.md
@@ -28,6 +28,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/05--map/mappedRenamedSubsetChild.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/05--map/mappedRenamedSubsetChild.md
@@ -36,6 +36,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/06--exclude/excludeNoEffect.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/06--exclude/excludeNoEffect.md
@@ -27,6 +27,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/06--exclude/excludedAbstractProperty.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/06--exclude/excludedAbstractProperty.md
@@ -30,6 +30,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/07--kdoc/description.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/07--kdoc/description.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/07--kdoc/descriptionAndExamples.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/07--kdoc/descriptionAndExamples.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/08--visibility/internalSealedParent.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/08--visibility/internalSealedParent.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/08--visibility/visibilityOverrideInternal.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/08--visibility/visibilityOverrideInternal.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/08--visibility/visibilityOverridePublic.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/08--visibility/visibilityOverridePublic.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/09--funName/literalFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/09--funName/literalFunName.md
@@ -25,6 +25,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/09--funName/tokenFunName.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/09--funName/tokenFunName.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/10--repeatable/duplicateFunNameRejected.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/10--repeatable/duplicateFunNameRejected.md
@@ -26,6 +26,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/10--repeatable/stackedVariants.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/All patterns/option=Default/10--repeatable/stackedVariants.md
@@ -37,6 +37,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/UseCase/CounterUiState shared context update in reducer.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/UseCase/CounterUiState shared context update in reducer.md
@@ -42,6 +42,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 

--- a/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/UseCase/FeedUiState refresh and banner keep subtype.md
+++ b/cream-ksp/src/test/resources/snapshots/SealedCopySnapshotTest/UseCase/FeedUiState refresh and banner keep subtype.md
@@ -51,6 +51,7 @@ ksp {
     arg("escapeDot", "lower-camel-case" /* default */)
     arg("notCopyToObject", "false" /* default */)
     arg("defaultVisibility", "INHERIT" /* default */)
+    arg("autoValueClassMapping", "true" /* default */)
 }
 ```
 


### PR DESCRIPTION
Refs #21

> [!IMPORTANT]
> #21 の機械的な前半だけを切り出した PR です。**単独でマージすると「宣言されているが誰も読まないオプション」が main に入る**ので、機能本体の #186 と続けてマージしてください。ユーザー向けドキュメントも #186 側にあります。

## 何をするか

`cream.autoValueClassMapping` を `CreamOptions` に足すだけです。**生成コードは 1 バイトも変わりません。**

```kotlin
val autoValueClassMapping: Boolean,   // default true
```

- パースは `notCopyToObject` と同じ寛容な boolean（リテラル `"false"` のみが無効化、大文字小文字は無視）
- snapshot の option matrix では既定値にピン留め。軸として振ると全 family のコンパイル回数が倍増するため、オプションの効果は #186 側の専用テストで確認します

✅ `ktlintCheck` / `:cream-ksp:test`

## なぜ分けたか

golden の `## KSP options` セクションは **`CreamOptions` の全プロパティを、既定値のものも `/* default */` 付きで書き出す**仕様です。そのためオプションを 1 つ足すだけで、リポジトリ内の全 golden に 1 行ずつ差分が出ます。

これを機能本体と同じ PR に入れると、**#186 で「実際に挙動が変わった golden 1 件」が 1210 件のノイズに埋もれます**。分離した結果:

| PR | golden 差分 |
|---|---|
| この PR | 1210 件（全て同一の 1 行追加） |
| #186 | 新規 46 件 + 実挙動が変わった 1 件 |

> #193 のマージ後の main に rebase 済みです。main 側で増えた golden 134 件（`ParentOptionalSnapshotTest` 78 / `ChildOptionalsSnapshotTest` 56）にも同じ 1 行が入るため、再生成して取り込んでいます。ソースファイルの衝突はありませんでした。

## レビューの仕方

golden 1210 件は目視不要です。**すべて同一の 1 行追加**であることを機械的に確認できます:

```console
$ git diff --name-only --diff-filter=M main -- cream-ksp/src/test/resources/snapshots \
  | while IFS= read -r f; do
      git diff -U0 main -- "$f" | grep '^[+-]' | grep -v '^\(+++\|---\)'
    done | sort -u
+    arg("autoValueClassMapping", "true" /* default */)
```

出力が 1 行だけ = 生成コードの変化なし、です（この PR で実測: 1210/1210 件が一致、それ以外 0 件）。

<details>
<summary>golden 以外の変更（5 ファイル）</summary>

| ファイル | 内容 |
|---|---|
| `options/CreamOptions.kt` | プロパティ + 既定値 + `properties` 登録 + パース（7 行） |
| `options/CreamOptionsParsingTest.kt` | 未指定→true / `"false"` `"FALSE"`→false / 非 `"false"` は true のまま |
| `testing/generator/cream/CreamOptionsGenerator.kt` | 新オプションを既定にピン留め、ラベル生成に追随 |
| `core/common/CopyFunctionNameTest.kt` | `CreamOptions(...)` を直接組み立てているため引数追加（1 行） |
| `core/common/FunctionNameTemplateTest.kt` | 同上（1 行） |

</details>

<details>
<summary>今後オプションを足すたびに同じことが起きます</summary>

根本原因は「golden が既定値のオプションもエコーする」設計です。将来のオプション追加でも全 golden に 1 行波及します。

避けるなら「既定値のオプションはエコーしない」に変える手もありますが、それは *goldenが実効設定を完全に記録する* という現在の性質を捨てることになります（既定値そのものが変わったときに全 golden が動いて気付ける、という利点があります）。今回は設計を変えず、PR を分けて影響を隔離する方を選びました。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01A9LNrMDsyAFeMNiDvMhAuD


